### PR TITLE
prevent bug census 3 select request token option

### DIFF
--- a/src/components/ProcessCreate/Census/Token.tsx
+++ b/src/components/ProcessCreate/Census/Token.tsx
@@ -300,7 +300,9 @@ export const CensusTokens = () => {
               else return `${props.name}`
             }}
             onChange={(token) => {
-              setValue('censusToken', token || undefined)
+              console.log(token.type === 'request')
+              if (token === null || token.type === 'request') setValue('censusToken', null)
+              else setValue('censusToken', token)
               setValue('maxCensusSize', undefined)
               clearErrors()
             }}
@@ -435,7 +437,7 @@ export const TokenPreview = ({
     }
   }, [])
 
-  if (!token || !strategySize) return null
+  if (!token || !strategySize || token.type === 'request') return null
 
   return (
     <Card ref={cardRef} w='full' my={5} boxShadow='var(--box-shadow)'>

--- a/src/components/ProcessCreate/Census/Token.tsx
+++ b/src/components/ProcessCreate/Census/Token.tsx
@@ -300,7 +300,6 @@ export const CensusTokens = () => {
               else return `${props.name}`
             }}
             onChange={(token) => {
-              console.log(token.type === 'request')
               if (token === null || token.type === 'request') setValue('censusToken', null)
               else setValue('censusToken', token)
               setValue('maxCensusSize', undefined)


### PR DESCRIPTION
Double-check that if the select token option is set to 'request,' do not render the token preview or value in the select