### PR TITLE
remove onClose when click on account btn

### DIFF
--- a/src/components/Navbar/List.tsx
+++ b/src/components/Navbar/List.tsx
@@ -61,7 +61,7 @@ const NavList = ({ mobile, onClose }: Props) => {
           </MenuList>
         </Menu>
       </ListItem>
-      <ListItem order={mobile ? 1 : undefined} listStyleType='none' onClick={onClose}>
+      <ListItem order={mobile ? 1 : undefined} listStyleType='none'>
         <Account />
       </ListItem>
     </>


### PR DESCRIPTION
Removed onClose when clicking on account button. It could be a good idea to close all the menu when clicking on the logout button. If not, after logout we are in a menu showing only the login option. But it's necessary prop drilling from list to account btn to pass onClose function