### PR TITLE
Use liveResults instead of secretUntilTheEnd

### DIFF
--- a/src/components/Auth/SignUp.tsx
+++ b/src/components/Auth/SignUp.tsx
@@ -123,7 +123,7 @@ const SignUp = ({ invite }: SignupProps) => {
             }}
           />
           <FormControl as='fieldset' isInvalid={!!errors?.terms}>
-            <Checkbox {...register('terms', { required: t('validation.required') })} isRequired>
+            <Checkbox {...register('terms', { required: t('cc.validation.required') })} isRequired>
               <Trans
                 i18nKey='signup_agree_terms'
                 components={{

--- a/src/components/ProcessCreate/Confirm/Preview.tsx
+++ b/src/components/ProcessCreate/Confirm/Preview.tsx
@@ -15,7 +15,7 @@ const Preview = () => {
 
   const {
     description,
-    electionType: { secretUntilTheEnd, anonymous },
+    electionType: { liveResults, anonymous },
     maxVoteOverwrites,
     questions,
     startDate: begin,
@@ -125,8 +125,8 @@ const Preview = () => {
             <Text>{t('form.process_create.confirm.vote_overwrite')}</Text>
           </Flex>
           <Flex gap={2} alignItems='center'>
-            <Icon as={secretUntilTheEnd ? IoMdCheckmark : IoMdClose} boxSize={5} />
-            <Text>{t('form.process_create.confirm.secret_until_the_end')}</Text>
+            <Icon as={liveResults ? IoMdCheckmark : IoMdClose} boxSize={5} />
+            <Text>{t('form.process_create.confirm.live_results')}</Text>
           </Flex>
           <Flex gap={2} alignItems='center'>
             <Icon as={anonymous ? IoMdCheckmark : IoMdClose} boxSize={5} />

--- a/src/components/ProcessCreate/Settings/Features.tsx
+++ b/src/components/ProcessCreate/Settings/Features.tsx
@@ -18,13 +18,13 @@ const useProcessFeatures = () => {
         name: 'electionType.anonymous',
         permission: 'features.anonymous',
       },
-      secretUntilTheEnd: {
-        title: t('secret_until_the_end.title', { defaultValue: 'Secret until the end' }),
-        description: t('secret_until_the_end.description', {
-          defaultValue: 'Vote contents will be encrypted till the end of the voting',
+      liveResults: {
+        title: t('live_results.title', { defaultValue: 'Live results' }),
+        description: t('live_results.description', {
+          defaultValue: 'Vote contents will be publicly available till the end of the voting',
         }),
         icon: BiCheckDouble,
-        name: 'electionType.secretUntilTheEnd',
+        name: 'electionType.liveResults',
       },
       overwrite: {
         title: t('overwrite.title', { defaultValue: 'Vote overwrite' }),

--- a/src/components/ProcessCreate/StepForm/Info.tsx
+++ b/src/components/ProcessCreate/StepForm/Info.tsx
@@ -19,7 +19,7 @@ export interface ConfigurationValues {
   electionType: {
     autoStart: boolean
     interruptible: boolean
-    secretUntilTheEnd: boolean
+    liveResults: boolean
     anonymous: boolean
   }
   resultsType: {

--- a/src/components/ProcessCreate/Steps/Confirm.tsx
+++ b/src/components/ProcessCreate/Steps/Confirm.tsx
@@ -393,6 +393,10 @@ const electionFromForm = (form: StepsFormValues) => {
   const maxCensusSize = form.maxCensusSize ?? form.spreadsheet?.data.length ?? form.addresses.length
   return {
     ...form,
+    electionType: {
+      ...form.electionType,
+      secretUntilTheEnd: !form.electionType.liveResults,
+    },
     maxCensusSize,
     // map questions back to IQuestion[]
     questions: form.questions.map(

--- a/src/components/ProcessCreate/Steps/Form.tsx
+++ b/src/components/ProcessCreate/Steps/Form.tsx
@@ -34,10 +34,9 @@ export const StepsForm = ({ steps, activeStep, next, prev, setActiveStep }: Step
     electionType: {
       autoStart: true,
       interruptible: true,
-      secretUntilTheEnd: true,
+      liveResults: false, // this is secretUntilTheEnd, but reversed
       anonymous: false,
     },
-    // hardcoded while there's no support for creating other types
     resultsType: {
       name: ElectionResultsTypeNames.SINGLE_CHOICE_MULTIQUESTION,
     },

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -223,7 +223,6 @@
   "control": "Control:",
   "copy": {
     "address": "Copia l'adreça",
-    "copied": "Copied",
     "copied_title": "Copiat!"
   },
   "country_selector": {
@@ -274,6 +273,7 @@
     }
   },
   "customization": "Customization",
+  "dark_mode": "Mode fosc",
   "delete_my_account": "Delete my account",
   "description": "Description",
   "edit_saas_profile": {
@@ -436,10 +436,10 @@
         "description_election": "Descripció",
         "edit": "Editar",
         "election_info": "Informació de la Votació",
+        "live_results": "Resultats en directe",
         "questions_one": "Pregunta",
         "questions_many": "Preguntes",
         "questions_other": "Preguntes",
-        "secret_until_the_end": "Secret fins el final",
         "title": "Vista prèvia i costos de votació",
         "title_election": "Títol",
         "vote_overwrite": "Sobreescriure vot"
@@ -766,10 +766,15 @@
   "invite_people": "Convida Gent",
   "keep_me_logged": "Mantén-me connectat",
   "languages": "Languages",
+  "light_mode": "Mode clar",
   "link": {
     "discord": "Enllaç al Discord de Vocdoni",
     "github": "Enllaç al Github de Vocdoni",
     "twitter": "Enllaç al Twitter de Vocdoni"
+  },
+  "live_results": {
+    "description": "Els continguts dels vots seran públics durant tota la votació.",
+    "title": "Resultats en directe"
   },
   "loading": "Carregant...",
   "login": {
@@ -1138,10 +1143,6 @@
   "role": {
     "read_permission": "Read-only access",
     "write_permission": "Can create and edit content"
-  },
-  "secret_until_the_end": {
-    "description": "Vote contents will be encrypted till the end of the voting",
-    "title": "Secret until the end"
   },
   "session_expired": "Session expired",
   "session_expired_description": "Session may have been expired and it could not be refreshed, please login again",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -220,7 +220,6 @@
   "control": "Control:",
   "copy": {
     "address": "Copy address",
-    "copied": "Copied",
     "copied_title": "Copied!"
   },
   "country_selector": {
@@ -271,6 +270,7 @@
     }
   },
   "customization": "Customization",
+  "dark_mode": "Dark mode",
   "delete_my_account": "Delete my account",
   "description": "Description",
   "edit_saas_profile": {
@@ -432,9 +432,9 @@
         "description_election": "Description",
         "edit": "Edit",
         "election_info": "Set up your voting process",
+        "live_results": "",
         "questions_one": "Question",
         "questions_other": "Questions",
-        "secret_until_the_end": "Secret until the end",
         "title": "Preview",
         "title_election": "Title",
         "vote_overwrite": "Vote overwrite"
@@ -759,10 +759,15 @@
   "invite_people": "Invite People",
   "keep_me_logged": "Keep me logged in",
   "languages": "Languages",
+  "light_mode": "Light mode",
   "link": {
     "discord": "Link to Vocdoni's discord",
     "github": "Link to Vocdoni's github",
     "twitter": "Link to Vocdoni's twitter"
+  },
+  "live_results": {
+    "description": "Vote contents will be publicly available till the end of the voting",
+    "title": "Live results"
   },
   "loading": "Loading...",
   "login": {
@@ -1126,10 +1131,6 @@
   "role": {
     "read_permission": "Read-only access",
     "write_permission": "Can create and edit content"
-  },
-  "secret_until_the_end": {
-    "description": "Vote contents will be encrypted till the end of the voting",
-    "title": "Secret until the end"
   },
   "session_expired": "Session expired",
   "session_expired_description": "Session may have been expired and it could not be refreshed, please login again",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -223,7 +223,6 @@
   "control": "Control:",
   "copy": {
     "address": "Copiar dirección",
-    "copied": "Copied",
     "copied_title": "¡Copiado!"
   },
   "country_selector": {
@@ -274,6 +273,7 @@
     }
   },
   "customization": "Customization",
+  "dark_mode": "Modo oscuro",
   "delete_my_account": "Delete my account",
   "description": "Description",
   "edit_saas_profile": {
@@ -322,7 +322,7 @@
     "custom_url": "Custom URL",
     "email_reminder": "Recordatorios por correo electrónico",
     "interruptible": "Interruptible",
-    "live_results": "Live results",
+    "live_results": "Resultados en directo",
     "live_streaming": "Live streaming",
     "memberships": "Hasta {{ value }} membresías",
     "multiple": "Multiple choice voting",
@@ -436,10 +436,10 @@
         "description_election": "Descripción",
         "edit": "Editar",
         "election_info": "Información de Votación",
+        "live_results": "Resultados en directo",
         "questions_one": "Pregunta",
         "questions_many": "Preguntas",
         "questions_other": "Preguntas",
-        "secret_until_the_end": "Secreto hasta el final",
         "title": "Vista previa y costos de votación",
         "title_election": "Título",
         "vote_overwrite": "Sobrescribir voto"
@@ -766,10 +766,15 @@
   "invite_people": "Invitar Gente",
   "keep_me_logged": "Mantenerme conectado",
   "languages": "Languages",
+  "light_mode": "Modo claro",
   "link": {
     "discord": "Enlace al Discord de Vocdoni",
     "github": "Enlace al Github de Vocdoni",
     "twitter": "Enlace al Twitter de Vocdoni"
+  },
+  "live_results": {
+    "description": "Los contenidos de los votos serán públicos durante toda la votación.",
+    "title": "Resultados en directo"
   },
   "loading": "Cargando...",
   "login": {
@@ -1138,10 +1143,6 @@
   "role": {
     "read_permission": "Read-only access",
     "write_permission": "Can create and edit content"
-  },
-  "secret_until_the_end": {
-    "description": "Vote contents will be encrypted till the end of the voting",
-    "title": "Secret until the end"
   },
   "session_expired": "Session expired",
   "session_expired_description": "Session may have been expired and it could not be refreshed, please login again",


### PR DESCRIPTION
This uses a new `liveResults`variable which gets its value reversed into `secretUntilTheEnd` when creating a process.

Note this is only during the process creation, vochain has not (and will not) change this, so it continues being `secretUntilTheEnd` in most places.

closes #809