### PR TITLE
Add time inputs for start and end date fields

### DIFF
--- a/src/components/ProcessCreate/Steps/Info.tsx
+++ b/src/components/ProcessCreate/Steps/Info.tsx
@@ -9,6 +9,7 @@ import { useProcessCreationSteps } from './use-steps'
 export interface InfoValues {
   title: string
   description: string
+  // dates need to be string to properly reset the values to the inputs
   endDate: string
   startDate: string
   electionType: {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -83,9 +83,9 @@
     "process_create": {
       "alert_info_title": "Info",
       "calendar": {
-        "date_format": "d/L",
+        "date_format": "PPPPpppp",
         "end_date": "End date",
-        "end_date_description": "This election will start at {{ date.begin, format }} and end at {{ date.end, format }} - Lasting {{ date, duration }}",
+        "end_date_description": "This election will start at {{ date.begin, format }} and end at {{ date.end, format }}, lasting ~{{ date, duration }}",
         "now": "Now",
         "start_date_description": "Define when the election should be active to recive votes. If 'Now' is selected, the proposal is immediatlely active after publishing.",
         "start_on_a_date": "Start on a date",


### PR DESCRIPTION
Ended up converting the fields to datetime-local, which is the easiest way for all sides (development, styling and even end-user side)
    
closes #41