### PR TITLE
fixed issue text world wide voting

### DIFF
--- a/src/elements/Layout.tsx
+++ b/src/elements/Layout.tsx
@@ -32,7 +32,7 @@ const Layout = () => {
           textTransform='uppercase'
           fontFamily='pixeloidsans'
           fontSize='16px'
-          display={{ base: 'none', sm: 'block' }}
+          display={{ base: 'none', md: 'block' }}
         >
           World wide voting
         </Text>

--- a/src/elements/LayoutProcessCreate.tsx
+++ b/src/elements/LayoutProcessCreate.tsx
@@ -50,7 +50,7 @@ const LayoutProcessCreate = () => {
           textTransform='uppercase'
           fontFamily='pixeloidsans'
           fontSize='16px'
-          display={{ base: 'none', sm: 'block' }}
+          display={{ base: 'none', md: 'block' }}
         >
           World wide voting
         </Text>


### PR DESCRIPTION
Fixed issue: Text breakpoint for 'world wide voting' in md, not in sm, to display the text when there is the correct padding