### PR TITLE
Saas mail verification page

### DIFF
--- a/src/components/Auth/SignUp.tsx
+++ b/src/components/Auth/SignUp.tsx
@@ -10,13 +10,13 @@ import GoogleAuth from './GoogleAuth'
 import { HSeparator } from './SignIn'
 import { useState } from 'react'
 import { IRegisterParams } from '~components/Auth/authQueries'
+import { VerifyAccountNeeded } from '~components/Auth/Verify'
 
 type FormData = {
   terms: boolean
 } & IRegisterParams
 
 const SignUp = () => {
-  const navigate = useNavigate()
   const { t } = useTranslation()
   const { textColor, textColorSecondary, textColorBrand, googleBg, googleHover, googleActive } = useDarkMode()
   const {
@@ -35,7 +35,7 @@ const SignUp = () => {
   }
 
   if (isSuccess) {
-    return <AccountCreated email={email} />
+    return <VerifyAccountNeeded email={email} />
   }
 
   return (
@@ -130,40 +130,4 @@ const SignUp = () => {
     </Flex>
   )
 }
-
-const AccountCreated = ({ email }: { email: string }) => {
-  const { textColor, textColorSecondary, textColorBrand, googleBg, googleHover, googleActive } = useDarkMode()
-  const { t } = useTranslation()
-  if (import.meta.env.NODE_ENV === 'dev') {
-  }
-
-  return (
-    <Flex direction='column'>
-      <Box me='auto'>
-        <Heading color={textColor} fontSize='36px' mb='10px'>
-          {t('signup.account_created_succesfully', { defaultValue: 'Account created successfully!' })}
-        </Heading>
-        <Text mb='36px' ms='4px' color={textColorSecondary} fontWeight='400' fontSize='md'>
-          {t('signup.verification_email_is_sent', {
-            defaultValue: 'A verification email has been sent to:',
-          })}
-        </Text>
-        <Text mb='36px' ms='4px' color={textColorSecondary} fontWeight='bold' fontSize='md'>
-          {email}
-        </Text>
-        <Text mb='36px' ms='4px' color={textColorSecondary} fontWeight='400' fontSize='md'>
-          {t('signup.follow_email_instructions', {
-            defaultValue: 'Follow the instructions there to activate your account.',
-          })}
-        </Text>
-        {import.meta.env.VOCDONI_ENVIRONMENT === 'dev' && (
-          <Button as={ReactRouterLink} to={`/account/verify?email=${email}&code=`}>
-            Mail verification for dev envs
-          </Button>
-        )}
-      </Box>
-    </Flex>
-  )
-}
-
 export default SignUp

--- a/src/components/Auth/SignUp.tsx
+++ b/src/components/Auth/SignUp.tsx
@@ -8,6 +8,7 @@ import CustomCheckbox from '../Layout/CheckboxCustom'
 import InputCustom from '../Layout/InputCustom'
 import GoogleAuth from './GoogleAuth'
 import { HSeparator } from './SignIn'
+import { useState } from 'react'
 import { IRegisterParams } from '~components/Auth/authQueries'
 
 type FormData = {
@@ -23,10 +24,18 @@ const SignUp = () => {
   } = useAuth()
 
   const methods = useForm<FormData>()
-  const { handleSubmit } = methods
+  const { handleSubmit, watch } = methods
+  const email = watch('email')
+
+  // State to show signup is successful
+  const [isSuccess, setIsSuccess] = useState(false)
 
   const onSubmit = async (data: FormData) => {
-    await signup(data).then(() => navigate('/organization'))
+    await signup(data).then(() => setIsSuccess(true))
+  }
+
+  if (isSuccess) {
+    return <AccountCreated email={email} />
   }
 
   return (
@@ -88,7 +97,6 @@ const SignUp = () => {
             }
             required
           />
-
           <Button
             isLoading={isPending}
             type='submit'
@@ -118,6 +126,41 @@ const SignUp = () => {
         <FormControl isInvalid={isError}>
           {isError && <FormErrorMessage>{error?.message || 'Error al realizar la operación'}</FormErrorMessage>}
         </FormControl>
+      </Box>
+    </Flex>
+  )
+}
+
+const AccountCreated = ({ email }: { email: string }) => {
+  const { textColor, textColorSecondary, textColorBrand, googleBg, googleHover, googleActive } = useDarkMode()
+  const { t } = useTranslation()
+  if (import.meta.env.NODE_ENV === 'dev') {
+  }
+
+  return (
+    <Flex direction='column'>
+      <Box me='auto'>
+        <Heading color={textColor} fontSize='36px' mb='10px'>
+          {t('signup.account_created_succesfully', { defaultValue: 'Account created successfully!' })}
+        </Heading>
+        <Text mb='36px' ms='4px' color={textColorSecondary} fontWeight='400' fontSize='md'>
+          {t('signup.verification_email_is_sent', {
+            defaultValue: 'A verification email has been sent to:',
+          })}
+        </Text>
+        <Text mb='36px' ms='4px' color={textColorSecondary} fontWeight='bold' fontSize='md'>
+          {email}
+        </Text>
+        <Text mb='36px' ms='4px' color={textColorSecondary} fontWeight='400' fontSize='md'>
+          {t('signup.follow_email_instructions', {
+            defaultValue: 'Follow the instructions there to activate your account.',
+          })}
+        </Text>
+        {import.meta.env.VOCDONI_ENVIRONMENT === 'dev' && (
+          <Button as={ReactRouterLink} to={`/account/verify?email=${email}&code=`}>
+            Mail verification for dev envs
+          </Button>
+        )}
       </Box>
     </Flex>
   )

--- a/src/components/Auth/Verify.tsx
+++ b/src/components/Auth/Verify.tsx
@@ -1,0 +1,69 @@
+import { Box, Flex, FormControl, FormErrorMessage, Heading, Text } from '@chakra-ui/react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import useDarkMode from '~src/themes/saas/hooks/useDarkMode'
+import { useAuth } from '~components/Auth/useAuth'
+import { Loading } from '~src/router/SuspenseLoader'
+import { useEffect } from 'react'
+
+const Verify = () => {
+  const navigate = useNavigate()
+  const { t } = useTranslation()
+  const [searchParams] = useSearchParams()
+  const { textColor, textColorSecondary } = useDarkMode()
+  const {
+    mailVerify: { isIdle, isPending, isError: isMutationError, error, mutateAsync },
+  } = useAuth()
+
+  const email = searchParams.get('email')
+  const code = searchParams.get('code')
+  const isLoading = isIdle || isPending
+  const isError = !email || isMutationError || (import.meta.env.VOCDONI_ENVIRONMENT !== 'dev' && !code)
+
+  // Trigger email verification on component load
+  useEffect(() => {
+    mutateAsync({ email, code }).then(() => navigate('/organization'))
+  }, [])
+
+  let title = t('verify_mail.verifying_title', { email: email, defaultValue: 'Verifying {{ email }}' })
+  let subTitle = t('verify_mail.verifying_subtitle', {
+    defaultValue: 'Await until we verify your email address. You will be redirect on success.',
+  })
+  // dev enviorment permits empty code
+  if (isError) {
+    title = t('verify_mail.error_title', { email: email, defaultValue: 'Error verifying {{ email }}' })
+    subTitle = t('verify_mail.error_subtitle', {
+      defaultValue:
+        'We found an error verifying your email, please check verification mail to ensure all data is correct',
+    })
+  }
+
+  return (
+    <Flex direction='column'>
+      <Box me='auto'>
+        <Heading color={textColor} fontSize='36px' mb='10px'>
+          {title}
+        </Heading>
+        <Text mb='36px' ms='4px' color={textColorSecondary} fontWeight='400' fontSize='md'>
+          {subTitle}
+        </Text>
+      </Box>
+      {isLoading && !isError && (
+        <Box height={'100px'}>
+          <Loading minHeight={1} />
+        </Box>
+      )}
+      <Box>
+        <FormControl isInvalid={isError}>
+          {isError && (
+            <FormErrorMessage>
+              {error?.message || t('error.error_doing_things', { defaultValue: 'Error al realizar la operación' })}
+            </FormErrorMessage>
+          )}
+        </FormControl>
+      </Box>
+    </Flex>
+  )
+}
+
+export default Verify

--- a/src/components/Auth/Verify.tsx
+++ b/src/components/Auth/Verify.tsx
@@ -1,6 +1,6 @@
-import { Box, Flex, FormControl, FormErrorMessage, Heading, Text } from '@chakra-ui/react'
-import { useTranslation } from 'react-i18next'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { Box, Button, Flex, FormControl, FormErrorMessage, Heading, Text } from '@chakra-ui/react'
+import { useTranslation, Trans } from 'react-i18next'
+import { Link as ReactRouterLink, useNavigate, useSearchParams } from 'react-router-dom'
 import useDarkMode from '~src/themes/saas/hooks/useDarkMode'
 import { useAuth } from '~components/Auth/useAuth'
 import { Loading } from '~src/router/SuspenseLoader'
@@ -62,6 +62,42 @@ const Verify = () => {
           )}
         </FormControl>
       </Box>
+    </Flex>
+  )
+}
+
+export const VerifyAccountNeeded = ({ email }: { email: string }) => {
+  const { textColor, textColorSecondary } = useDarkMode()
+  const { t } = useTranslation()
+
+  return (
+    <Flex direction='column'>
+      <Box me='auto'>
+        <Heading color={textColor} fontSize='36px' mb='10px'>
+          {t('verify.account_created_succesfully', { defaultValue: 'Account created successfully!' })}
+        </Heading>
+        <Text mb='36px' ms='4px' color={textColorSecondary} fontWeight='400' fontSize='md'>
+          {t('verify.verification_email_is_sent', {
+            defaultValue: 'A verification email has been sent to:',
+          })}
+        </Text>
+        <Text mb='36px' ms='4px' color={textColorSecondary} fontWeight='bold' fontSize='md'>
+          {email}
+        </Text>
+        <Text mb='36px' ms='4px' color={textColorSecondary} fontWeight='400' fontSize='md'>
+          {t('verify.follow_email_instructions', {
+            defaultValue: 'Follow the instructions there to activate your account.',
+          })}
+        </Text>
+      </Box>
+      <Button>
+        <Trans i18nKey={'verify.resend_confirmation_mail'}>Resend Email</Trans>
+      </Button>
+      {import.meta.env.VOCDONI_ENVIRONMENT === 'dev' && (
+        <Button mt={4} as={ReactRouterLink} to={`/account/verify?email=${email}&code=`}>
+          Mail verification for dev envs
+        </Button>
+      )}
     </Flex>
   )
 }

--- a/src/components/Auth/api.ts
+++ b/src/components/Auth/api.ts
@@ -65,9 +65,9 @@ export const api = <T>(
           const sanitized = responseText.replace('\n', '')
           error = { error: sanitized.length ? sanitized : response.statusText }
         }
+        // Handle unauthorized error
         if (response.status === 401) {
-          // Handle unauthorized error
-          if (error.error === 'user not authorized: user not verified') {
+          if (error?.code === 40014) {
             throw new UnverifiedApiError(error, response)
           }
           throw new UnauthorizedApiError(error, response)

--- a/src/components/Auth/api.ts
+++ b/src/components/Auth/api.ts
@@ -5,6 +5,7 @@ export enum ApiEndpoints {
   REFRESH = 'auth/refresh',
   REGISTER = 'users',
   VERIFY = 'users/verify',
+  RESEND_VERIFICATION = 'users/verify/code',
   ACCOUNT_CREATE = 'organizations',
 }
 

--- a/src/components/Auth/api.ts
+++ b/src/components/Auth/api.ts
@@ -54,15 +54,14 @@ export const api = <T>(
     body: JSON.stringify(body),
   })
     .then(async (response) => {
-      const responseText = await response.text()
+      const sanitized = (await response.text()).replace('\n', '')
       // Parse error response
       if (!response.ok) {
         let error: IApiError
         try {
-          error = JSON.parse(responseText) as IApiError
+          error = JSON.parse(sanitized) as IApiError
         } catch (e) {
           // If parsing fails, use the raw text as the error message
-          const sanitized = responseText.replace('\n', '')
           error = { error: sanitized.length ? sanitized : response.statusText }
         }
         // Handle unauthorized error
@@ -75,7 +74,7 @@ export const api = <T>(
 
         throw new ApiError(error, response)
       }
-      return responseText ? (JSON.parse(responseText) as T) : undefined
+      return sanitized ? (JSON.parse(sanitized) as T) : undefined
     })
     .catch((error: Error) => {
       throw error

--- a/src/components/Auth/api.ts
+++ b/src/components/Auth/api.ts
@@ -75,11 +75,7 @@ export const api = <T>(
 
         throw new ApiError(error, response)
       }
-      // check if type T is void or undefined, return void
-      if ((undefined as T) === undefined) {
-        return
-      }
-      return JSON.parse(responseText) as T
+      return responseText ? (JSON.parse(responseText) as T) : undefined
     })
     .catch((error: Error) => {
       throw error

--- a/src/components/Auth/api.ts
+++ b/src/components/Auth/api.ts
@@ -3,6 +3,7 @@ type MethodTypes = 'GET' | 'POST' | 'PUT' | 'DELETE'
 export enum ApiEndpoints {
   LOGIN = 'auth/login',
   REFRESH = 'auth/refresh',
+  VERIFY = 'auth/verify',
   REGISTER = 'users',
   ACCOUNT_CREATE = 'organizations',
 }

--- a/src/components/Auth/authQueries.ts
+++ b/src/components/Auth/authQueries.ts
@@ -20,6 +20,10 @@ export interface IVerifyParams {
   code: string
 }
 
+export interface IResendVerificationParams {
+  email: string
+}
+
 export const useLogin = (options?: Omit<UseMutationOptions<LoginResponse, Error, ILoginParams>, 'mutationFn'>) => {
   return useMutation<LoginResponse, Error, ILoginParams>({
     mutationFn: (params: ILoginParams) => api<LoginResponse>(ApiEndpoints.LOGIN, { body: params, method: 'POST' }),
@@ -42,6 +46,16 @@ export const useVerifyMail = (
 ) => {
   return useMutation<LoginResponse, Error, IVerifyParams>({
     mutationFn: (params: IVerifyParams) => api<LoginResponse>(ApiEndpoints.VERIFY, { body: params, method: 'POST' }),
+    ...options,
+  })
+}
+
+export const useResendVerificationMail = (
+  options?: Omit<UseMutationOptions<void, Error, IResendVerificationParams>, 'mutationFn'>
+) => {
+  return useMutation<void, Error, IResendVerificationParams>({
+    mutationFn: (params: IResendVerificationParams) =>
+      api<void>(ApiEndpoints.RESEND_VERIFICATION, { body: params, method: 'POST' }),
     ...options,
   })
 }

--- a/src/components/Auth/authQueries.ts
+++ b/src/components/Auth/authQueries.ts
@@ -15,6 +15,11 @@ export interface IRegisterParams {
   password: string
 }
 
+export interface IVerifyParams {
+  email: string
+  code: string
+}
+
 export const useLogin = (options: Omit<UseMutationOptions<LoginResponse, Error, ILoginParams>, 'mutationFn'>) => {
   return useMutation<LoginResponse, Error, ILoginParams>({
     mutationFn: (params: ILoginParams) => api<LoginResponse>(ApiEndpoints.LOGIN, { body: params, method: 'POST' }),
@@ -26,6 +31,13 @@ export const useRegister = (options: Omit<UseMutationOptions<LoginResponse, Erro
   return useMutation<LoginResponse, Error, IRegisterParams>({
     mutationFn: (params: IRegisterParams) =>
       api<LoginResponse>(ApiEndpoints.REGISTER, { body: params, method: 'POST' }),
+    ...options,
+  })
+}
+
+export const useVerifyMail = (options: Omit<UseMutationOptions<LoginResponse, Error, IVerifyParams>, 'mutationFn'>) => {
+  return useMutation<LoginResponse, Error, IVerifyParams>({
+    mutationFn: (params: IVerifyParams) => api<LoginResponse>(ApiEndpoints.VERIFY, { body: params, method: 'POST' }),
     ...options,
   })
 }

--- a/src/components/Auth/authQueries.ts
+++ b/src/components/Auth/authQueries.ts
@@ -20,14 +20,16 @@ export interface IVerifyParams {
   code: string
 }
 
-export const useLogin = (options: Omit<UseMutationOptions<LoginResponse, Error, ILoginParams>, 'mutationFn'>) => {
+export const useLogin = (options?: Omit<UseMutationOptions<LoginResponse, Error, ILoginParams>, 'mutationFn'>) => {
   return useMutation<LoginResponse, Error, ILoginParams>({
     mutationFn: (params: ILoginParams) => api<LoginResponse>(ApiEndpoints.LOGIN, { body: params, method: 'POST' }),
     ...options,
   })
 }
 
-export const useRegister = (options: Omit<UseMutationOptions<LoginResponse, Error, IRegisterParams>, 'mutationFn'>) => {
+export const useRegister = (
+  options?: Omit<UseMutationOptions<LoginResponse, Error, IRegisterParams>, 'mutationFn'>
+) => {
   return useMutation<LoginResponse, Error, IRegisterParams>({
     mutationFn: (params: IRegisterParams) =>
       api<LoginResponse>(ApiEndpoints.REGISTER, { body: params, method: 'POST' }),
@@ -35,7 +37,9 @@ export const useRegister = (options: Omit<UseMutationOptions<LoginResponse, Erro
   })
 }
 
-export const useVerifyMail = (options: Omit<UseMutationOptions<LoginResponse, Error, IVerifyParams>, 'mutationFn'>) => {
+export const useVerifyMail = (
+  options?: Omit<UseMutationOptions<LoginResponse, Error, IVerifyParams>, 'mutationFn'>
+) => {
   return useMutation<LoginResponse, Error, IVerifyParams>({
     mutationFn: (params: IVerifyParams) => api<LoginResponse>(ApiEndpoints.VERIFY, { body: params, method: 'POST' }),
     ...options,

--- a/src/components/Auth/useAuthProvider.ts
+++ b/src/components/Auth/useAuthProvider.ts
@@ -2,7 +2,7 @@ import { useClient } from '@vocdoni/react-providers'
 import { RemoteSigner } from '@vocdoni/sdk'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { api, ApiEndpoints, ApiParams, UnauthorizedApiError } from '~components/Auth/api'
-import { LoginResponse, useLogin, useRegister } from '~components/Auth/authQueries'
+import { LoginResponse, useLogin, useRegister, useVerifyMail } from '~components/Auth/authQueries'
 
 enum LocalStorageKeys {
   AUTH_TOKEN = 'authToken',
@@ -17,6 +17,11 @@ export const useAuthProvider = () => {
     },
   })
   const register = useRegister({
+    onSuccess: (data, variables) => {
+      storeLogin(data)
+    },
+  })
+  const mailVerify = useVerifyMail({
     onSuccess: (data, variables) => {
       storeLogin(data)
     },
@@ -94,6 +99,7 @@ export const useAuthProvider = () => {
     isAuthenticated,
     login,
     register,
+    mailVerify,
     logout,
     bearedFetch,
     refresh,

--- a/src/components/Auth/useAuthProvider.ts
+++ b/src/components/Auth/useAuthProvider.ts
@@ -16,11 +16,7 @@ export const useAuthProvider = () => {
       storeLogin(data)
     },
   })
-  const register = useRegister({
-    onSuccess: (data, variables) => {
-      storeLogin(data)
-    },
-  })
+  const register = useRegister()
   const mailVerify = useVerifyMail({
     onSuccess: (data, variables) => {
       storeLogin(data)

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -34,6 +34,7 @@ const Terms = lazy(() => import('~components/TermsAndPrivacy/Terms'))
 const Privacy = lazy(() => import('~components/TermsAndPrivacy/Privacy'))
 const SignIn = lazy(() => import('~components/Auth/SignIn'))
 const SignUp = lazy(() => import('~components/Auth/SignUp'))
+const Verify = lazy(() => import('~components/Auth/Verify'))
 const ForgotPassword = lazy(() => import('~components/Auth/ForgotPassword'))
 const Calculator = lazy(() => import('~components/Calculator'))
 
@@ -185,10 +186,18 @@ export const RoutesProvider = () => {
                 ),
               },
               {
-                path: 'forgot-password',
+                path: 'account/recovery',
                 element: (
                   <SuspenseLoader>
                     <ForgotPassword />
+                  </SuspenseLoader>
+                ),
+              },
+              {
+                path: 'account/verify',
+                element: (
+                  <SuspenseLoader>
+                    <Verify />
                   </SuspenseLoader>
                 ),
               },

--- a/src/router/SuspenseLoader.tsx
+++ b/src/router/SuspenseLoader.tsx
@@ -1,12 +1,12 @@
-import { Spinner, Square, Text } from '@chakra-ui/react'
+import { Spinner, Square, SquareProps, Text } from '@chakra-ui/react'
 import { ReactNode, Suspense } from 'react'
 import { useTranslation } from 'react-i18next'
 
-export const Loading = () => {
+export const Loading = ({ ...rest }: SquareProps) => {
   const { t } = useTranslation()
 
   return (
-    <Square centerContent size='full' minHeight='100vh'>
+    <Square centerContent size='full' minHeight='100vh' {...rest}>
       <Spinner size='sm' mr={3} />
       <Text>{t('loading')}</Text>
     </Square>


### PR DESCRIPTION
Depends on https://github.com/vocdoni/saas-backend/pull/9/ and needs https://github.com/vocdoni/ui-scaffold/pull/765

It implements the email verification page. 

- On signup page, once signup is success it shows an "verification email sent" message with a "resend email button"
- On login page if the error of the backend is that the email is not verified, it shows the "verification email sent" message with a "resend email button"
- Implements the route `/account/verify?email=${email}&code=xxxxxxx`
- Performs an automatic verification attempt using a `useEffect`
- If success redirect to `/organization`
- Else show an error
- **Resend verification mail mutation is implemented but won't work until implemented on the backend**

In addition, it implements specific considerations for dev environments: 

- On signin page it shows a button to redirect to verify page without having verification code (because is not needed)
- It permits empty verification codes on verify page (on dev envs they are not neeeded)

An it fixes API function to:

- throw plain text errors