### PR TITLE
feat(i18n): allow defining languages via env var

### DIFF
--- a/src/components/shared/Navbar/LanguagesList.tsx
+++ b/src/components/shared/Navbar/LanguagesList.tsx
@@ -22,18 +22,18 @@ import { Trans, useTranslation } from 'react-i18next'
 import { FaGlobeAmericas } from 'react-icons/fa'
 import { LuCheck } from 'react-icons/lu'
 import i18n from '~i18n'
-import { LanguagesSlice } from '~i18n/languages.mjs'
 import { Select } from '~shared/Form/Select'
 import { languagesListSelectStyles } from '~theme/selectStyles'
 
 export const LanguagesList = ({ closeOnSelect }: { closeOnSelect: boolean }) => {
   const { i18n } = useTranslation()
 
-  const languages = LanguagesSlice as { [key: string]: string }
+  const languages = import.meta.env.LANGUAGES as Record<string, string>
+  const languageEntries = Object.entries(languages).sort(([, a], [, b]) => a.localeCompare(b))
 
   return (
     <>
-      {Object.keys(languages).map((k: string) => (
+      {languageEntries.map(([k]) => (
         <MenuItem
           key={k}
           onClick={() => {
@@ -55,6 +55,12 @@ export const LanguagesList = ({ closeOnSelect }: { closeOnSelect: boolean }) => 
 
 export const LanguagesMenu = ({ ...props }) => {
   const { t } = useTranslation()
+
+  const languages = import.meta.env.LANGUAGES as Record<string, string>
+  const hasMultipleLanguages = Object.keys(languages).length > 1
+  if (!hasMultipleLanguages) {
+    return null
+  }
 
   return (
     <Menu>
@@ -102,10 +108,13 @@ const LanguageOptionLabel = ({ value, label }, { context }) => {
 export const LanguageListDashboard = ({ ...props }) => {
   const { t, i18n } = useTranslation()
 
-  const languageOptions: LanguageOption[] = Object.entries(LanguagesSlice).map(([key, label]) => ({
-    value: key,
-    label: t(`language.${label.toLowerCase()}`, label),
-  }))
+  const languages = import.meta.env.LANGUAGES as Record<string, string>
+  const languageOptions: LanguageOption[] = Object.entries(languages)
+    .map(([key, label]) => ({
+      value: key,
+      label,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label))
 
   const selectedLanguage = languageOptions.find((opt) => opt.value === i18n.language)
 
@@ -138,7 +147,16 @@ export const LanguageListDashboard = ({ ...props }) => {
 export const LanguagesListAccordion = () => {
   const { i18n } = useTranslation()
 
-  const languages = LanguagesSlice as { [key: string]: string }
+  const languages = import.meta.env.LANGUAGES as Record<string, string>
+  const languageEntries = Object.entries(languages).sort(([, a], [, b]) => a.localeCompare(b))
+
+  // Check if there's only one language
+  const hasMultipleLanguages = Object.keys(languages).length > 1
+
+  // Only render if there are multiple languages
+  if (!hasMultipleLanguages) {
+    return null
+  }
 
   return (
     <Accordion allowMultiple m={0} p={0} borderColor='transparent'>
@@ -160,7 +178,7 @@ export const LanguagesListAccordion = () => {
         </AccordionButton>
         <AccordionPanel pb={0}>
           <Stack direction={{ base: 'column', md: 'row' }} spacing={2} mt={2}>
-            {Object.entries(languages).map(([k, lang]: [string, string]) => (
+            {languageEntries.map(([k, lang]) => (
               <Button
                 key={k}
                 onClick={() => {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -3,8 +3,11 @@ import i18next from 'i18next'
 import BrowserLanguageDetector from 'i18next-browser-languagedetector'
 import { initReactI18next } from 'react-i18next'
 import { ucfirst } from '~utils/strings'
-import { LanguagesSlice } from './languages.mjs'
 import { dateLocales, translations } from './locales'
+
+const languagesSlice = import.meta.env.LANGUAGES as Record<string, string>
+const supportedLanguages = Object.keys(languagesSlice)
+const fallbackLanguage = supportedLanguages[0]
 
 // initialize i18next
 const i18n = i18next.createInstance()
@@ -13,7 +16,8 @@ i18n
   .use(initReactI18next)
   .init(
     {
-      fallbackLng: 'en',
+      fallbackLng: fallbackLanguage,
+      supportedLngs: supportedLanguages,
       debug: import.meta.env.NODE_ENV === 'development',
       defaultNS: 'translation',
       interpolation: {
@@ -34,7 +38,7 @@ i18n
   )
 
 // load translations
-for (const lang of Object.keys(LanguagesSlice)) {
+for (const lang of supportedLanguages) {
   if (typeof translations[lang] !== 'undefined') {
     i18n.addResourceBundle(lang, 'translation', translations[lang])
   }

--- a/src/i18n/languages.mjs
+++ b/src/i18n/languages.mjs
@@ -6,18 +6,11 @@
   to update locales/index.ts
 */
 
-export const LanguagesSlice = {
+export const baseLanguages = {
   en: 'English',
   es: 'Spanish',
   ca: 'Catalan',
   it: 'Italiano',
 }
 
-// t('language.english', 'English')
-// t('language.spanish', 'Spanish')
-// t('language.catalan', 'Catalan')
-// t('language.italian', 'Italiano')
-
-const languages = Object.keys(LanguagesSlice)
-
-export default languages
+export default Object.keys(baseLanguages)

--- a/src/i18n/languages.test.ts
+++ b/src/i18n/languages.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import languages, { baseLanguages } from './languages.mjs'
+
+describe('languages configuration', () => {
+  it('exports the base language map', () => {
+    expect(baseLanguages).toEqual({
+      en: 'English',
+      es: 'Spanish',
+      ca: 'Catalan',
+      it: 'Italiano',
+    })
+  })
+
+  it('exports the list of language keys from the base map', () => {
+    expect(languages).toEqual(Object.keys(baseLanguages))
+  })
+})

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -959,12 +959,6 @@
     "unexpected_error": "",
     "user_invited": "S'ha enviat un correu a {{email}}"
   },
-  "language": {
-    "catalan": "Català",
-    "english": "English",
-    "italian": "Italiano",
-    "spanish": "Castellano"
-  },
   "languages": "Idiomes",
   "lastname": "Cognoms",
   "light": "Clar",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -951,12 +951,6 @@
     "unexpected_error": "",
     "user_invited": "Email sent to {{email}}"
   },
-  "language": {
-    "catalan": "Català",
-    "english": "English",
-    "italian": "Italiano",
-    "spanish": "Castellano"
-  },
   "languages": "Languages",
   "lastname": "Last name",
   "light": "Light",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -959,12 +959,6 @@
     "unexpected_error": "",
     "user_invited": "Correo enviado a {{email}}"
   },
-  "language": {
-    "catalan": "Català",
-    "english": "English",
-    "italian": "Italiano",
-    "spanish": "Castellano"
-  },
   "languages": "Idiomas",
   "lastname": "Apellidos",
   "light": "Claro",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -959,12 +959,6 @@
     "unexpected_error": "",
     "user_invited": "Email inviata a {{email}}"
   },
-  "language": {
-    "catalan": "Català",
-    "english": "English",
-    "italian": "Italiano",
-    "spanish": "Castellano"
-  },
   "languages": "Lingue",
   "lastname": "Cognome",
   "light": "Chiaro",

--- a/src/importmeta.d.ts
+++ b/src/importmeta.d.ts
@@ -29,5 +29,6 @@ interface ImportMeta {
     PRIVACY_POLICY_URL: string
     TERMS_OF_SERVICE_URL: string
     WHATSAPP_PHONE_NUMBER: string
+    LANGUAGES: Record<string, string>
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig, loadEnv } from 'vite'
 import { createHtmlPlugin } from 'vite-plugin-html'
 import svgr from 'vite-plugin-svgr'
 import tsconfigPaths from 'vite-tsconfig-paths'
+import { resolveLanguagesSlice } from './vite/language-env'
 
 // https://vitejs.dev/config/
 const viteconfig = ({ mode }) => {
@@ -70,6 +71,8 @@ const viteconfig = ({ mode }) => {
     }
   }
 
+  const languagesSlice = resolveLanguagesSlice(process.env.LANGUAGES)
+
   return defineConfig({
     base,
     build: {
@@ -99,6 +102,7 @@ const viteconfig = ({ mode }) => {
       'import.meta.env.PRIVACY_POLICY_URL': JSON.stringify(privacyPolicyUrl),
       'import.meta.env.TERMS_OF_SERVICE_URL': JSON.stringify(termsOfServiceUrl),
       'import.meta.env.WHATSAPP_PHONE_NUMBER': JSON.stringify(process.env.WHATSAPP_PHONE_NUMBER || '+34 621 501 155'),
+      'import.meta.env.LANGUAGES': JSON.stringify(languagesSlice),
     },
     plugins: [
       tsconfigPaths(),

--- a/vite/language-env.ts
+++ b/vite/language-env.ts
@@ -1,0 +1,31 @@
+import { baseLanguages } from '../src/i18n/languages.mjs'
+
+export const resolveLanguagesSlice = (rawValue?: string) => {
+  if (!rawValue) {
+    return { ...baseLanguages }
+  }
+
+  const languages = rawValue
+    .split(',')
+    .map((lang) => lang.trim())
+    .filter(Boolean)
+
+  if (languages.length === 0) {
+    return { ...baseLanguages }
+  }
+
+  const invalidLanguages = languages.filter((lang) => !baseLanguages[lang])
+
+  if (invalidLanguages.length) {
+    throw new Error(
+      `Invalid LANGUAGES configuration. Received: ${invalidLanguages.join(', ')}. Supported: ${Object.keys(baseLanguages).join(', ')}.`
+    )
+  }
+
+  return languages.reduce((acc, lang) => {
+    acc[lang] = baseLanguages[lang]
+    return acc
+  }, {} as Record<string, string>)
+}
+
+export { baseLanguages }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,29 +1,14 @@
-import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
-import fs from 'fs'
-
-// Generate aliases from tsconfig.paths.json
-function getAliasesFromTsConfig() {
-  const tsconfigPath = path.resolve(__dirname, './tsconfig.paths.json')
-  const tsconfig = JSON.parse(fs.readFileSync(tsconfigPath, 'utf-8'))
-  const paths = tsconfig.compilerOptions.paths
-  const aliases: Record<string, string> = {}
-
-  Object.keys(paths).forEach((alias) => {
-    // Remove the /* suffix from the alias key
-    const aliasKey = alias.replace(/\/\*$/, '')
-    // Get the first path value (remove /* suffix and resolve)
-    const aliasPath = paths[alias][0].replace(/\/\*$/, '')
-    // Resolve to absolute path
-    aliases[aliasKey] = path.resolve(__dirname, './src', aliasPath)
-  })
-
-  return aliases
-}
+import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from 'vitest/config'
+import { resolveLanguagesSlice } from './vite/language-env'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tsconfigPaths()],
+  define: {
+    'import.meta.env.LANGUAGES': JSON.stringify(resolveLanguagesSlice(process.env.LANGUAGES)),
+  },
   test: {
     globals: true,
     environment: 'jsdom',
@@ -49,7 +34,6 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      ...getAliasesFromTsConfig(),
       // Mock problematic packages for testing
       '@plausible-analytics/tracker': path.resolve(__dirname, './src/__mocks__/@plausible-analytics/tracker.ts'),
       'react-gtm-module': path.resolve(__dirname, './src/__mocks__/react-gtm-module.ts'),


### PR DESCRIPTION
This pull request refactors the way supported languages are configured and accessed throughout the application. Instead of importing a static language map, the list of supported languages is now injected at build time via an environment variable, making it easier to customize language support per deployment. The codebase has been updated to consistently use this new approach, and related language configuration is now validated and tested.

**Build-time language configuration and usage:**

* Added a new utility, `resolveLanguagesSlice`, in `vite/language-env.ts` to resolve and validate the list of supported languages from the `LANGUAGES` environment variable, defaulting to the base set if not provided.
* Updated `vite.config.ts` and `vitest.config.ts` to inject the resolved language map into `import.meta.env.LANGUAGES` for both build and test environments. [[1]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR7) [[2]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR74-R75) [[3]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR105) [[4]](diffhunk://#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92L1-R11)
* All language selection components (`LanguagesList`, `LanguagesMenu`, `LanguageListDashboard`, `LanguagesListAccordion`) now use `import.meta.env.LANGUAGES` instead of importing a static language slice, and only render if multiple languages are available. [[1]](diffhunk://#diff-cb7e82c27e1e2ac1f266c7573516e1bd423d78425283570f882bec052df88dacL25-R36) [[2]](diffhunk://#diff-cb7e82c27e1e2ac1f266c7573516e1bd423d78425283570f882bec052df88dacR59-R64) [[3]](diffhunk://#diff-cb7e82c27e1e2ac1f266c7573516e1bd423d78425283570f882bec052df88dacL105-R117) [[4]](diffhunk://#diff-cb7e82c27e1e2ac1f266c7573516e1bd423d78425283570f882bec052df88dacL141-R159) [[5]](diffhunk://#diff-cb7e82c27e1e2ac1f266c7573516e1bd423d78425283570f882bec052df88dacL163-R181)

**i18n initialization and resource loading:**

* The i18n setup in `src/i18n/index.ts` now dynamically sets `fallbackLng` and `supportedLngs` based on the injected language configuration, ensuring only the selected languages are loaded and available. [[1]](diffhunk://#diff-8a518b6807c2692686b085051a2455e70aacd2bb6e1e228c3389fdec04226417L6-R20) [[2]](diffhunk://#diff-8a518b6807c2692686b085051a2455e70aacd2bb6e1e228c3389fdec04226417L37-R41)

**Language data and tests:**

* Refactored `src/i18n/languages.mjs` to export a `baseLanguages` map and a default list of language keys, aligning with the new configuration approach.
* Added a new test file, `src/i18n/languages.test.ts`, to verify the exported language map and list.

**Translation file cleanup:**

* Removed the redundant `"language"` section from all locale JSON files, as language names are now sourced from the configuration. [[1]](diffhunk://#diff-57df87d637a41556624c6359bc7666727216abc8ff4c32d5559acf0e99cf612bL962-L967) [[2]](diffhunk://#diff-86d6ad78f4bfa98b2f9fc37e63d2f4c94b23dc54736ab069327947546c55ccd0L954-L959) [[3]](diffhunk://#diff-581cafae589f127d1df75c001f7d6b39daaa697a2e5e19bb6386caa3462810abL962-L967) [[4]](diffhunk://#diff-66604ad1a09167c4e1cfde3794c38d07a3b6373a9fd6c46c59f071e2aa3687efL962-L967)