### PR TITLE
fixed issue process scroll, closes #668

### DIFF
--- a/src/components/Process/Header.tsx
+++ b/src/components/Process/Header.tsx
@@ -139,9 +139,7 @@ const ProcessHeader = () => {
                 {t('process.status.canceled')}
               </Text>
             )}
-            <Box position='absolute' right={0} top={0}>
-              <ActionsMenu />
-            </Box>
+            <ActionsMenu />
           </Box>
           {election?.electionType.anonymous && (
             <Box>


### PR DESCRIPTION
It was a silly problem but hard to find. The div that wrapped the actions button had position: absolute from the previous layout, which caused the menu to render off-screen until you opened it for the first time

closes #668 