### PR TITLE
refactor: improve auth token refresh logic

### DIFF
--- a/src/components/Auth/authQueries.ts
+++ b/src/components/Auth/authQueries.ts
@@ -6,7 +6,6 @@ export type LoginResponse = { token: string; expirity: string }
 export interface ILoginParams {
   email: string
   password: string
-  keepMeLoggedIn?: boolean
 }
 
 export interface IRegisterParams {

--- a/src/components/Auth/authQueries.ts
+++ b/src/components/Auth/authQueries.ts
@@ -6,6 +6,7 @@ export type LoginResponse = { token: string; expirity: string }
 export interface ILoginParams {
   email: string
   password: string
+  keepMeLoggedIn?: boolean
 }
 
 export interface IRegisterParams {

--- a/src/components/Auth/useAuthProvider.ts
+++ b/src/components/Auth/useAuthProvider.ts
@@ -10,11 +10,11 @@ import { LoginResponse, useLogin, useRegister, useVerifyMail } from '~components
 enum LocalStorageKeys {
   Token = 'authToken',
   Expiry = 'authExpiry',
-  KeepLoggedIn = 'authKeepLoggedIn',
+  RenewSession = 'authRenewSession',
 }
 
 // One week in milliseconds
-const ONE_WEEK = 7 * 24 * 60 * 60 * 1000
+const OneWeek = 7 * 24 * 60 * 60 * 1000
 
 /**
  * Mutation to set the RemoteSigner and check its address
@@ -74,11 +74,11 @@ export const useAuthProvider = () => {
     [bearer]
   )
 
-  const storeLogin = useCallback(({ token, expirity }: LoginResponse, keepMeLoggedIn = false) => {
+  const storeLogin = useCallback(({ token, expirity }: LoginResponse, renewSession = false) => {
     localStorage.setItem(LocalStorageKeys.Token, token)
     localStorage.setItem(LocalStorageKeys.Expiry, expirity)
-    if (keepMeLoggedIn) {
-      localStorage.setItem(LocalStorageKeys.KeepLoggedIn, 'true')
+    if (renewSession) {
+      localStorage.setItem(LocalStorageKeys.RenewSession, 'true')
     }
     setBearer(token)
     updateSigner(token)
@@ -87,7 +87,7 @@ export const useAuthProvider = () => {
   const logout = useCallback(() => {
     localStorage.removeItem(LocalStorageKeys.Token)
     localStorage.removeItem(LocalStorageKeys.Expiry)
-    localStorage.removeItem(LocalStorageKeys.KeepLoggedIn)
+    localStorage.removeItem(LocalStorageKeys.RenewSession)
     setBearer(null)
     clear()
   }, [])
@@ -114,9 +114,9 @@ export const useAuthProvider = () => {
     if (!bearer) return
 
     const expiry = localStorage.getItem(LocalStorageKeys.Expiry)
-    const keepLoggedIn = localStorage.getItem(LocalStorageKeys.KeepLoggedIn)
+    const renewSession = localStorage.getItem(LocalStorageKeys.RenewSession)
 
-    if (!expiry || !keepLoggedIn) return
+    if (!expiry || !renewSession) return
 
     const expiryDate = new Date(expiry)
     const now = new Date()
@@ -129,13 +129,13 @@ export const useAuthProvider = () => {
     }
 
     // If token expires in less than a week, refresh it
-    if (timeUntilExpiry <= ONE_WEEK) {
+    if (timeUntilExpiry <= OneWeek) {
       refreshToken()
     } else {
       // Set up refresh timer for one week before expiry
       const refreshTimeout = setTimeout(() => {
         refreshToken()
-      }, timeUntilExpiry - ONE_WEEK)
+      }, timeUntilExpiry - OneWeek)
 
       return () => clearTimeout(refreshTimeout)
     }

--- a/src/components/Auth/useAuthProvider.ts
+++ b/src/components/Auth/useAuthProvider.ts
@@ -4,12 +4,17 @@ import { useClient } from '@vocdoni/react-providers'
 import { NoOrganizationsError, RemoteSigner } from '@vocdoni/sdk'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, ApiEndpoints, ApiParams, UnauthorizedApiError } from '~components/Auth/api'
+import { api, ApiEndpoints, ApiParams } from '~components/Auth/api'
 import { LoginResponse, useLogin, useRegister, useVerifyMail } from '~components/Auth/authQueries'
 
 enum LocalStorageKeys {
   Token = 'authToken',
+  Expiry = 'authExpiry',
+  KeepLoggedIn = 'authKeepLoggedIn',
 }
+
+// One week in milliseconds
+const ONE_WEEK = 7 * 24 * 60 * 60 * 1000
 
 /**
  * Mutation to set the RemoteSigner and check its address
@@ -64,43 +69,77 @@ export const useAuthProvider = () => {
       if (bearer) {
         headers.append('Authorization', `Bearer ${bearer}`)
       }
-      return api<T>(path, { headers, ...params }).catch((e) => {
-        if (e instanceof UnauthorizedApiError) {
-          return api<LoginResponse>(ApiEndpoints.Refresh, { headers, method: 'POST' })
-            .then((data) => {
-              storeLogin(data)
-              headers.set('Authorization', `Bearer ${data.token}`)
-              return api<T>(path, { headers, ...params })
-            })
-            .catch((e) => {
-              toast({
-                status: 'error',
-                title: t('session_expired', { defaultValue: 'Session expired' }),
-                description: t('session_expired_description', {
-                  defaultValue: 'Session may have been expired and it could not be refreshed, please login again',
-                }),
-              })
-              logout()
-              throw e
-            })
-        }
-        throw e
-      })
+      return api<T>(path, { headers, ...params })
     },
     [bearer]
   )
 
-  const storeLogin = useCallback(({ token }: LoginResponse) => {
+  const storeLogin = useCallback(({ token, expirity }: LoginResponse, keepMeLoggedIn = false) => {
     localStorage.setItem(LocalStorageKeys.Token, token)
+    localStorage.setItem(LocalStorageKeys.Expiry, expirity)
+    if (keepMeLoggedIn) {
+      localStorage.setItem(LocalStorageKeys.KeepLoggedIn, 'true')
+    }
     setBearer(token)
     updateSigner(token)
   }, [])
 
   const logout = useCallback(() => {
     localStorage.removeItem(LocalStorageKeys.Token)
+    localStorage.removeItem(LocalStorageKeys.Expiry)
+    localStorage.removeItem(LocalStorageKeys.KeepLoggedIn)
     setBearer(null)
     clear()
   }, [])
+
+  const refreshToken = useCallback(async () => {
+    try {
+      const response = await api<LoginResponse>(ApiEndpoints.Refresh, { method: 'POST' })
+      storeLogin(response)
+    } catch (e) {
+      toast({
+        status: 'error',
+        title: t('session_expired', { defaultValue: 'Session expired' }),
+        description: t('session_expired_description', {
+          defaultValue: 'Session may have been expired and it could not be refreshed, please login again',
+        }),
+      })
+      logout()
+      throw e
+    }
+  }, [])
+
+  // Handle token refresh
+  useEffect(() => {
+    if (!bearer) return
+
+    const expiry = localStorage.getItem(LocalStorageKeys.Expiry)
+    const keepLoggedIn = localStorage.getItem(LocalStorageKeys.KeepLoggedIn)
+
+    if (!expiry || !keepLoggedIn) return
+
+    const expiryDate = new Date(expiry)
+    const now = new Date()
+    const timeUntilExpiry = expiryDate.getTime() - now.getTime()
+
+    // If token is expired, logout
+    if (timeUntilExpiry <= 0) {
+      logout()
+      return
+    }
+
+    // If token expires in less than a week, refresh it
+    if (timeUntilExpiry <= ONE_WEEK) {
+      refreshToken()
+    } else {
+      // Set up refresh timer for one week before expiry
+      const refreshTimeout = setTimeout(() => {
+        refreshToken()
+      }, timeUntilExpiry - ONE_WEEK)
+
+      return () => clearTimeout(refreshTimeout)
+    }
+  }, [bearer])
 
   const signerRefresh = useCallback(() => {
     if (bearer) {


### PR DESCRIPTION
- Add proper token refresh logic based on expiry time
- Remove refresh logic from bearedFetch
- Store token expiry and keepMeLoggedIn in localStorage
- Add automatic token refresh one week before expiry