### PR TITLE
Visual Improvements

### DIFF
--- a/src/components/Process/View.tsx
+++ b/src/components/Process/View.tsx
@@ -138,7 +138,7 @@ export const ProcessView = () => {
             </TabList>
             <TabPanels>
               <TabPanel>
-                <Box ref={electionRef} className='md-sizes' mb='100px' pt='50px'>
+                <Box ref={electionRef} className='md-sizes' mb='100px' pt='25px'>
                   <ElectionQuestions
                     onInvalid={(args) => {
                       setFormErrors(args)

--- a/src/components/ProcessCreate/Census/Gitcoin/GitcoinForm.tsx
+++ b/src/components/ProcessCreate/Census/Gitcoin/GitcoinForm.tsx
@@ -40,7 +40,6 @@ export const GitcoinForm: FC<IGitcoinFormProps> = ({ gitcoinTokens }) => {
       <Controller
         name={'passportScore'}
         control={control}
-        defaultValue={15}
         rules={{
           required,
         }}
@@ -51,7 +50,6 @@ export const GitcoinForm: FC<IGitcoinFormProps> = ({ gitcoinTokens }) => {
             </FormLabel>
             <Flex gap={8}>
               <NumberInput
-                defaultValue={15}
                 min={1}
                 max={100}
                 maxW={40}
@@ -71,6 +69,8 @@ export const GitcoinForm: FC<IGitcoinFormProps> = ({ gitcoinTokens }) => {
                 flex='1'
                 focusThumbOnChange={false}
                 value={value}
+                min={1}
+                max={100}
                 onChange={(e) => {
                   onChange(Number(e))
                 }}

--- a/src/components/ProcessCreate/Census/Token.tsx
+++ b/src/components/ProcessCreate/Census/Token.tsx
@@ -315,6 +315,7 @@ export const CensusTokens = () => {
             placeholder={t('form.process_create.census.tokens_placeholder')}
             aria-label={t('form.process_create.census.tokens_placeholder')}
             defaultValue={ct}
+            value={ct} // By setting the value will prevent to show request tokens as selected value
             name={ctoken.name}
             onBlur={ctoken.onBlur}
             formatGroupLabel={formatGroupLabel}

--- a/src/components/ProcessCreate/StepForm/CensusGitcoin.tsx
+++ b/src/components/ProcessCreate/StepForm/CensusGitcoin.tsx
@@ -1,6 +1,6 @@
-import { Box, Text } from '@chakra-ui/react'
+import { Box, Link, Text } from '@chakra-ui/react'
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { useProcessCreationSteps } from '../Steps/use-steps'
 import { CensusTokenValues } from '~components/ProcessCreate/StepForm/CensusToken'
 import { GitcoinStampToken, GitcoinStrategyBuilder } from '../Census/Gitcoin'
@@ -43,7 +43,18 @@ export const StepFormCensusGitcoin = () => {
         {t('census.gitcoin_title')}
       </Text>
       <Text fontSize='sm' color='process_create.description' mb={5}>
-        {t('census.gitcoin_description')}
+        {t('census.gitcoin_description')} <br />
+        <Trans
+          i18nKey='census.gitcoin_read_more'
+          components={{
+            link: (
+              <Link
+                href={'https://docs.passport.gitcoin.co/building-with-passport/major-concepts/scoring-thresholds'}
+                target='_blank'
+              />
+            ),
+          }}
+        />
       </Text>
       <FormProvider {...methods}>
         <Box as='form' id='process-create-form' onSubmit={methods.handleSubmit(onSubmit)}>

--- a/src/components/ProcessCreate/StepForm/CensusGitcoin.tsx
+++ b/src/components/ProcessCreate/StepForm/CensusGitcoin.tsx
@@ -47,10 +47,15 @@ export const StepFormCensusGitcoin = () => {
         <Trans
           i18nKey='census.gitcoin_read_more'
           components={{
-            link: (
+            a: (
               <Link
                 href={'https://docs.passport.gitcoin.co/building-with-passport/major-concepts/scoring-thresholds'}
                 target='_blank'
+                variant='primary'
+                textDecoration='underline'
+                _hover={{
+                  textDecoration: 'none',
+                }}
               />
             ),
           }}

--- a/src/components/ProcessCreate/StepForm/CensusToken.tsx
+++ b/src/components/ProcessCreate/StepForm/CensusToken.tsx
@@ -1,7 +1,7 @@
-import { Box, Text } from '@chakra-ui/react'
+import { Box, Link, Text } from '@chakra-ui/react'
 import { Census3Token, ICensus3SupportedChain } from '@vocdoni/sdk'
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { CensusTokens } from '../Census/Token'
 import { useProcessCreationSteps } from '../Steps/use-steps'
 
@@ -37,7 +37,12 @@ export const StepFormCensusToken = () => {
         {t('census.token_title')}
       </Text>
       <Text fontSize='sm' color='process_create.description' mb={5}>
-        {t('census.token_description')}
+        <Trans
+          i18nKey='census.token_description'
+          components={{
+            link1: <Link href={'https://tally.so/r/mO46VY'} target='_blank' />,
+          }}
+        />
       </Text>
       <FormProvider {...methods}>
         <Box as='form' id='process-create-form' onSubmit={methods.handleSubmit(onSubmit)}>

--- a/src/components/ProcessCreate/Steps/Form.tsx
+++ b/src/components/ProcessCreate/Steps/Form.tsx
@@ -27,6 +27,7 @@ export const StepsForm = ({ steps, children, activeStep, next, prev, setActiveSt
     questions: [{ options: [{}, {}] }],
     addresses: [],
     gpsWeighted: false,
+    passportScore: 20,
   })
 
   const [isLoadingPreview, setIsLoadingPreview] = useState(false)

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -11,7 +11,7 @@
     "votes_one": "<span>1</span> <text>votant</text>",
     "votes_many": "<span>{{ count }}</span> <text>votants</text>",
     "votes_other": "<span>{{ count }}</span> <text>votants</text>",
-    "voting_anonymous_advice": "Si us plau, espera mentre la màgia té lloc \uD83E\uDE84.\nAixò pot trigar uns minuts; no tanquis la finestra."
+    "voting_anonymous_advice": "Si us plau, espera mentre la màgia té lloc 🪄.\nAixò pot trigar uns minuts; no tanquis la finestra."
   },
   "banner": {
     "start_now": "Crea una votació!",

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -11,7 +11,7 @@
     "votes_one": "<span>1</span> <text>votant</text>",
     "votes_many": "<span>{{ count }}</span> <text>votants</text>",
     "votes_other": "<span>{{ count }}</span> <text>votants</text>",
-    "voting_anonymous_advice": "Si us plau, espera mentre la màgia té lloc.Això pot trigar uns minuts; no tanquis la finestra."
+    "voting_anonymous_advice": "Si us plau, espera mentre la màgia té lloc \uD83E\uDE84.\nAixò pot trigar uns minuts; no tanquis la finestra."
   },
   "banner": {
     "start_now": "Crea una votació!",
@@ -22,7 +22,6 @@
   "banner_voting_types": {
     "anonymous_description": "La identitat dels votants serà completament confidencial, gràcies a la tecnologia zk-SNARKS.",
     "anonymous_title": "100% Anònim",
-    "bottom_text": "La privacitat hauria de ser normal",
     "flexible_description": "Personalitza el teu procés de votació i la llista de participants per adaptar-los als requisits únics de la teva comunitat.",
     "flexible_title": "Votació Flexible",
     "token_description": "Vota amb tokens ERC20/ERC721 (NFT) o afegeix els teus propis tokens i vota sense pagar.",
@@ -95,13 +94,14 @@
     "chain_required": "Necessites seleccionar una xarxa",
     "description": "Selecciona com s'autenticaran i identificaran els votants.",
     "gitcoin_description": "Amb aquest cens, només els votants amb Gitcoin Passport podran votar, proporcionant un mètode de resistència contra atacs sybil. Pots definir la puntuació general (GPS) i diferents stamps que el votant ha de tenir.",
+    "gitcoin_read_more": "",
     "gitcoin_title": "Gitcoin Passport",
     "pro": "",
     "request_custom_token": "Sol·licitar Tokens Personalitzats",
     "social_address_title": "Usuaris de Github",
     "spreadsheet_title": "Dades personalitzades",
     "title": "Trieu el cens",
-    "token_description": "Selecciona la red y el token para crear un censo donde los titulares de token votarán con su poder de voto.",
+    "token_description": "Seleccioneu la xarxa i el token per crear un cens on els titulars del token votaran amb el seu poder de vot. Pots sol·licitar un token <link1>aquí</link1>.",
     "token_required": "Necessites seleccionar un token",
     "token_title": "Cens basat en tokens",
     "wallet_address_title": "Adreces de cartera"
@@ -168,10 +168,7 @@
     "tokens_you_own": "Tens {{ balance }} tokens."
   },
   "footer": {
-    "about": "Sobre nosaltres",
-    "blog": "Blog",
     "company": "Empresa",
-    "contact": "Contacte",
     "demo": "Tipus de Votació",
     "demo1": "Elecció Simple",
     "demo2": "Elecció Múltiple",
@@ -179,25 +176,16 @@
     "demo4": "Votació per Classificació",
     "demo5": "Pressupostos Participatius",
     "demo6": "Votació Ponderada",
-    "developer_portal": "Portal de desenvolupadors",
-    "developers": "Desenvolupadors",
-    "discord": "Discord",
     "follow_us": "Segueix-nos",
     "footer_subtitle": "El Protocol de Votació Global",
-    "homepage": "Inici",
-    "repos": "Codi Obert",
-    "resources": "Recursos",
     "terms_and_privacy": "<link1>Termes d'ús</link1> i <link2>Política de privacitat</link2>",
     "text": "<p1>El futur</p1><p2>de la votació en Web3 comença aquí</p2>",
-    "tutorials": "Tutorials",
     "uses_cases": "Casos d'Ús",
     "uses_cases1": "Assemblees Generals d'Accionistes (AGMs)",
     "uses_cases2": "Eleccions",
     "uses_cases3": "Pressupostos Participatius",
     "uses_cases4": "Votació Digital",
-    "uses_cases5": "Enquesta Digital Tancada",
-    "vocdoni_api": "API de Vocdoni",
-    "vocdoni_app": "APP de Vocdoni"
+    "uses_cases5": "Enquesta Digital Tancada"
   },
   "form": {
     "account_create": {
@@ -260,6 +248,7 @@
         "add_new_address": "Afageix una nova adreça",
         "delete_web3_address": "Eliminar adreça amb index {{ index }}",
         "gitcoin_description": "Construeix un cens resistents a Sybil (resistent a la falsificació d'identitat) amb Gitcoin Passport i els seus segells de verificació per a una seguretat reforçada",
+        "gitcoin_read_more": "Llegeix més sobre Scorer & Thresholds de Gitcoin <link>aquí</link>",
         "gitcoin_passport_score": "Puntuació del Gitcoin Passport",
         "gitcoin_stamps": "Stamps",
         "gitcoin_strategy_description_AND": "Els usuaris votants han de ser propietaris de tots els segells seleccionats i tenir un GPS igual o superior.",
@@ -651,9 +640,6 @@
     "organization": "Edita Organització",
     "privacy": "Privadesa",
     "terms": "Termes",
-    "vocdoni": {
-      "login": "Login"
-    },
     "wallet": "Cartera"
   },
   "meta": {
@@ -686,7 +672,6 @@
     "census": "Cens",
     "census_strategies": {
       "csp": "CSP",
-      "gitcoin": "Gitcoin",
       "spreadsheet": "CSV",
       "token": "Token ({{ token.type, uppercase }}): {{ token.symbol }}",
       "web3": "Adreces Web3"

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -248,7 +248,7 @@
         "add_new_address": "Afageix una nova adreça",
         "delete_web3_address": "Eliminar adreça amb index {{ index }}",
         "gitcoin_description": "Construeix un cens resistents a Sybil (resistent a la falsificació d'identitat) amb Gitcoin Passport i els seus segells de verificació per a una seguretat reforçada",
-        "gitcoin_read_more": "Llegeix més sobre Scorer & Thresholds de Gitcoin <link>aquí</link>",
+        "gitcoin_read_more": "Llegeix més sobre Scorer & Thresholds de Gitcoin <a>aquí</a>",
         "gitcoin_passport_score": "Puntuació del Gitcoin Passport",
         "gitcoin_stamps": "Stamps",
         "gitcoin_strategy_description_AND": "Els usuaris votants han de ser propietaris de tots els segells seleccionats i tenir un GPS igual o superior.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -9,7 +9,7 @@
     "verify_vote_on_explorer": "Verify your vote on the explorer",
     "votes_one": "<span>1</span> <text>voter</text>",
     "votes_other": "<span>{{ count }}</span> <text>voters</text>",
-    "voting_anonymous_advice": "Please wait while the anonymous magic happens \uD83E\uDE84.\nThis can take up to several minutes; don't close the window."
+    "voting_anonymous_advice": "Please wait while the anonymous magic happens 🪄.\nThis can take up to several minutes; don't close the window."
   },
   "banner": {
     "start_now": "Create a vote now!",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -92,7 +92,7 @@
     "chain_required": "You need to select a network",
     "description": "Choose how to authenticate and verify voters.",
     "gitcoin_description": "With this census only voters with a Gitcoin Passport will be able to vote, providing a sybil-attack resistance method. You can define the general score (GPS) and different stamps that the voter must have.",
-    "gitcoin_read_more": "Read more about Gitcoin's Scorer & Thresholds <link>here</link>",
+    "gitcoin_read_more": "Read more about Gitcoin's Scorer & Thresholds <a>here</a>",
     "gitcoin_title": "Gitcoin Passport",
     "pro": "Pro Census",
     "request_custom_token": "'Request Custom Tokens'",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3,13 +3,13 @@
     "has_already_voted": "Your vote is properly cast",
     "is_not_in_census": "You are not in the census",
     "not_connected": "You are not connected",
-    "overwrite_votes_left_one": "You can correct your vote only once.",
+    "overwrite_votes_left_one": "You can correct your vote once.",
     "overwrite_votes_left_other": "You can correct your vote up to {{ count }} times.",
     "submitting": "Submitting",
     "verify_vote_on_explorer": "Verify your vote on the explorer",
     "votes_one": "<span>1</span> <text>voter</text>",
     "votes_other": "<span>{{ count }}</span> <text>voters</text>",
-    "voting_anonymous_advice": "Please wait while the anonymous magic happens.\nThis can take up to several minutes; don't close the window."
+    "voting_anonymous_advice": "Please wait while the anonymous magic happens \uD83E\uDE84.\nThis can take up to several minutes; don't close the window."
   },
   "banner": {
     "start_now": "Create a vote now!",
@@ -20,7 +20,6 @@
   "banner_voting_types": {
     "anonymous_description": "Say goodbye to the high expenses of traditional voting methods. {{app}} brings you a more affordable way to conduct elections, cutting down on logistical and administrative costs while maintaining the highest standards of quality and security.",
     "anonymous_title": "Cost-Effective Voting Solutions",
-    "bottom_text": "Privacy should be normal",
     "flexible_description": "Engagement is key in democratic processes, and our platform is designed to maximize it. With its user-friendly interface and accessibility, {{app}} encourages higher participation rates, ensuring a more representative and inclusive voting experience.",
     "flexible_title": "Boosted Participation Rates",
     "token_description": "At the heart of {{app}} is our commitment to security. Leveraging cutting-edge cryptographic methods, we ensure that every vote cast is not only secure but fully verifiable. This transparency builds unparalleled trust among participants, crucial for the legitimacy of any election.",
@@ -92,14 +91,15 @@
   "census": {
     "chain_required": "You need to select a network",
     "description": "Choose how to authenticate and verify voters.",
-    "gitcoin_description": "With this census only voters with a Gitcoin Passport will be able to vote, providing a sybyl-attack resistance method. You can define the general score (GPS) and different stamps that the voter must have.",
+    "gitcoin_description": "With this census only voters with a Gitcoin Passport will be able to vote, providing a sybil-attack resistance method. You can define the general score (GPS) and different stamps that the voter must have.",
+    "gitcoin_read_more": "Read more about Gitcoin's Scorer & Thresholds <link>here</link>",
     "gitcoin_title": "Gitcoin Passport",
     "pro": "Pro Census",
     "request_custom_token": "'Request Custom Tokens'",
     "social_address_title": "Github users",
     "spreadsheet_title": "Custom data",
     "title": "Census",
-    "token_description": "Configure the census by choosing a token from any available network. You can request a token here.",
+    "token_description": "Configure the census by choosing a token from any available network. You can request a token <link1>here</link1>.",
     "token_required": "You need to select a token",
     "token_title": "Token based census",
     "wallet_address_title": "Wallet addresses"
@@ -165,10 +165,7 @@
     "tokens_you_own": "You own {{ balance }} tokens."
   },
   "footer": {
-    "about": "About",
-    "blog": "Blog",
     "company": "Company",
-    "contact": "Contact",
     "demo": "Voting Types",
     "demo1": "Single Choice",
     "demo2": "Multiple Choice",
@@ -176,25 +173,16 @@
     "demo4": "Ranked Voting",
     "demo5": "Participatory Budgeting",
     "demo6": "Weighted Voting",
-    "developer_portal": "Developers Portal",
-    "developers": "Developers",
-    "discord": "Discord",
     "follow_us": "Follow us",
     "footer_subtitle": "The Global Voting Protocol",
-    "homepage": "Home",
-    "repos": "Open-source Code",
-    "resources": "Resources",
     "terms_and_privacy": "<link1>Terms of use</link1> & <link2>Privacy Policy</link2>",
     "text": "<p1>The future</p1><p2>of Web3 voting starts here</p2>",
-    "tutorials": "Tutorials",
     "uses_cases": "Use Cases",
     "uses_cases1": "AGMs",
     "uses_cases2": "Elections",
     "uses_cases3": "Participatory Budgeting",
     "uses_cases4": "Online Voting",
-    "uses_cases5": "Gated Online Survey",
-    "vocdoni_api": "Vocdoni API",
-    "vocdoni_app": "Vocdoni APP"
+    "uses_cases5": "Gated Online Survey"
   },
   "form": {
     "account_create": {
@@ -644,9 +632,6 @@
     "organization": "Edit Organization",
     "privacy": "Privacy",
     "terms": "Terms",
-    "vocdoni": {
-      "login": "Open App"
-    },
     "wallet": "Wallet"
   },
   "meta": {
@@ -679,7 +664,6 @@
     "census": "Census",
     "census_strategies": {
       "csp": "CSP",
-      "gitcoin": "Gitcoin",
       "spreadsheet": "CSV/Spreadsheet",
       "token": "Token ({{ token.type, uppercase }}): {{ token.symbol }}",
       "web3": "Web3 addresses"

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -248,7 +248,7 @@
         "add_new_address": "Añade una nueva dirección",
         "delete_web3_address": "Eliminar direccion con índice {{ index }}",
         "gitcoin_description": "Construye un censo resistente a Sybil (resistente a la falsificación de identidad) con Gitcoin Passport y sus sellos de verificación para una seguridad mejorada",
-        "gitcoin_read_more": "Lee más sobre Scorer & Thresholds de Gitcoin <link>aquí</link>",
+        "gitcoin_read_more": "Lee más sobre Scorer & Thresholds de Gitcoin <a>aquí</a>",
         "gitcoin_passport_score": "Puntuación de Gitcoin Pasaport",
         "gitcoin_stamps": "Stamps",
         "gitcoin_strategy_description_AND": "Los usuarios votantes deben ser propietarios de todos los sellos seleccionados y tener un GPS igual o superior.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -11,7 +11,7 @@
     "votes_one": "<span>1</span> <text>votante</text>",
     "votes_many": "<span>{{ count }}</span> <text>votantes</text>",
     "votes_other": "<span>{{ count }}</span> <text>votantes</text>",
-    "voting_anonymous_advice": "Por favor, espera mientras sucede la magia \uD83E\uDE84.\nEsto puede tardar varios minutos; no cierres la ventana."
+    "voting_anonymous_advice": "Por favor, espera mientras sucede la magia 🪄.\nEsto puede tardar varios minutos; no cierres la ventana."
   },
   "banner": {
     "start_now": "¡Crea una votación ahora!",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -11,7 +11,7 @@
     "votes_one": "<span>1</span> <text>votante</text>",
     "votes_many": "<span>{{ count }}</span> <text>votantes</text>",
     "votes_other": "<span>{{ count }}</span> <text>votantes</text>",
-    "voting_anonymous_advice": "Por favor, espera mientras sucede la magia.\nEsto puede tardar varios minutos; no cierres la ventana."
+    "voting_anonymous_advice": "Por favor, espera mientras sucede la magia \uD83E\uDE84.\nEsto puede tardar varios minutos; no cierres la ventana."
   },
   "banner": {
     "start_now": "¡Crea una votación ahora!",
@@ -22,7 +22,6 @@
   "banner_voting_types": {
     "anonymous_description": "La identidad de los votantes permanece completamente confidencial, gracias a la tecnología zk-SNARKS.",
     "anonymous_title": "100% Anónimo",
-    "bottom_text": "La privacidad debería ser normal",
     "flexible_description": "Personaliza tu proceso de votación y censo para satisfacer los requisitos únicos de tu comunidad.",
     "flexible_title": "Votación Flexible",
     "token_description": "Vota con tokens ERC20/ERC721 (NFT) o agrega tus propios tokens y vota sin coste de gas con ellos.",
@@ -95,13 +94,14 @@
     "chain_required": "Necesitas seleccionar una red",
     "description": "Selecciona cómo los votantes se autenticarán e identificarán.",
     "gitcoin_description": "Con este censo, solo los votantes con Gitcoin Passport podrán votar, proporcionando un método de resistencia contra sybil-attack. Puedes definir la puntuación general (GPS) y diferentes stamps que el votante debe tener.",
+    "gitcoin_read_more": "",
     "gitcoin_title": "Gitcoin Passport",
     "pro": "",
     "request_custom_token": "Solicitar Tokens Personalizados",
     "social_address_title": "Usuarios de Github",
     "spreadsheet_title": "Datos personalizados",
     "title": "Censo",
-    "token_description": "Seleccioneu la xarxa i el token per crear un cens on els titulars del token votaran amb el seu poder de vot.",
+    "token_description": "Selecciona la red y el token para crear un censo donde los titulares de token votarán con su poder de voto. Puedes solicitar un token <link1>aquí</link1>.",
     "token_required": "Necesitas seleccionar un token",
     "token_title": "Censo basado en tokens",
     "wallet_address_title": "Direcciones de billetera"
@@ -168,10 +168,7 @@
     "tokens_you_own": "Tienes {{ balance }} tokens."
   },
   "footer": {
-    "about": "Acerca de",
-    "blog": "Blog",
     "company": "Empresa",
-    "contact": "Contacto",
     "demo": "Tipos de Votación",
     "demo1": "Elección Simple",
     "demo2": "Elección Múltiple",
@@ -179,25 +176,16 @@
     "demo4": "Votación por Clasificación",
     "demo5": "Presupuestos Participativos",
     "demo6": "Votación Ponderada",
-    "developer_portal": "Portal para desarrolladores",
-    "developers": "Desarrolladores",
-    "discord": "Discord",
     "follow_us": "Síguenos",
     "footer_subtitle": "El Protocolo de Votación Global",
-    "homepage": "Inicio",
-    "repos": "Código abierto",
-    "resources": "Recursos",
     "terms_and_privacy": "<link1>Términos de uso</link1> y <link2>Política de privacidad</link2>",
     "text": "<p1>El futuro</p1><p2>de la votación en Web3 comienza aquí</p2>",
-    "tutorials": "Tutoriales",
     "uses_cases": "Casos de Uso",
     "uses_cases1": "Asambleas Generales de Accionistas (AGMs)",
     "uses_cases2": "Elecciones",
     "uses_cases3": "Presupuestos Participativos",
     "uses_cases4": "Votación Digital",
-    "uses_cases5": "Encuesta Digital Cerrada",
-    "vocdoni_api": "API de Vocdoni",
-    "vocdoni_app": "APP de Vocdoni"
+    "uses_cases5": "Encuesta Digital Cerrada"
   },
   "form": {
     "account_create": {
@@ -260,6 +248,7 @@
         "add_new_address": "Añade una nueva dirección",
         "delete_web3_address": "Eliminar direccion con índice {{ index }}",
         "gitcoin_description": "Construye un censo resistente a Sybil (resistente a la falsificación de identidad) con Gitcoin Passport y sus sellos de verificación para una seguridad mejorada",
+        "gitcoin_read_more": "Lee más sobre Scorer & Thresholds de Gitcoin <link>aquí</link>",
         "gitcoin_passport_score": "Puntuación de Gitcoin Pasaport",
         "gitcoin_stamps": "Stamps",
         "gitcoin_strategy_description_AND": "Los usuarios votantes deben ser propietarios de todos los sellos seleccionados y tener un GPS igual o superior.",
@@ -651,9 +640,6 @@
     "organization": "Editar Organización",
     "privacy": "Privacidad",
     "terms": "Términos",
-    "vocdoni": {
-      "login": "Login"
-    },
     "wallet": "Billetera"
   },
   "meta": {
@@ -686,7 +672,6 @@
     "census": "Censo",
     "census_strategies": {
       "csp": "CSP",
-      "gitcoin": "Gitcoin",
       "spreadsheet": "CSV",
       "token": "Token ({{ token.type, uppercase }}): {{ token.symbol }}",
       "web3": "Direcciones web3"

--- a/src/themes/default/components/Questions.ts
+++ b/src/themes/default/components/Questions.ts
@@ -8,7 +8,7 @@ const baseStyle = definePartsStyle({
   alert: {
     px: { base: 3, sm: 5 },
     py: 7,
-    my: '10px',
+    mb: '30px',
     borderRadius: '8px',
     color: 'process.questions.alert.color',
     bgColor: 'process.questions.alert.bg',

--- a/src/themes/onvote/components/Questions.ts
+++ b/src/themes/onvote/components/Questions.ts
@@ -8,7 +8,7 @@ const baseStyle = definePartsStyle({
   alert: {
     px: { base: 3, sm: 5 },
     py: 7,
-    my: '10px',
+    mb: '30px',
     color: 'process.questions.alert.color',
     bgColor: 'process.questions.alert.bg',
     display: 'grid',


### PR DESCRIPTION
Fix #661 

From the list it fixes 

- [x] In the "Gitcoin passport" census, once selected add in the end of the description the following text "Read more about Gitcoin's Scorer & Thresholds here" with a link in the "here" that opens a new tab linking: "https://docs.passport.gitcoin.co/building-with-passport/major-concepts/scoring-thresholds"
- [x] The minimum possible GPS should be "1" instead of "0" (both for the numeric input & slider). 
- [x] The default GPS should be set to "20".
- [x] Correct the typo: `sybyl-attack` to `sybil-attack`.
- [x] In the "Token census", the description is as follows: "Configure the census by choosing a token from any available network. You can request a token here." but the "here" is not a link. Add the link to the "Add token form" (https://tally.so/r/mO46VY).
- [x] Remove top margin space from the "Verify your vote" box and add some bottom margin.
![image](https://github.com/vocdoni/ui-scaffold/assets/6894329/20a9927f-f2c2-4cc3-a373-f7fec855671d)
- [x] Change "You can correct your vote only once." to "You can correct your vote once."
- [x] Add the "magic" emoji in the phrase: "Please wait while the anonymous magic happens  🪄."
- [x] When click in the "Request Custom Tokens", the form is open but also the option is selected in the dropdown. Prevent the dropdown to show this as an option: 
![image](https://github.com/vocdoni/ui-scaffold/assets/6894329/90bf2d5e-d8f8-4906-babe-fae18fbca23f)
