### PR TITLE
Truncate correctly the description in card detailed

### DIFF
--- a/src/theme/components/Card.ts
+++ b/src/theme/components/Card.ts
@@ -131,7 +131,7 @@ const detailed = definePartsStyle({
         mb: 3,
       },
       '& > div:nth-of-type(2)': {
-        '& > p': {
+        '& > p:first-of-type': {
           textAlign: 'start',
           color: 'card.description',
           noOfLines: 4,
@@ -139,6 +139,9 @@ const detailed = definePartsStyle({
           display: '-webkit-box',
           WebkitBoxOrient: 'vertical',
           WebkitLineClamp: 'var(--chakra-line-clamp)',
+        },
+        '& > p:not(:first-of-type)': {
+          display: 'none',
         },
       },
       '& > p:nth-of-type(2)': {


### PR DESCRIPTION
issue fixed, when the description has more than one paragraph, truncate the first one and hide the others.

closes #214