### PR TITLE
census spreadsheet preview overflowx scroll

### DIFF
--- a/src/components/ProcessCreate/Confirm/CensusSpreadsheet.tsx
+++ b/src/components/ProcessCreate/Confirm/CensusSpreadsheet.tsx
@@ -23,7 +23,7 @@ const PreviewCensusSpreadsheet = () => {
 
   return (
     <Flex flexDirection='column' gap={1}>
-      <Box>
+      <Box overflowX='scroll'>
         <Table variant='striped' colorScheme='blackAlpha' fontSize='xs' size='sm'>
           <Thead>
             <Tr>

--- a/src/components/ProcessCreate/Confirm/Preview.tsx
+++ b/src/components/ProcessCreate/Confirm/Preview.tsx
@@ -118,7 +118,9 @@ const Preview = () => {
         <Text flexBasis={{ md: '30%' }} flexShrink={0} flexGrow={0} fontWeight='extrabold'>
           {t('form.process_create.confirm.census')}
         </Text>
-        <Census />
+        <Box maxW={{ md: '65%' }}>
+          <Census />
+        </Box>
         <Link variant='primary' position='absolute' top={0} right={0} onClick={() => setActiveStep(3)}>
           <Icon
             as={IoMdCreate}


### PR DESCRIPTION
Fixed issue, added overflow-x scroll to the spreadsheet preview as the number of columns/content can be larger than the available space

closes #379