### PR TITLE
Switch to browser router

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,6 +41,12 @@ jobs:
           VOCDONI_ENVIRONMENT: 'stg'
           BUILD_PATH: 'build/stg'
 
+      # required, otherwise routes won't work in gh pages
+      - name: Create 404 pages for GitHub Pages
+        run: |
+          cp build/dev/index.html build/dev/404.html
+          cp build/stg/index.html build/stg/404.html
+
       - name: Create redirect index
         run: echo '<meta http-equiv="refresh" content="0;url=https://vocdoni.github.io/ui-scaffold/stg" />' > build/index.html
 

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,6 +1,6 @@
 import { useClient } from '@vocdoni/react-providers'
 import { lazy } from 'react'
-import { createHashRouter, createRoutesFromElements, Route, RouterProvider } from 'react-router-dom'
+import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider } from 'react-router-dom'
 // These aren't lazy loaded to avoid excessive loaders in different locations
 import { VocdoniEnvironment } from '~constants'
 import Error from '~elements/Error'
@@ -20,7 +20,7 @@ const Faucet = lazy(() => import('../elements/Faucet'))
 export const RoutesProvider = () => {
   const { client } = useClient()
 
-  const router = createHashRouter(
+  const router = createBrowserRouter(
     createRoutesFromElements(
       <Route path='/'>
         <Route element={<Layout />}>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ if (!vocdoniEnvironment) {
 }
 
 const outDir = process.env.BUILD_PATH
-const base = process.env.BASE_URL || ''
+const base = process.env.BASE_URL || '/'
 
 const commit = execSync('git rev-parse --short HEAD').toString()
 


### PR DESCRIPTION
Also fixed an issue related to BASE_URL, which should be / by default if not specified, instead of an empty space (since an empty space would make relative URLs, and that's not what we want).

**Note:** to be able to use this browser router, some changes are required depending on the server you're using to host the static pages:

- Github Pages: copy your index.html to 404.html, to trick gh pages into always returning your index.html file. Also don't forget to set the proper `BASE_URL`.
- Netlify, `serve` and others: nothing required, since `BASE_URL` has been changed to `/` already
- nginx and apache: you'll have to change the config in order to make all requests be redirected to the index.html file, for nginx would be something like this:

~~~nginx
location / {
  try_files $uri /index.html;
}
~~~

refs #347