### PR TITLE
fix english typo and unify titles between languages

### DIFF
--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -17,7 +17,7 @@
     "start_now": "Crea una votació!",
     "subtitle": "Utilitza adreces web3, vota amb un token ERC20 o amb NFTs!",
     "subtitle1": "Augmenta la participació electoral un 30%",
-    "title": "Votacions per DAOs i comunitats Web3"
+    "title": "Vot digital segur, verificable i flexible"
   },
   "banner_voting_types": {
     "anonymous_description": "La identitat dels votants serà completament confidencial, gràcies a la tecnologia zk-SNARKS.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -15,7 +15,7 @@
     "start_now": "Create a vote now!",
     "subtitle": "Save time, money and effort with our easy-to-use & customizable app.",
     "subtitle1": "Boost election participation up by 30%.",
-    "title": "Secure, verifiable and transparent online voting"
+    "title": "Secure, verifiable and flexible digital voting"
   },
   "banner_voting_types": {
     "anonymous_description": "Say goodbye to the high expenses of traditional voting methods. Vocdoni App brings you a more affordable way to conduct elections, cutting down on logistical and administrative costs while maintaining the highest standards of quality and security.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -17,7 +17,7 @@
     "start_now": "¡Crea una votación ahora!",
     "subtitle": "Usa direcciones de cartera, vota con un token ERC20 o con NFTs!",
     "subtitle1": "Aumenta la participación electoral un 30%",
-    "title": "Votaciones para DAOs y comunidades Web3"
+    "title": "Voto digital seguro, verificable y flexible"
   },
   "banner_voting_types": {
     "anonymous_description": "La identidad de los votantes permanece completamente confidencial, gracias a la tecnología zk-SNARKS.",


### PR DESCRIPTION
- Fixes a typo in the title of the main page (EN)
- Unifies titles between languages
- Changes the title from `Secure, verificable and transparent online voting` to `Secure, verifiable and flexible digital voting`.

Reasoning for changing the title is because transparent can be understood from verifiable, and flexible is an important component of the protocol design that appeals more users than transparent.

cc: @p4u @jpaulet @ferranrego 