### PR TITLE
Multiple organization support

### DIFF
--- a/src/components/Account/Teams.tsx
+++ b/src/components/Account/Teams.tsx
@@ -1,6 +1,6 @@
 import { Avatar, Badge, Box, HStack, VStack } from '@chakra-ui/react'
 import { OrganizationName } from '@vocdoni/chakra-components'
-import { OrganizationProvider } from '@vocdoni/react-providers'
+import { OrganizationProvider, useOrganization } from '@vocdoni/react-providers'
 import { NoOrganizations } from '~components/Organization/NoOrganizations'
 import { UserRole } from '~src/queries/account'
 
@@ -11,29 +11,37 @@ const Teams = ({ roles }: { roles: UserRole[] }) => {
     <VStack spacing={4} align='stretch'>
       {roles.map((role) => (
         <OrganizationProvider key={role.organization.address} id={role.organization.address}>
-          <Box
-            p={4}
-            borderWidth='1px'
-            borderRadius='lg'
-            _hover={{ bg: 'gray.50', _dark: { bg: 'gray.700' } }}
-            transition='background 0.2s'
-          >
-            <HStack spacing={4}>
-              <Avatar size='md' src={role.organization.logo} name={role.organization.name} />
-              <Box flex='1'>
-                <OrganizationName fontWeight='medium' />
-                <Badge
-                  colorScheme={role.role === 'admin' ? 'purple' : role.role === 'owner' ? 'green' : 'blue'}
-                  fontSize='sm'
-                >
-                  {role.role}
-                </Badge>
-              </Box>
-            </HStack>
-          </Box>
+          <Team role={role} />
         </OrganizationProvider>
       ))}
     </VStack>
+  )
+}
+
+export const Team = ({ role }: { role: UserRole }) => {
+  const { organization } = useOrganization()
+
+  return (
+    <Box
+      p={4}
+      borderWidth='1px'
+      borderRadius='lg'
+      _hover={{ bg: 'gray.50', _dark: { bg: 'gray.700' } }}
+      transition='background 0.2s'
+    >
+      <HStack spacing={4}>
+        <Avatar size='md' src={role.organization.logo} name={organization?.account.name.default} />
+        <Box flex='1'>
+          <OrganizationName fontWeight='medium' />
+          <Badge
+            colorScheme={role.role === 'admin' ? 'purple' : role.role === 'owner' ? 'green' : 'blue'}
+            fontSize='sm'
+          >
+            {role.role}
+          </Badge>
+        </Box>
+      </HStack>
+    </Box>
   )
 }
 

--- a/src/components/Dashboard/Menu/Options.tsx
+++ b/src/components/Dashboard/Menu/Options.tsx
@@ -1,10 +1,15 @@
 import { Box, Collapse } from '@chakra-ui/react'
 import { OrganizationName } from '@vocdoni/chakra-components'
-import { useEffect, useState } from 'react'
+import { Select } from 'chakra-react-select'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { HiSquares2X2 } from 'react-icons/hi2'
 import { IoIosSettings } from 'react-icons/io'
 import { generatePath, matchPath, useLocation } from 'react-router-dom'
+import { useQueryClient } from 'wagmi'
+import { useAuth } from '~components/Auth/useAuth'
+import { LocalStorageKeys } from '~components/Auth/useAuthProvider'
+import { Organization, useProfile } from '~src/queries/account'
 import { Routes } from '~src/router/routes'
 import { DashboardMenuItem } from './Item'
 
@@ -19,6 +24,44 @@ export const DashboardMenuOptions = () => {
   const { t } = useTranslation()
   const location = useLocation()
   const [openSection, setOpenSection] = useState<string | null>(null)
+  const { data: profile } = useProfile()
+  const [selectedOrg, setSelectedOrg] = useState<string | null>(localStorage.getItem(LocalStorageKeys.SignerAddress))
+  const { signerRefresh } = useAuth()
+  const client = useQueryClient()
+
+  const organizations = useMemo(() => {
+    if (!profile?.organizations) return []
+    return profile.organizations.map((org) => ({
+      value: org.organization.address,
+      label: org.organization.address,
+      organization: org.organization,
+    }))
+  }, [profile])
+
+  // Set first organization as default if none selected
+  useEffect(() => {
+    if (organizations.length && !selectedOrg) {
+      const firstOrgAddress = organizations[0].value
+      setSelectedOrg(firstOrgAddress)
+      localStorage.setItem(LocalStorageKeys.SignerAddress, firstOrgAddress)
+    }
+  }, [organizations, selectedOrg])
+
+  type SelectOption = {
+    value: string
+    label: string
+    organization: Organization
+  }
+
+  const handleOrgChange = async (option: SelectOption | null) => {
+    if (!option) return
+    setSelectedOrg(option.value)
+    localStorage.setItem(LocalStorageKeys.SignerAddress, option.value)
+    // clear all query client query cache
+    client.clear()
+    // refresh signer
+    await signerRefresh()
+  }
 
   const menuItems: MenuItem[] = [
     // {
@@ -82,7 +125,24 @@ export const DashboardMenuOptions = () => {
 
   return (
     <Box>
-      <OrganizationName mb={2} px={3.5} />
+      {organizations.length > 1 ? (
+        <Box mb={2} px={3.5}>
+          <Select
+            value={organizations.find((org) => org.value === selectedOrg)}
+            onChange={handleOrgChange}
+            options={organizations}
+            size='sm'
+            chakraStyles={{
+              container: (provided) => ({
+                ...provided,
+                width: '100%',
+              }),
+            }}
+          />
+        </Box>
+      ) : (
+        <OrganizationName mb={2} px={3.5} />
+      )}
 
       {menuItems.map((item, index) => (
         <Box key={index}>

--- a/src/components/Dashboard/Menu/Options.tsx
+++ b/src/components/Dashboard/Menu/Options.tsx
@@ -1,17 +1,12 @@
 import { Box, Collapse } from '@chakra-ui/react'
-import { OrganizationName } from '@vocdoni/chakra-components'
-import { Select } from 'chakra-react-select'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { HiSquares2X2 } from 'react-icons/hi2'
 import { IoIosSettings } from 'react-icons/io'
 import { generatePath, matchPath, useLocation } from 'react-router-dom'
-import { useQueryClient } from 'wagmi'
-import { useAuth } from '~components/Auth/useAuth'
-import { LocalStorageKeys } from '~components/Auth/useAuthProvider'
-import { Organization, useProfile } from '~src/queries/account'
 import { Routes } from '~src/router/routes'
 import { DashboardMenuItem } from './Item'
+import { OrganizationSwitcher } from './OrganizationSwitcher'
 
 type MenuItem = {
   label: string
@@ -24,45 +19,6 @@ export const DashboardMenuOptions = () => {
   const { t } = useTranslation()
   const location = useLocation()
   const [openSection, setOpenSection] = useState<string | null>(null)
-  const { data: profile } = useProfile()
-  const [selectedOrg, setSelectedOrg] = useState<string | null>(localStorage.getItem(LocalStorageKeys.SignerAddress))
-  const { signerRefresh } = useAuth()
-  const client = useQueryClient()
-
-  const organizations = useMemo(() => {
-    if (!profile?.organizations) return []
-    return profile.organizations.map((org) => ({
-      value: org.organization.address,
-      label: org.organization.address,
-      organization: org.organization,
-    }))
-  }, [profile])
-
-  // Set first organization as default if none selected
-  useEffect(() => {
-    if (organizations.length && !selectedOrg) {
-      const firstOrgAddress = organizations[0].value
-      setSelectedOrg(firstOrgAddress)
-      localStorage.setItem(LocalStorageKeys.SignerAddress, firstOrgAddress)
-    }
-  }, [organizations, selectedOrg])
-
-  type SelectOption = {
-    value: string
-    label: string
-    organization: Organization
-  }
-
-  const handleOrgChange = async (option: SelectOption | null) => {
-    if (!option) return
-    setSelectedOrg(option.value)
-    localStorage.setItem(LocalStorageKeys.SignerAddress, option.value)
-    // clear all query client query cache
-    client.clear()
-    // refresh signer
-    await signerRefresh()
-  }
-
   const menuItems: MenuItem[] = [
     // {
     //   label: t('organization.dashboard'),
@@ -125,24 +81,7 @@ export const DashboardMenuOptions = () => {
 
   return (
     <Box>
-      {organizations.length > 1 ? (
-        <Box mb={2} px={3.5}>
-          <Select
-            value={organizations.find((org) => org.value === selectedOrg)}
-            onChange={handleOrgChange}
-            options={organizations}
-            size='sm'
-            chakraStyles={{
-              container: (provided) => ({
-                ...provided,
-                width: '100%',
-              }),
-            }}
-          />
-        </Box>
-      ) : (
-        <OrganizationName mb={2} px={3.5} />
-      )}
+      <OrganizationSwitcher />
 
       {menuItems.map((item, index) => (
         <Box key={index}>

--- a/src/components/Dashboard/Menu/OrganizationSwitcher.tsx
+++ b/src/components/Dashboard/Menu/OrganizationSwitcher.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@chakra-ui/react'
 import { OrganizationName } from '@vocdoni/chakra-components'
+import { OrganizationProvider, useOrganization } from '@vocdoni/react-providers'
 import { Select } from 'chakra-react-select'
 import { useEffect, useMemo, useState } from 'react'
 import { useQueryClient } from 'wagmi'
@@ -7,9 +8,14 @@ import { useAuth } from '~components/Auth/useAuth'
 import { LocalStorageKeys } from '~components/Auth/useAuthProvider'
 import { Organization, useProfile } from '~src/queries/account'
 
+const OrganizationOption = ({ organization }: { organization: Organization }) => {
+  const { organization: orgData } = useOrganization()
+  return <Box>{orgData?.account?.name?.default || organization.address}</Box>
+}
+
 type SelectOption = {
   value: string
-  label: string
+  label: JSX.Element
   organization: Organization
 }
 
@@ -23,7 +29,11 @@ export const OrganizationSwitcher = () => {
     if (!profile?.organizations) return []
     return profile.organizations.map((org) => ({
       value: org.organization.address,
-      label: org.organization.address,
+      label: (
+        <OrganizationProvider id={org.organization.address}>
+          <OrganizationOption organization={org.organization} />
+        </OrganizationProvider>
+      ),
       organization: org.organization,
     }))
   }, [profile])

--- a/src/components/Dashboard/Menu/OrganizationSwitcher.tsx
+++ b/src/components/Dashboard/Menu/OrganizationSwitcher.tsx
@@ -1,0 +1,68 @@
+import { Box } from '@chakra-ui/react'
+import { OrganizationName } from '@vocdoni/chakra-components'
+import { Select } from 'chakra-react-select'
+import { useEffect, useMemo, useState } from 'react'
+import { useQueryClient } from 'wagmi'
+import { useAuth } from '~components/Auth/useAuth'
+import { LocalStorageKeys } from '~components/Auth/useAuthProvider'
+import { Organization, useProfile } from '~src/queries/account'
+
+type SelectOption = {
+  value: string
+  label: string
+  organization: Organization
+}
+
+export const OrganizationSwitcher = () => {
+  const { data: profile } = useProfile()
+  const [selectedOrg, setSelectedOrg] = useState<string | null>(localStorage.getItem(LocalStorageKeys.SignerAddress))
+  const { signerRefresh } = useAuth()
+  const client = useQueryClient()
+
+  const organizations = useMemo(() => {
+    if (!profile?.organizations) return []
+    return profile.organizations.map((org) => ({
+      value: org.organization.address,
+      label: org.organization.address,
+      organization: org.organization,
+    }))
+  }, [profile])
+
+  // Set first organization as default if none selected
+  useEffect(() => {
+    if (organizations.length && !selectedOrg) {
+      const firstOrgAddress = organizations[0].value
+      setSelectedOrg(firstOrgAddress)
+      localStorage.setItem(LocalStorageKeys.SignerAddress, firstOrgAddress)
+    }
+  }, [organizations, selectedOrg])
+
+  const handleOrgChange = async (option: SelectOption | null) => {
+    if (!option) return
+    setSelectedOrg(option.value)
+    localStorage.setItem(LocalStorageKeys.SignerAddress, option.value)
+    // clear all query client query cache
+    client.clear()
+    // refresh signer
+    await signerRefresh()
+  }
+
+  return organizations.length > 1 ? (
+    <Box mb={2} px={3.5}>
+      <Select
+        value={organizations.find((org) => org.value === selectedOrg)}
+        onChange={handleOrgChange}
+        options={organizations}
+        size='sm'
+        chakraStyles={{
+          container: (provided) => ({
+            ...provided,
+            width: '100%',
+          }),
+        }}
+      />
+    </Box>
+  ) : (
+    <OrganizationName mb={2} px={3.5} />
+  )
+}

--- a/src/components/Dashboard/Menu/OrganizationSwitcher.tsx
+++ b/src/components/Dashboard/Menu/OrganizationSwitcher.tsx
@@ -1,12 +1,16 @@
-import { Box } from '@chakra-ui/react'
+import { Box, IconButton } from '@chakra-ui/react'
+import { PlusSquare } from '@untitled-ui/icons-react'
 import { OrganizationName } from '@vocdoni/chakra-components'
 import { useClient } from '@vocdoni/react-providers'
 import { Select } from 'chakra-react-select'
 import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
 import { useQueryClient } from 'wagmi'
 import { useAuth } from '~components/Auth/useAuth'
 import { LocalStorageKeys } from '~components/Auth/useAuthProvider'
 import { Organization, useProfile } from '~src/queries/account'
+import { Routes } from '~src/router/routes'
 
 type SelectOption = {
   value: string
@@ -15,6 +19,7 @@ type SelectOption = {
 }
 
 export const OrganizationSwitcher = () => {
+  const { t } = useTranslation()
   const { data: profile } = useProfile()
   const [selectedOrg, setSelectedOrg] = useState<string | null>(localStorage.getItem(LocalStorageKeys.SignerAddress))
   const [names, setNames] = useState<Record<string, string>>({})
@@ -73,22 +78,33 @@ export const OrganizationSwitcher = () => {
     await signerRefresh()
   }
 
-  return organizations.length > 1 ? (
-    <Box mb={2} px={3.5}>
-      <Select
-        value={organizations.find((org) => org.value === selectedOrg)}
-        onChange={handleOrgChange}
-        options={organizations}
-        size='sm'
-        chakraStyles={{
-          container: (provided) => ({
-            ...provided,
-            width: '100%',
-          }),
-        }}
+  return (
+    <Box mb={2} px={3.5} display='flex' alignItems='center' gap={2} justifyContent='space-between'>
+      {organizations.length > 1 ? (
+        <Select
+          value={organizations.find((org) => org.value === selectedOrg)}
+          onChange={handleOrgChange}
+          options={organizations}
+          size='sm'
+          chakraStyles={{
+            container: (provided) => ({
+              ...provided,
+              width: '100%',
+            }),
+          }}
+        />
+      ) : (
+        <OrganizationName mb={2} px={3.5} />
+      )}
+      <IconButton
+        size='xs'
+        as={Link}
+        variant='solid'
+        colorScheme='gray'
+        aria-label={t('create_org.title')}
+        icon={<PlusSquare />}
+        to={Routes.dashboard.organizationCreate}
       />
     </Box>
-  ) : (
-    <OrganizationName mb={2} px={3.5} />
   )
 }

--- a/src/components/Layout/ColorModeSwitcher.tsx
+++ b/src/components/Layout/ColorModeSwitcher.tsx
@@ -35,7 +35,7 @@ export const DropdownColorModeSwitcher = (props) => {
   return (
     <MenuItem onClick={toggleColorMode} closeOnSelect={true} {...props}>
       <Icon as={SwitchIcon} />
-      <Trans i18nKey={isLightMode ? 'dark_mode' : 'light_mode'}>Light mode</Trans>
+      {!isLightMode ? <Trans i18nKey='light_mode'>Light mode</Trans> : <Trans i18nKey='dark_mode'>Dark mode</Trans>}
     </MenuItem>
   )
 }

--- a/src/components/Organization/Edit.tsx
+++ b/src/components/Organization/Edit.tsx
@@ -77,13 +77,7 @@ const EditOrganization = () => {
   } = useClient()
   const { organization } = useSaasAccount()
 
-  const {
-    mutateAsync,
-    isPending: isSaasPending,
-    isError: isSaasError,
-    error: saasError,
-    isSuccess,
-  } = useOrganizationEdit()
+  const { mutateAsync, isError: isSaasError, error: saasError, isSuccess } = useOrganizationEdit()
 
   const methods = useForm<FormData>({
     defaultValues: {

--- a/src/elements/dashboard/organization/create.tsx
+++ b/src/elements/dashboard/organization/create.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useOutletContext } from 'react-router-dom'
+import { To, useOutletContext } from 'react-router-dom'
 import { DashboardContents } from '~components/Layout/Dashboard'
 import { OrganizationCreate } from '~components/Organization/Create'
 import { DashboardLayoutContext } from '~elements/LayoutDashboard'
+import { Routes } from '~src/router/routes'
 
 const DashBoardCreateOrg = () => {
   const { t } = useTranslation()
-  const [onSuccessRoute, setOnSuccessRoute] = useState<number>(null)
+  const [onSuccessRoute, setOnSuccessRoute] = useState<To>(Routes.dashboard.base)
   const { setTitle } = useOutletContext<DashboardLayoutContext>()
 
   // Set layout title and subtitle and back button
@@ -15,7 +16,7 @@ const DashBoardCreateOrg = () => {
     setTitle(t('create_org.title', { defaultValue: 'Organization' }))
 
     if (window.history.state.idx) {
-      setOnSuccessRoute(-1)
+      setOnSuccessRoute(-1 as unknown)
     }
   }, [])
 

--- a/src/elements/dashboard/organization/create.tsx
+++ b/src/elements/dashboard/organization/create.tsx
@@ -1,26 +1,19 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate, useOutletContext } from 'react-router-dom'
-import { useAccountHealthTools } from '~components/Account/use-account-health-tools'
+import { useOutletContext } from 'react-router-dom'
 import { DashboardContents } from '~components/Layout/Dashboard'
 import { OrganizationCreate } from '~components/Organization/Create'
 import { DashboardLayoutContext } from '~elements/LayoutDashboard'
-import { Routes } from '~src/router/routes'
 
 const DashBoardCreateOrg = () => {
   const { t } = useTranslation()
   const [onSuccessRoute, setOnSuccessRoute] = useState<number>(null)
   const { setTitle } = useOutletContext<DashboardLayoutContext>()
-  const { exists } = useAccountHealthTools()
-  const navigate = useNavigate()
 
   // Set layout title and subtitle and back button
   useEffect(() => {
     setTitle(t('create_org.title', { defaultValue: 'Organization' }))
-    // redirect to profile if organization already exists
-    if (exists) {
-      navigate(Routes.dashboard.organization)
-    }
+
     if (window.history.state.idx) {
       setOnSuccessRoute(-1)
     }

--- a/src/queries/account.ts
+++ b/src/queries/account.ts
@@ -5,9 +5,7 @@ import { QueryKeys } from './keys'
 
 export interface Organization {
   address: string
-  name: string
   type: string
-  description: string
   size: number
   color: string
   logo: string


### PR DESCRIPTION
- Add SignerAddress to LocalStorageKeys
- Store and retrieve signer address from localStorage
- Use stored address if available, otherwise use first address
- Clear stored address on logout
- Fixed organization type incorrectly having name and description
- Updated components due to the previous change
- Added an organization selector for people having more than one org
- Made required changes to properly change the signer between organization changes
- Updated organization creation form to properly manage multiple organizations creation
- Removed check in previous section to ensure you can always create an org, even having one already
- Move organization switcher logic to its own component
- Added button in the menu to be able to create new orgs (will be moved probably, but at least is there already)

closes #937