### PR TITLE
Implement token census max size limit

### DIFF
--- a/src/components/ProcessCreate/Census/Token.tsx
+++ b/src/components/ProcessCreate/Census/Token.tsx
@@ -370,7 +370,8 @@ export const CensusTokens = () => {
   )
 }
 
-const SliderButtonsValues = [0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1]
+const SliderButtonsValuesDesktop = [0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1]
+const SliderButtonsValues = [0.05, 0.1, 0.25, 0.5, 0.75, 1]
 
 export const MaxCensusSizeSelector = ({ token, strategySize }: { token?: Census3Token; strategySize: number }) => {
   const {
@@ -462,6 +463,9 @@ export const MaxCensusSizeSelector = ({ token, strategySize }: { token?: Census3
                   setSliderValue(val)
                   setValue('maxCensusSize', val)
                 }}
+                fontSize='sm'
+                variant={'secondary'}
+                height={'var(--chakra-sizes-8)'}
               >
                 {v * 100}%
               </Button>

--- a/src/components/ProcessCreate/Census/Token.tsx
+++ b/src/components/ProcessCreate/Census/Token.tsx
@@ -33,7 +33,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { customStylesSelect, customStylesTokensSelect } from '~theme/tokenSelectStyles'
 import { useProcessCreationSteps } from '../Steps/use-steps'
 import selectComponents, { CryptoAvatar } from './select-components'
-import { MaxCensusLimit } from '~constants'
+import { DefaultCensusSize } from '~constants'
 
 export interface FilterOptionOption<Option> {
   readonly label: string
@@ -394,7 +394,7 @@ export const MaxCensusSizeSelector = ({ token, strategySize }: { token?: Census3
     required: t('process_create.census.mandatory_max_census_size'),
   })
 
-  const maxStrategySize = strategySize < MaxCensusLimit ? strategySize : MaxCensusLimit
+  const maxStrategySize = strategySize < DefaultCensusSize ? strategySize : DefaultCensusSize
 
   useEffect(() => {
     if (sliderValue !== undefined) return

--- a/src/components/ProcessCreate/Census/Token.tsx
+++ b/src/components/ProcessCreate/Census/Token.tsx
@@ -2,6 +2,7 @@ import {
   Alert,
   AlertIcon,
   Badge,
+  Button,
   Card,
   CardHeader,
   Flex,
@@ -20,6 +21,8 @@ import {
   Stack,
   Text,
   Tooltip,
+  Wrap,
+  WrapItem,
 } from '@chakra-ui/react'
 import { errorToString, useClient } from '@vocdoni/react-providers'
 import { Census3Token, EnvOptions, ICensus3SupportedChain, TokenSummary, VocdoniCensus3Client } from '@vocdoni/sdk'
@@ -367,6 +370,8 @@ export const CensusTokens = () => {
   )
 }
 
+const SliderButtonsValues = [0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1]
+
 export const MaxCensusSizeSelector = ({ token, strategySize }: { token?: Census3Token; strategySize: number }) => {
   const {
     setValue,
@@ -408,6 +413,7 @@ export const MaxCensusSizeSelector = ({ token, strategySize }: { token?: Census3
         </FormLabel>
         <Slider
           aria-label={t('form.process_create.census.max_census_slider_arialabel')}
+          value={sliderValue}
           defaultValue={sliderValue}
           min={0}
           max={maxStrategySize}
@@ -447,6 +453,21 @@ export const MaxCensusSizeSelector = ({ token, strategySize }: { token?: Census3
           </Tooltip>
         </Slider>
         <FormErrorMessage>{errors.maxCensusSize && errors.maxCensusSize.message?.toString()}</FormErrorMessage>
+        <Wrap spacing={4} mt={10} justify='center' w={'100%'}>
+          {SliderButtonsValues.map((v) => (
+            <WrapItem key={v}>
+              <Button
+                onClick={() => {
+                  const val = Math.round(maxStrategySize * v)
+                  setSliderValue(val)
+                  setValue('maxCensusSize', val)
+                }}
+              >
+                {v * 100}%
+              </Button>
+            </WrapItem>
+          ))}
+        </Wrap>
       </FormControl>
       <Text>
         <Trans

--- a/src/components/ProcessCreate/Census/Token.tsx
+++ b/src/components/ProcessCreate/Census/Token.tsx
@@ -30,6 +30,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { customStylesSelect, customStylesTokensSelect } from '~theme/tokenSelectStyles'
 import { useProcessCreationSteps } from '../Steps/use-steps'
 import selectComponents, { CryptoAvatar } from './select-components'
+import { MaxCensusLimit } from '~constants'
 
 export interface FilterOptionOption<Option> {
   readonly label: string
@@ -366,7 +367,7 @@ export const CensusTokens = () => {
   )
 }
 
-export const MaxCensusSizeSelector = ({ token, strategySize }: { token?: Census3Token; strategySize?: number }) => {
+export const MaxCensusSizeSelector = ({ token, strategySize }: { token?: Census3Token; strategySize: number }) => {
   const {
     setValue,
     getValues,
@@ -387,15 +388,17 @@ export const MaxCensusSizeSelector = ({ token, strategySize }: { token?: Census3
     required: t('process_create.census.mandatory_max_census_size'),
   })
 
+  const maxStrategySize = strategySize < MaxCensusLimit ? strategySize : MaxCensusLimit
+
   useEffect(() => {
     if (sliderValue !== undefined) return
-    setValue('maxCensusSize', strategySize)
-    setSliderValue(strategySize as number)
+    setValue('maxCensusSize', maxStrategySize)
+    setSliderValue(maxStrategySize as number)
   }, [])
 
   if (sliderValue === undefined || !token || !strategySize) return null
 
-  const percent = Math.round((sliderValue / strategySize) * 100)
+  const percent = Math.round((sliderValue / maxStrategySize) * 100)
 
   return (
     <>
@@ -407,7 +410,7 @@ export const MaxCensusSizeSelector = ({ token, strategySize }: { token?: Census3
           aria-label={t('form.process_create.census.max_census_slider_arialabel')}
           defaultValue={sliderValue}
           min={0}
-          max={strategySize}
+          max={maxStrategySize}
           ref={field.ref}
           onBlur={field.onBlur}
           onChange={(v) => {
@@ -417,13 +420,13 @@ export const MaxCensusSizeSelector = ({ token, strategySize }: { token?: Census3
           onMouseEnter={() => setShowTooltip(true)}
           onMouseLeave={() => setShowTooltip(false)}
         >
-          <SliderMark value={strategySize * 0.25} mt='1' ml='-2.5' fontSize='sm'>
+          <SliderMark value={maxStrategySize * 0.25} mt='1' ml='-2.5' fontSize='sm'>
             25%
           </SliderMark>
-          <SliderMark value={strategySize * 0.5} mt='1' ml='-2.5' fontSize='sm'>
+          <SliderMark value={maxStrategySize * 0.5} mt='1' ml='-2.5' fontSize='sm'>
             50%
           </SliderMark>
-          <SliderMark value={strategySize * 0.75} mt='1' ml='-2.5' fontSize='sm'>
+          <SliderMark value={maxStrategySize * 0.75} mt='1' ml='-2.5' fontSize='sm'>
             75%
           </SliderMark>
           <SliderTrack>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -14,8 +14,8 @@ export const ExplorerBaseURL = explorer
 export const VocdoniEnvironment = evocdoni
 export const CensusPreviewRowsLimit = 10
 
-const maxCensusLimit = import.meta.env.MAX_CENSUS_LIMIT
-export const MaxCensusLimit = maxCensusLimit
+const defaultCensusSize = import.meta.env.DEFAULT_CENSUS_SIZE
+export const DefaultCensusSize = defaultCensusSize
 
 /**
  * Given an object of react-hook-form errors, determines if the specified mapped field is invalid (returns an error)

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -14,6 +14,9 @@ export const ExplorerBaseURL = explorer
 export const VocdoniEnvironment = evocdoni
 export const CensusPreviewRowsLimit = 10
 
+const maxCensusLimit = import.meta.env.MAX_CENSUS_LIMIT
+export const MaxCensusLimit = maxCensusLimit
+
 /**
  * Given an object of react-hook-form errors, determines if the specified mapped field is invalid (returns an error)
  *

--- a/src/importmeta.d.ts
+++ b/src/importmeta.d.ts
@@ -28,6 +28,6 @@ interface ImportMeta {
     theme: string
     CSP_URL: string
     CSP_PUBKEY: string
-    MAX_CENSUS_LIMIT: number
+    DEFAULT_CENSUS_SIZE: number
   }
 }

--- a/src/importmeta.d.ts
+++ b/src/importmeta.d.ts
@@ -28,5 +28,6 @@ interface ImportMeta {
     theme: string
     CSP_URL: string
     CSP_PUBKEY: string
+    MAX_CENSUS_LIMIT: number
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,11 @@ const viteconfig = ({ mode }) => {
 
   const commit = execSync('git rev-parse --short HEAD').toString()
 
+  let maxCensusLimit = Number(process.env.MAX_CENSUS_LIMIT)
+  if (!maxCensusLimit) {
+    maxCensusLimit = 5000
+  }
+
   return defineConfig({
     base,
     build: {
@@ -33,6 +38,7 @@ const viteconfig = ({ mode }) => {
       'import.meta.env.CUSTOM_FAUCET_URL': JSON.stringify(process.env.CUSTOM_FAUCET_URL),
       'import.meta.env.CSP_PUBKEY': JSON.stringify(process.env.CSP_PUBKEY),
       'import.meta.env.CSP_URL': JSON.stringify(process.env.CSP_URL),
+      'import.meta.env.MAX_CENSUS_LIMIT': JSON.stringify(maxCensusLimit),
     },
     plugins: [
       tsconfigPaths(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,9 +22,9 @@ const viteconfig = ({ mode }) => {
 
   const commit = execSync('git rev-parse --short HEAD').toString()
 
-  let maxCensusLimit = Number(process.env.MAX_CENSUS_LIMIT)
-  if (!maxCensusLimit) {
-    maxCensusLimit = 5000
+  let defaultCensusSize = Number(process.env.DEFAULT_CENSUS_SIZE)
+  if (!defaultCensusSize) {
+    defaultCensusSize = 5000
   }
 
   return defineConfig({
@@ -38,7 +38,7 @@ const viteconfig = ({ mode }) => {
       'import.meta.env.CUSTOM_FAUCET_URL': JSON.stringify(process.env.CUSTOM_FAUCET_URL),
       'import.meta.env.CSP_PUBKEY': JSON.stringify(process.env.CSP_PUBKEY),
       'import.meta.env.CSP_URL': JSON.stringify(process.env.CSP_URL),
-      'import.meta.env.MAX_CENSUS_LIMIT': JSON.stringify(maxCensusLimit),
+      'import.meta.env.DEFAULT_CENSUS_SIZE': JSON.stringify(defaultCensusSize),
     },
     plugins: [
       tsconfigPaths(),


### PR DESCRIPTION
- Implement a max census size limit as env variable, by default 5000.
- Also implement buttons to the token max census size slider, to select 1%, 5% etc...
