### PR TITLE
Improve auth state

### DIFF
--- a/src/components/Auth/useAuthProvider.ts
+++ b/src/components/Auth/useAuthProvider.ts
@@ -1,21 +1,52 @@
 import { useClient } from '@vocdoni/react-providers'
-import { RemoteSigner } from '@vocdoni/sdk'
+import { NoOrganizationsError, RemoteSigner } from '@vocdoni/sdk'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { api, ApiEndpoints, ApiParams, UnauthorizedApiError } from '~components/Auth/api'
 import { LoginResponse, useLogin, useRegister, useVerifyMail } from '~components/Auth/authQueries'
+import { useMutation } from '@tanstack/react-query'
 
 enum LocalStorageKeys {
   AUTH_TOKEN = 'authToken',
 }
 
-export const useAuthProvider = () => {
-  const { signer, setSigner, clear } = useClient()
-  const [bearer, setBearer] = useState<string | null>(localStorage.getItem(LocalStorageKeys.AUTH_TOKEN))
+/**
+ * Mutation to set the RemoteSigner and check its address
+ * This hook is used as state to determine if an address is associated to the Signer to redirect
+ * to create organization page if not.
+ */
+const useSigner = () => {
+  const { setSigner } = useClient()
 
-  // Helper state to determine if the bearer key is loaded and the signer address is available
-  const [loaded, setLoaded] = useState<boolean>(false)
-  // Helper state to determine the signer have an address available
-  const [signerAddress, setSignerAddress] = useState<string>('')
+  const updateSigner = useCallback(async (token: string) => {
+    let saasUrl = import.meta.env.SAAS_URL
+    // Ensure saas url doesn't end with `/` because the inner paths of the SDK are absolute
+    if (saasUrl.endsWith('/')) {
+      saasUrl = saasUrl.slice(0, -1)
+    }
+    const signer = new RemoteSigner({
+      url: saasUrl,
+      token,
+    })
+    setSigner(signer)
+    // Once the signer is set, try to get the signer address
+    // This is an asynchronous call because the address are fetched from the server,
+    // and we don't know if we need to create an organization until we try to retrieve the address
+    try {
+      return await signer.getAddress()
+    } catch (e) {
+      // If is NoOrganizationsError ignore the error
+      if (!(e instanceof NoOrganizationsError)) {
+        throw e
+      }
+    }
+  }, [])
+
+  return useMutation<string, Error, string>({ mutationFn: updateSigner })
+}
+
+export const useAuthProvider = () => {
+  const { signer: clientSigner, clear } = useClient()
+  const [bearer, setBearer] = useState<string | null>(localStorage.getItem(LocalStorageKeys.AUTH_TOKEN))
 
   const login = useLogin({
     onSuccess: (data, variables) => {
@@ -28,8 +59,7 @@ export const useAuthProvider = () => {
       storeLogin(data)
     },
   })
-
-  const isAuthenticated = useMemo(() => !!bearer, [bearer])
+  const { mutate: updateSigner, isIdle: signerIdle, isPending: signerPending, data: signerAddress } = useSigner()
 
   const bearedFetch = useCallback(
     <T>(path: ApiEndpoints, { headers = new Headers({}), ...params }: ApiParams) => {
@@ -57,20 +87,6 @@ export const useAuthProvider = () => {
     [bearer]
   )
 
-  const updateSigner = useCallback(async (token: string) => {
-    let saasUrl = import.meta.env.SAAS_URL
-    // Ensure saas url doesn't end with `/` because the inner paths of the SDK are absolute
-    if (saasUrl.endsWith('/')) {
-      saasUrl = saasUrl.slice(0, -1)
-    }
-    const signer = new RemoteSigner({
-      url: saasUrl,
-      token,
-    })
-    setSignerAddress(await signer.getAddress())
-    setSigner(signer)
-  }, [])
-
   const storeLogin = useCallback(({ token }: LoginResponse) => {
     localStorage.setItem(LocalStorageKeys.AUTH_TOKEN, token)
     setBearer(token)
@@ -83,23 +99,19 @@ export const useAuthProvider = () => {
     clear()
   }, [])
 
-  /**
-   * Reinstantate Remotesigner to perform updates on the client
-   */
-  const refresh = useCallback(() => {
-    updateSigner(bearer)
-  }, [bearer])
-
   // If no signer but berarer instantiate the signer
   // For example when bearer is on local storage but no login was done to instantiate the signer
   useEffect(() => {
-    ;(async () => {
-      if (bearer && !signer) {
-        await updateSigner(bearer)
-      }
-      setLoaded(true)
-    })()
-  }, [bearer, signer])
+    if (bearer && !clientSigner) {
+      updateSigner(bearer)
+    }
+  }, [bearer, clientSigner])
+
+  const isAuthenticated = useMemo(() => !!bearer, [bearer])
+  const isAuthLoading = useMemo(
+    () => (isAuthenticated && signerIdle) || (isAuthenticated && !signerIdle && signerPending),
+    [isAuthenticated, signerIdle, signerPending]
+  )
 
   return {
     isAuthenticated,
@@ -108,8 +120,7 @@ export const useAuthProvider = () => {
     mailVerify,
     logout,
     bearedFetch,
-    refresh,
-    loaded,
+    isAuthLoading,
     signerAddress,
   }
 }

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -10,7 +10,7 @@ import { StripeCheckout, StripeReturn } from '~elements/Stripe'
 import { default as ScaffoldOrganizationProtectedRoute } from './OrganizationProtectedRoute'
 
 import { SuspenseLoader } from './SuspenseLoader'
-import SaasOrganizationProtectedRoute from '~src/router/SaasOrganizationProtectedRoute'
+import SaasOrganizationProtectedRoute from './SaasOrganizationProtectedRoute'
 
 // Lazy loading helps splitting the final code, which helps downloading the app (theoretically)
 const ProtectedRoutes = lazy(() => import('./ProtectedRoutes'))

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -7,9 +7,10 @@ import Layout from '~elements/Layout'
 import LayoutAuth from '~elements/LayoutAuth'
 import LayoutProcessCreate from '~elements/LayoutProcessCreate'
 import { StripeCheckout, StripeReturn } from '~elements/Stripe'
-import OrganizationProtectedRoute from './OrganizationProtectedRoute'
+import { default as ScaffoldOrganizationProtectedRoute } from './OrganizationProtectedRoute'
 
 import { SuspenseLoader } from './SuspenseLoader'
+import SaasOrganizationProtectedRoute from '~src/router/SaasOrganizationProtectedRoute'
 
 // Lazy loading helps splitting the final code, which helps downloading the app (theoretically)
 const ProtectedRoutes = lazy(() => import('./ProtectedRoutes'))
@@ -43,6 +44,8 @@ export const RoutesProvider = () => {
 
   const domains = import.meta.env.CUSTOM_ORGANIZATION_DOMAINS
   const isSaas = !!import.meta.env.SAAS_URL
+
+  const OrganizationProtectedRoute = isSaas ? SaasOrganizationProtectedRoute : ScaffoldOrganizationProtectedRoute
 
   const mainLayoutRoutes: RouteObject[] = [
     {

--- a/src/router/SaasOrganizationProtectedRoute.tsx
+++ b/src/router/SaasOrganizationProtectedRoute.tsx
@@ -5,6 +5,7 @@ import { useAccountHealthTools } from '~components/Account/use-account-health-to
 import { useAuth } from '~components/Auth/useAuth'
 import CreateOrganizationSaas from '~components/OrganizationSaas/Dashboard/Create'
 import SignInScreen from './SignInScreen'
+import { Loading } from '~src/router/SuspenseLoader'
 
 const SaasOrganizationProtectedRoute = () => {
   const {
@@ -16,12 +17,7 @@ const SaasOrganizationProtectedRoute = () => {
   const { isAuthenticated, isAuthLoading, signerAddress } = useAuth()
 
   if ((!fetchLoaded && fetchLoading) || isAuthLoading) {
-    return (
-      <Flex mt={10} justifyContent='center'>
-        todo: use spinner loading page
-        <Spinner />
-      </Flex>
-    )
+    return <Loading />
   }
 
   if (!isAuthenticated) {

--- a/src/router/SaasOrganizationProtectedRoute.tsx
+++ b/src/router/SaasOrganizationProtectedRoute.tsx
@@ -2,18 +2,20 @@ import { Flex, Spinner } from '@chakra-ui/react'
 import { useClient } from '@vocdoni/react-providers'
 import { Outlet } from 'react-router-dom'
 import { useAccountHealthTools } from '~components/Account/use-account-health-tools'
+import { useAuth } from '~components/Auth/useAuth'
 import CreateOrganization from '~components/Organization/Dashboard/Create'
+import CreateOrganizationSaas from '~components/OrganizationSaas/Dashboard/Create'
 import SignInScreen from './SignInScreen'
 
-const OrganizationProtectedRoute = () => {
+const SaasOrganizationProtectedRoute = () => {
   const {
-    connected,
     loaded: { fetch: fetchLoaded },
     loading: { fetch: fetchLoading },
   } = useClient()
   const { exists } = useAccountHealthTools()
+  const { isAuthenticated, loaded, signerAddress } = useAuth()
 
-  if (!fetchLoaded && fetchLoading) {
+  if ((!fetchLoaded && fetchLoading) || !loaded) {
     return (
       <Flex mt={10} justifyContent='center'>
         <Spinner />
@@ -21,15 +23,15 @@ const OrganizationProtectedRoute = () => {
     )
   }
 
-  if (!connected) {
+  if (!isAuthenticated) {
     return <SignInScreen />
   }
 
-  if (!exists) {
-    return <CreateOrganization />
+  if (!exists && !signerAddress) {
+    return <CreateOrganizationSaas />
   }
 
   return <Outlet />
 }
 
-export default OrganizationProtectedRoute
+export default SaasOrganizationProtectedRoute

--- a/src/router/SaasOrganizationProtectedRoute.tsx
+++ b/src/router/SaasOrganizationProtectedRoute.tsx
@@ -3,21 +3,22 @@ import { useClient } from '@vocdoni/react-providers'
 import { Outlet } from 'react-router-dom'
 import { useAccountHealthTools } from '~components/Account/use-account-health-tools'
 import { useAuth } from '~components/Auth/useAuth'
-import CreateOrganization from '~components/Organization/Dashboard/Create'
 import CreateOrganizationSaas from '~components/OrganizationSaas/Dashboard/Create'
 import SignInScreen from './SignInScreen'
 
 const SaasOrganizationProtectedRoute = () => {
   const {
-    loaded: { fetch: fetchLoaded },
-    loading: { fetch: fetchLoading },
+    loaded: { account: fetchLoaded },
+    loading: { account: fetchLoading },
   } = useClient()
   const { exists } = useAccountHealthTools()
-  const { isAuthenticated, loaded, signerAddress } = useAuth()
 
-  if ((!fetchLoaded && fetchLoading) || !loaded) {
+  const { isAuthenticated, isAuthLoading, signerAddress } = useAuth()
+
+  if ((!fetchLoaded && fetchLoading) || isAuthLoading) {
     return (
       <Flex mt={10} justifyContent='center'>
+        todo: use spinner loading page
         <Spinner />
       </Flex>
     )

--- a/src/router/SignInScreen.tsx
+++ b/src/router/SignInScreen.tsx
@@ -3,6 +3,7 @@ import { useConnectModal } from '@rainbow-me/rainbowkit'
 import { Trans } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { useEffect } from 'react'
+import { Loading } from '~src/router/SuspenseLoader'
 
 const SignInScreen = () => {
   const { openConnectModal } = useConnectModal()
@@ -10,10 +11,13 @@ const SignInScreen = () => {
 
   // Redirect to the SAAS sign-in page
   useEffect(() => {
-    if (!!import.meta.env.SAAS_URL) {
+    if (import.meta.env.SAAS_URL) {
       navigate('/signin')
     }
-  }, [navigate])
+  }, [])
+  if (import.meta.env.SAAS_URL) {
+    return <Loading />
+  }
 
   return (
     <Flex gap={4} justifyContent='center' alignItems='center' flexDirection='column' h='100%'>


### PR DESCRIPTION
## Motivation

RemoteSigner class has a little difference with the normal Signer that is that `getAddress` function is asynchronous. 

This provoked some errors when accessing protected routes causing a blink show of Create Organization view on an "already logged in  with organization account".

To fix this I created an inner auth state to check if the RemoteSigner is loaded and has an address associated to it.

## Whats done

Add necessary authentication states on the provider to fix blinking page bugs when login in 

- Implements specific `SaasOrganizationProtectedRoute` to do not mix logics with the old scaffol `OrganizationProtectedRoute`
- Implements needed inner auth provider based on the signer state to properly redirect to create organization page. I used a Mutation to take advantage of the states that react query implements for this cases