### PR TITLE
Improve census info

### DIFF
--- a/src/components/Process/Header.tsx
+++ b/src/components/Process/Header.tsx
@@ -149,8 +149,8 @@ const ProcessHeader = () => {
                 color='white'
                 placement='top'
                 label={t('process.total_census_size_tooltip', {
-                  max: censusInfo?.size,
-                  count: election?.maxCensusSize,
+                  censusSize: censusInfo?.size,
+                  maxCensusSize: election?.maxCensusSize,
                   percent:
                     censusInfo?.size && election?.maxCensusSize
                       ? Math.round((election?.maxCensusSize / censusInfo?.size) * 100)
@@ -159,8 +159,8 @@ const ProcessHeader = () => {
               >
                 <Text>
                   {t('process.total_census_size', {
-                    max: censusInfo?.size,
-                    count: election?.maxCensusSize,
+                    censusSize: censusInfo?.size,
+                    maxCensusSize: election?.maxCensusSize,
                   })}
                 </Text>
               </Tooltip>

--- a/src/components/Process/Header.tsx
+++ b/src/components/Process/Header.tsx
@@ -1,5 +1,5 @@
-import { WarningIcon } from '@chakra-ui/icons'
-import { Box, Button, Flex, Icon, Image, Text } from '@chakra-ui/react'
+import { InfoIcon, WarningIcon } from '@chakra-ui/icons'
+import { Box, Button, Flex, Icon, Image, SliderThumb, Text, Tooltip } from '@chakra-ui/react'
 import {
   ElectionDescription,
   ElectionSchedule,
@@ -8,7 +8,7 @@ import {
   OrganizationName,
 } from '@vocdoni/chakra-components'
 import { useClient, useElection, useOrganization } from '@vocdoni/react-providers'
-import { ElectionStatus } from '@vocdoni/sdk'
+import { CensusType, ElectionStatus } from '@vocdoni/sdk'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { useReadMoreMarkdown } from '~components/Layout/use-read-more'
@@ -17,12 +17,16 @@ import { ActionsMenu } from './ActionsMenu'
 import { CreatedBy } from './CreatedBy'
 import { ProcessDate } from './Date'
 import { ShareModalButton } from '~components/Share'
+import { useEffect, useState } from 'react'
+
+type CensusInfo = { size: number; weight: bigint; type: CensusType }
 
 const ProcessHeader = () => {
   const { t } = useTranslation()
   const { election } = useElection()
   const { organization, loaded } = useOrganization()
-  const { account } = useClient()
+  const { account, client } = useClient()
+  const [censusInfo, setCensusInfo] = useState<CensusInfo>()
   const { ReadMoreMarkdownWrapper, ReadMoreMarkdownButton } = useReadMoreMarkdown(
     'rgba(242, 242, 242, 0)',
     'rgba(242, 242, 242, 1)',
@@ -31,8 +35,16 @@ const ProcessHeader = () => {
   )
   const strategy = useStrategy()
 
-  const showOrgInformation = !loaded || (loaded && organization?.account?.name)
+  useEffect(() => {
+    ;(async () => {
+      if (!election?.census?.censusId || !client) return
+      const censusInfo: CensusInfo = await client.fetchCensusInfo(election.census.censusId)
+      setCensusInfo(censusInfo)
+    })()
+  }, [election, client])
 
+  const showOrgInformation = !loaded || (loaded && organization?.account?.name)
+  const showTotalCensusSize = censusInfo?.size !== election?.maxCensusSize
   return (
     <Box mb={10}>
       {showOrgInformation && (
@@ -119,9 +131,35 @@ const ProcessHeader = () => {
               <Text>{t('process.is_anonymous.description')}</Text>
             </Box>
           )}
-          <Box>
-            <Text fontWeight='bold'>{t('process.census')}</Text>
-            <Text>{t('process.people_in_census', { count: election?.maxCensusSize })}</Text>
+          <Box cursor='help'>
+            <Text fontWeight='bold'>
+              {t('process.census')} {showTotalCensusSize && <InfoIcon color='process_create.alert_info.color' ml={1} />}
+            </Text>
+            {showTotalCensusSize ? (
+              <Tooltip
+                hasArrow
+                bg='primary.600'
+                color='white'
+                placement='top'
+                label={t('process.total_census_size_tooltip', {
+                  max: censusInfo?.size,
+                  count: election?.maxCensusSize,
+                  percent:
+                    censusInfo?.size && election?.maxCensusSize
+                      ? Math.round((election?.maxCensusSize / censusInfo?.size) * 100)
+                      : 0,
+                })}
+              >
+                <Text>
+                  {t('process.total_census_size', {
+                    max: censusInfo?.size,
+                    count: election?.maxCensusSize,
+                  })}
+                </Text>
+              </Tooltip>
+            ) : (
+              <Text>{t('process.people_in_census', { count: election?.maxCensusSize })}</Text>
+            )}
           </Box>
           {election?.meta?.census && (
             <Box>
@@ -129,7 +167,6 @@ const ProcessHeader = () => {
               <Text>{strategy}</Text>
             </Box>
           )}
-
           {showOrgInformation && (
             <Box w={{ lg2: 'full' }}>
               <Text fontWeight='bold' mb={1}>

--- a/src/components/Process/Header.tsx
+++ b/src/components/Process/Header.tsx
@@ -44,7 +44,8 @@ const ProcessHeader = () => {
   }, [election, client])
 
   const showOrgInformation = !loaded || (loaded && organization?.account?.name)
-  const showTotalCensusSize = censusInfo?.size !== election?.maxCensusSize
+  const showTotalCensusSize = censusInfo?.size && election?.maxCensusSize && election.maxCensusSize < censusInfo.size
+
   return (
     <Box mb={10}>
       {showOrgInformation && (

--- a/src/components/Process/Header.tsx
+++ b/src/components/Process/Header.tsx
@@ -35,11 +35,17 @@ const ProcessHeader = () => {
   )
   const strategy = useStrategy()
 
+  // Get the census info to show the total size if the maxCensusSize is less than the total size
   useEffect(() => {
     ;(async () => {
-      if (!election?.census?.censusId || !client) return
-      const censusInfo: CensusInfo = await client.fetchCensusInfo(election.census.censusId)
-      setCensusInfo(censusInfo)
+      try {
+        if (!election?.census?.censusId || !client) return
+        const censusInfo: CensusInfo = await client.fetchCensusInfo(election.census.censusId)
+        setCensusInfo(censusInfo)
+      } catch (e) {
+        // If the census info is not available, just ignore it
+        setCensusInfo(undefined)
+      }
     })()
   }, [election, client])
 

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -501,6 +501,8 @@
       "text": "<p>El teu vot ha estat emès i emmagatzemat de forma segura a la cadena de blocs de Vocdoni. Pots comprovar-ho <verify>aquí</verify>.</p><p>La democràcia és important, la pots compartir amb la teva comunitat i amics:</p>",
       "title": "Vot emès correctament!"
     },
+    "total_census_size_other": "{{count}} electors permesos de {{max}} totals en el cens",
+    "total_census_size_tooltip_other": "El nombre màxim d'electors permesos està limitat a {{count}} d'un cens de {{max}} ({{percent}}% del total). Només els primers {{count}} electors poden votar.",
     "voters": "Votants"
   },
   "process_actions": {

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -501,8 +501,8 @@
       "text": "<p>El teu vot ha estat emès i emmagatzemat de forma segura a la cadena de blocs de Vocdoni. Pots comprovar-ho <verify>aquí</verify>.</p><p>La democràcia és important, la pots compartir amb la teva comunitat i amics:</p>",
       "title": "Vot emès correctament!"
     },
-    "total_census_size_other": "{{count}} electors permesos de {{max}} totals en el cens",
-    "total_census_size_tooltip_other": "El nombre màxim d'electors permesos està limitat a {{count}} d'un cens de {{max}} ({{percent}}% del total). Només els primers {{count}} electors poden votar.",
+    "total_census_size": "{{maxCensusSize}} electors permesos de {{censusSize}} totals en el cens",
+    "total_census_size_tooltip": "El nombre màxim d'electors permesos està limitat a {{maxCensusSize}} d'un cens de {{censusSize}} ({{percent}}% del total). Només els primers {{maxCensusSize}} electors poden votar.",
     "voters": "Votants"
   },
   "process_actions": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -493,6 +493,10 @@
       "text": "<p>We've securely processed and stored your vote on our Blockchain. Click <verify>here</verify> to verify your vote.</p>",
       "title": "Vote submitted!"
     },
+    "total_census_size_one": "",
+    "total_census_size_other": "{{count}} allowed voters of {{max}} total in census",
+    "total_census_size_tooltip_one": "",
+    "total_census_size_tooltip_other": "The maximum number of voters allowed is limited to {{count}} from a census of {{max}} ({{percent}}% of the total). Only the first {{count}} voters can vote.",
     "voters": "Voters"
   },
   "process_actions": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -493,10 +493,8 @@
       "text": "<p>We've securely processed and stored your vote on our Blockchain. Click <verify>here</verify> to verify your vote.</p>",
       "title": "Vote submitted!"
     },
-    "total_census_size_one": "",
-    "total_census_size_other": "{{count}} allowed voters of {{max}} total in census",
-    "total_census_size_tooltip_one": "",
-    "total_census_size_tooltip_other": "The maximum number of voters allowed is limited to {{count}} from a census of {{max}} ({{percent}}% of the total). Only the first {{count}} voters can vote.",
+    "total_census_size": "{{maxCensusSize}} allowed voters of {{censusSize}} total in census",
+    "total_census_size_tooltip": "The maximum number of voters allowed is limited to {{maxCensusSize}} from a census of {{censusSize}} ({{percent}}% of the total). Only the first {{maxCensusSize}} voters can vote.",
     "voters": "Voters"
   },
   "process_actions": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -501,8 +501,8 @@
       "text": "<p>Tu voto ha sido emitido y almacenado de forma segura en la cadena de bloques de Vocdoni. Puedes comprobarlo <verify>aquí</verify>.</p><p>La democracia es importante, puedes compartirla con tu comunidad y amigos:</p>",
       "title": "Voto emitido correctamente!"
     },
-    "total_census_size_other": "{{count}} votantes permitidos de {{max}} totales en el censo",
-    "total_census_size_tooltip_other": "El número máximo de votantes permitidos está limitado a {{count}} de un censo de {{max}} ({{percent}}% del total). Solo los primeros {{count}} votantes pueden votar.",
+    "total_census_size": "{{maxCensusSize}} votantes permitidos de {{censusSize}} totales en el censo",
+    "total_census_size_tooltip": "El número máximo de votantes permitidos está limitado a {{maxCensusSize}} de un censo de {{censusSize}} ({{percent}}% del total). Solo los primeros {{maxCensusSize}} votantes pueden votar.",
     "voters": "Votantes"
   },
   "process_actions": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -501,6 +501,8 @@
       "text": "<p>Tu voto ha sido emitido y almacenado de forma segura en la cadena de bloques de Vocdoni. Puedes comprobarlo <verify>aquí</verify>.</p><p>La democracia es importante, puedes compartirla con tu comunidad y amigos:</p>",
       "title": "Voto emitido correctamente!"
     },
+    "total_census_size_other": "{{count}} votantes permitidos de {{max}} totales en el censo",
+    "total_census_size_tooltip_other": "El número máximo de votantes permitidos está limitado a {{count}} de un censo de {{max}} ({{percent}}% del total). Solo los primeros {{count}} votantes pueden votar.",
     "voters": "Votantes"
   },
   "process_actions": {


### PR DESCRIPTION
Fixes https://github.com/vocdoni/ui-scaffold/issues/562

Add total census size information if the census size differs from maxCensusSize. 

![image](https://github.com/vocdoni/ui-scaffold/assets/16777076/f3fca5b5-f3f3-46e3-bc37-143e16e1ffb4)

![image](https://github.com/vocdoni/ui-scaffold/assets/16777076/d5e2a9c5-635d-4056-81fa-d413781957da)

It has a problem when runing `yarn translations` it add a `total_census_size_tooltip_one` key, which is not needed and nor used (this case should not going to happen). @elboletaire should we take attention to it or can we ignore it?
