### PR TITLE
Fix copy info toast showing weird styles

### DIFF
--- a/src/components/Organization/AddressBtn.tsx
+++ b/src/components/Organization/AddressBtn.tsx
@@ -41,7 +41,6 @@ const AddressBtn = () => {
           leftIcon={<CopyIcon />}
           onClick={() => {
             toast({
-              status: 'info',
               title: t('copy.copied_title'),
               duration: 3000,
             })


### PR DESCRIPTION
Removed status info from the toast of the copy address button to prevent it from using the custom styles of the alert info, thus using the default info styles of Chakra