### PR TITLE
feat: Fix pagination buttons sizes

### DIFF
--- a/src/theme/components/ellipsisButton.ts
+++ b/src/theme/components/ellipsisButton.ts
@@ -2,10 +2,11 @@ import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
 import { ellipsisButtonAnatomy } from '@vocdoni/chakra-components'
 const { defineMultiStyleConfig, definePartsStyle } = createMultiStyleConfigHelpers(ellipsisButtonAnatomy)
 
+const sharedButtonInputStyle = { py: 4, px: 3, h: '8', minW: '8', fontSize: 'sm' }
 const sizes = {
   xs: definePartsStyle({
-    button: { py: 4, px: 3, h: '8', minW: '8', fontSize: 'sm' },
-    input: { py: 4, px: 3, h: '8', minW: '8', fontSize: 'sm' },
+    button: sharedButtonInputStyle,
+    input: sharedButtonInputStyle,
   }),
 }
 

--- a/src/theme/components/ellipsisButton.ts
+++ b/src/theme/components/ellipsisButton.ts
@@ -1,0 +1,17 @@
+import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
+import { ellipsisButtonAnatomy } from '@vocdoni/chakra-components'
+const { defineMultiStyleConfig, definePartsStyle } = createMultiStyleConfigHelpers(ellipsisButtonAnatomy)
+
+const sizes = {
+  xs: definePartsStyle({
+    button: { py: 4, px: 3, h: '8', minW: '8', fontSize: 'sm' },
+    input: { py: 4, px: 3, h: '8', minW: '8', fontSize: 'sm' },
+  }),
+}
+
+export const EllipsisButton = defineMultiStyleConfig({
+  sizes,
+  defaultProps: {
+    size: 'xs',
+  },
+})

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -4,6 +4,7 @@ import { Card } from './card'
 import { Checkbox, DetailedCheckbox } from './checkbox'
 import { ConfirmModal } from './confirmModal'
 import { Drawer } from './drawer'
+import { EllipsisButton } from './ellipsisButton'
 import { FormLabel } from './form'
 import { ElectionTitle, Heading } from './heading'
 import { Input } from './input'
@@ -32,6 +33,7 @@ import { Tooltip } from './tooltip'
 const components = {
   Badge,
   Button,
+  EllipsisButton,
   Card,
   Checkbox,
   DetailedCheckbox,


### PR DESCRIPTION
closes #1275 

This is a patch, maybe we should edit the component in ui-components so that inputProps and buttonProps are passed to EllipsisButton via usePaginationPages hook in [packages/chakra-components/src/components/Pagination/Pagination.tsx](https://github.com/vocdoni/ui-components/blob/main/packages/chakra-components/src/components/Pagination/Pagination.tsx#L114-L124)