### PR TITLE
 weighted vote checkbox

### DIFF
--- a/src/components/ProcessCreate/Census/Spreadsheet/index.tsx
+++ b/src/components/ProcessCreate/Census/Spreadsheet/index.tsx
@@ -108,7 +108,6 @@ export const CensusCsvManager = () => {
           </UnorderedList>
           <FormControl
             bgColor='process_create.bg'
-            p={3}
             borderRadius='md'
             sx={{
               '& > label': {
@@ -144,6 +143,8 @@ export const CensusCsvManager = () => {
                   onBlur={onBlur}
                   ref={ref}
                   isChecked={value}
+                  w='full'
+                  p={3}
                 >
                   <Flex alignItems='center' gap={1}>
                     <Icon as={BiCheckDouble} />


### PR DESCRIPTION
Fixed issue in the weighted vote checkbox, which now occupies 100% of the container, and the padding is applied to the checkbox, not the container