### PR TITLE
Implement union type custom radio button

### DIFF
--- a/src/components/ProcessCreate/Census/Gitcoin/StampsUnionType.tsx
+++ b/src/components/ProcessCreate/Census/Gitcoin/StampsUnionType.tsx
@@ -58,10 +58,10 @@ export const StampsUnionType = () => {
 
   return (
     <Flex
-      gap={5}
-      flexDirection={{ base: 'column', md: 'row' }}
+      gap={2}
+      flexDirection={'column'}
       justifyContent={{ base: 'start', md: 'space-between' }}
-      alignItems={{ base: 'start', md: 'center' }}
+      alignItems={{ base: 'start', md: 'end' }}
       maxW={600}
     >
       <HStack>

--- a/src/components/ProcessCreate/Census/Gitcoin/StampsUnionType.tsx
+++ b/src/components/ProcessCreate/Census/Gitcoin/StampsUnionType.tsx
@@ -22,8 +22,8 @@ const UnionTypeRadioCard = (props: UseRadioProps & PropsWithChildren) => {
         borderRadius='md'
         boxShadow='md'
         _checked={{
-          bg: 'primary.main',
-          color: 'primary.50',
+          bg: 'checkbox.selected',
+          color: 'checkbox.selected_text',
           borderColor: 'primary.dark2',
         }}
         _focus={{

--- a/src/components/ProcessCreate/Census/Gitcoin/StampsUnionType.tsx
+++ b/src/components/ProcessCreate/Census/Gitcoin/StampsUnionType.tsx
@@ -22,9 +22,9 @@ const UnionTypeRadioCard = (props: UseRadioProps & PropsWithChildren) => {
         borderRadius='md'
         boxShadow='md'
         _checked={{
-          bg: 'teal.600',
+          bg: 'primary.main',
           color: 'white',
-          borderColor: 'teal.600',
+          borderColor: 'primary.dark2',
         }}
         _focus={{
           boxShadow: 'outline',

--- a/src/components/ProcessCreate/Census/Gitcoin/StampsUnionType.tsx
+++ b/src/components/ProcessCreate/Census/Gitcoin/StampsUnionType.tsx
@@ -23,7 +23,7 @@ const UnionTypeRadioCard = (props: UseRadioProps & PropsWithChildren) => {
         boxShadow='md'
         _checked={{
           bg: 'primary.main',
-          color: 'white',
+          color: 'primary.50',
           borderColor: 'primary.dark2',
         }}
         _focus={{

--- a/src/components/ProcessCreate/Census/Gitcoin/StampsUnionType.tsx
+++ b/src/components/ProcessCreate/Census/Gitcoin/StampsUnionType.tsx
@@ -1,55 +1,82 @@
-import { Flex, FormLabel, Switch, Text } from '@chakra-ui/react'
-import { Controller, useFormContext } from 'react-hook-form'
+import { Box, Flex, HStack, Text, useRadio, useRadioGroup } from '@chakra-ui/react'
+import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { CensusGitcoinValues } from '~components/ProcessCreate/StepForm/CensusGitcoin'
+import { UseRadioProps } from '@chakra-ui/radio/dist/use-radio'
+import { PropsWithChildren } from 'react'
 
 export type StampsUnionTypes = 'AND' | 'OR'
 
+const UnionTypeRadioCard = (props: UseRadioProps & PropsWithChildren) => {
+  const { getInputProps, getRadioProps } = useRadio(props)
+
+  const input = getInputProps()
+  const checkbox = getRadioProps()
+
+  return (
+    <Box as='label'>
+      <input {...input} />
+      <Box
+        {...checkbox}
+        cursor='pointer'
+        borderWidth='1px'
+        borderRadius='md'
+        boxShadow='md'
+        _checked={{
+          bg: 'teal.600',
+          color: 'white',
+          borderColor: 'teal.600',
+        }}
+        _focus={{
+          boxShadow: 'outline',
+        }}
+        px={5}
+        py={3}
+      >
+        {props.children}
+      </Box>
+    </Box>
+  )
+}
+
 export const StampsUnionType = () => {
-  const { control, setValue } = useFormContext<CensusGitcoinValues>()
   const { t } = useTranslation()
-  const switchOnChange = (value: string) => {
-    const newValue = value === 'OR' ? 'AND' : 'OR'
-    setValue('stampsUnionType', newValue)
+  const options: StampsUnionTypes[] = ['OR', 'AND']
+  const { setValue, getValues, watch } = useFormContext()
+
+  const { getRadioProps } = useRadioGroup({
+    name: 'stampsUnionType',
+    defaultValue: getValues('stampsUnionType'),
+    onChange: (value) => {
+      setValue('stampsUnionType', value)
+    },
+  })
+
+  let description = t('form.process_create.census.gitcoin_strategy_description_OR')
+  if (watch('stampsUnionType') === 'AND') {
+    description = t('form.process_create.census.gitcoin_strategy_description_AND')
   }
 
   return (
-    <Controller
-      name='stampsUnionType'
-      control={control}
-      defaultValue={'OR'}
-      render={({ field }) => {
-        const isChecked = field.value === 'AND'
-        let description = t('form.process_create.census.gitcoin_strategy_description_OR')
-        if (isChecked) {
-          description = t('form.process_create.census.gitcoin_strategy_description_AND')
-        }
-        return (
-          <Flex
-            gap={5}
-            flexDirection={{ base: 'column', md: 'row' }}
-            justifyContent={{ base: 'start', md: 'space-between' }}
-            alignItems={{ base: 'start', md: 'center' }}
-            maxW={600}
-          >
-            <Flex flexDirection={'row'} gap={4} alignItems={'center'}>
-              <Switch
-                {...field}
-                size={'lg'}
-                id='stampsUnionType'
-                isChecked={isChecked}
-                onChange={(e) => switchOnChange(e.target.value)}
-              />
-              <FormLabel minWidth='40px' fontWeight='bold' m={0}>
-                {field.value}
-              </FormLabel>
-            </Flex>
-            <Text fontSize='xs' color='process_create.description' flex={1} textAlign={'left'}>
-              {description}
-            </Text>
-          </Flex>
-        )
-      }}
-    />
+    <Flex
+      gap={5}
+      flexDirection={{ base: 'column', md: 'row' }}
+      justifyContent={{ base: 'start', md: 'space-between' }}
+      alignItems={{ base: 'start', md: 'center' }}
+      maxW={600}
+    >
+      <HStack>
+        {options.map((value) => {
+          const radio = getRadioProps({ value })
+          return (
+            <UnionTypeRadioCard key={value} {...radio}>
+              {value}
+            </UnionTypeRadioCard>
+          )
+        })}
+      </HStack>
+      <Text fontSize='xs' color='process_create.description' flex={1} textAlign={'left'}>
+        {description}
+      </Text>
+    </Flex>
   )
 }

--- a/src/components/ProcessCreate/Steps/Form.tsx
+++ b/src/components/ProcessCreate/Steps/Form.tsx
@@ -28,6 +28,7 @@ export const StepsForm = ({ steps, children, activeStep, next, prev, setActiveSt
     addresses: [],
     gpsWeighted: false,
     passportScore: 20,
+    stampsUnionType: 'OR',
   })
 
   const [isLoadingPreview, setIsLoadingPreview] = useState(false)

--- a/src/themes/default/colors.ts
+++ b/src/themes/default/colors.ts
@@ -47,7 +47,10 @@ export const colors = {
     700: colorsBase.black,
   },
 
-  checkbox: colorsBase.primary.main,
+  checkbox: {
+    selected: colorsBase.primary.main,
+    selected_text: colorsBase.white.pure,
+  },
 
   editor: {
     character_limit: colorsBase.gray.light,

--- a/src/themes/default/components/Checkbox.ts
+++ b/src/themes/default/components/Checkbox.ts
@@ -8,7 +8,7 @@ const baseStyle = definePartsStyle({
     borderRadius: 'full',
 
     '&[data-checked=""]': {
-      background: 'checkbox',
+      background: 'checkbox.selected',
     },
   },
 })

--- a/src/themes/default/components/Tabs.ts
+++ b/src/themes/default/components/Tabs.ts
@@ -75,7 +75,7 @@ const card = definePartsStyle({
     '& > svg': {
       w: 5,
       h: 5,
-      color: 'checkbox',
+      color: 'checkbox.selected',
       position: 'absolute',
       top: 2,
       right: 2,

--- a/src/themes/onvote/colors.ts
+++ b/src/themes/onvote/colors.ts
@@ -64,7 +64,10 @@ export const colors = {
   error: colorsBase.red,
   success: colorsBase.green,
 
-  checkbox: colorsBase.primary.main,
+  checkbox: {
+    selected: colorsBase.primary.main,
+    selected_text: colorsBase.white.pure,
+  },
 
   footer_icon: colorsBase.white.pure,
 

--- a/src/themes/onvote/components/Checkbox.ts
+++ b/src/themes/onvote/components/Checkbox.ts
@@ -8,7 +8,7 @@ const baseStyle = definePartsStyle({
     borderRadius: 0,
 
     '&[data-checked=""]': {
-      background: 'checkbox',
+      background: 'checkbox.selected',
       bgImage: checkIcon,
       bgSize: '10px',
       bgRepeat: 'no-repeat',

--- a/src/themes/onvote/components/Tabs.ts
+++ b/src/themes/onvote/components/Tabs.ts
@@ -69,7 +69,7 @@ const card = definePartsStyle({
     '& > img': {
       w: 5,
       h: 5,
-      bgColor: 'checkbox',
+      bgColor: 'checkbox.selected',
       p: 1,
       position: 'absolute',
       top: 2,


### PR DESCRIPTION
It fixes the first an issue of #661

> Improve OR/AND selector in the "Gitcoin Passport" census type. Change the current switch to the "custom radio button" Chakra component, while preserving the text change depending on the selected option:
> ![image](https://github.com/vocdoni/ui-scaffold/assets/6894329/c2d9a730-1c3c-48ad-b03d-762f951fee5b)