### PR TITLE
switch to the questions tab when voting

### DIFF
--- a/src/components/Process/Aside.tsx
+++ b/src/components/Process/Aside.tsx
@@ -1,15 +1,15 @@
 import { Box, Button, Flex, Text } from '@chakra-ui/react'
 import { CensusMeta } from '@components/ProcessCreate/Steps/Confirm'
 import { ConnectButton } from '@rainbow-me/rainbowkit'
-import { environment, SpreadsheetAccess, VoteButton } from '@vocdoni/chakra-components'
+import { SpreadsheetAccess, VoteButton, environment } from '@vocdoni/chakra-components'
 import { useClient, useElection } from '@vocdoni/react-providers'
-import { dotobject, ElectionStatus, PublishedElection } from '@vocdoni/sdk'
+import { ElectionStatus, PublishedElection, dotobject } from '@vocdoni/sdk'
 import { TFunction } from 'i18next'
 import { Trans, useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { useAccount } from 'wagmi'
 
-const ProcessAside = ({ ...props }) => {
+const ProcessAside = ({ setQuestionsTab }: { setQuestionsTab: () => void }) => {
   const { t } = useTranslation()
   const { election, connected, isAbleToVote, isInCensus, voted, votesLeft } = useElection()
   const { isConnected } = useAccount()
@@ -32,7 +32,6 @@ const ProcessAside = ({ ...props }) => {
         background='process.aside.bg'
         borderRadius='lg'
         boxShadow='var(--box-shadow-banner)'
-        {...props}
       >
         <Text textAlign='center' fontSize='xl3' lineHeight={1}>
           {getStatusText(t, election?.status).toUpperCase()}
@@ -71,7 +70,7 @@ const ProcessAside = ({ ...props }) => {
 
         {renderVoteMenu && (
           <Flex flexDirection='column' alignItems='center' gap={3} w='full'>
-            {isAbleToVote && <VoteButton variant='process' mb={0} />}
+            {isAbleToVote && <VoteButton variant='process' mb={0} onClick={setQuestionsTab} />}
             {voted !== null && voted.length > 0 && (
               <Box textAlign='center'>
                 <Link to={environment.verifyVote(env, voted)} target='_blank'>

--- a/src/components/Process/View.tsx
+++ b/src/components/Process/View.tsx
@@ -42,6 +42,8 @@ export const ProcessView = () => {
     setTabIndex(index)
   }
 
+  const setQuestionsTab = () => setTabIndex(0)
+
   useEffect(() => {
     if (election?.status === ElectionStatus.RESULTS) setTabIndex(1)
   }, [election])
@@ -73,7 +75,7 @@ export const ProcessView = () => {
             mx='auto'
             mt={{ xl: 10 }}
           >
-            <ProcessAside />
+            <ProcessAside setQuestionsTab={setQuestionsTab}/>
           </Flex>
         </Flex>
       </Box>


### PR DESCRIPTION
Switch to the 'Questions' tab whenever you vote, as currently, errors cannot be accessed from the front.

closes #299 