### PR TITLE
separation in the process header on mobile

### DIFF
--- a/src/components/Process/Header.tsx
+++ b/src/components/Process/Header.tsx
@@ -38,7 +38,7 @@ const ProcessHeader = () => {
           <OrganizationName as='span' overflow='hidden' fontSize='sm' isTruncated />
         </Button>
       </Link>
-      <Flex direction={{ base: 'column', md: 'row' }} mb={7} gap={{ md: 10 }}>
+      <Flex direction={{ base: 'column', md: 'row' }} mb={7} gap={10}>
         <Box flexGrow={0} flexShrink={0} flexBasis={{ base: '100%', md: '60%', lg: '65%', lg2: '70%', xl2: '75%' }}>
           <ElectionTitle fontSize='xl4' textAlign='left' mb={5} />
           <Flex


### PR DESCRIPTION
Added separation between the 'read more' button and the lower content to avoid it looking too close on mobile