### PR TITLE
Tabs card layout

### DIFF
--- a/src/theme/components/Tabs.ts
+++ b/src/theme/components/Tabs.ts
@@ -27,7 +27,7 @@ const card = definePartsStyle({
     display: 'flex',
     flexDirection: 'row',
     flexWrap: 'wrap',
-    columnGap: 10,
+    justifyContent: 'space-between',
     '& > div': {
       display: 'grid',
       gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',


### PR DESCRIPTION
Removed the gap from the display flex and replaced it with justify-content: space-between.