### PR TITLE
chore(analytics): make sure client prop is always defined

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ PRIORITY_SUPPORT_PHONE="+34 900 123 456"
 STRIPE_PUBLIC_KEY=key
 GTM_CONTAINER_ID=GTM-XXXXXXX
 PLAUSIBLE_DOMAIN=app.vocdoni.io
+ANALYTICS_CLIENT_ID=client-id
 ANNOUNCEMENT='{"message": {"en": "Welcome!", "es": "¡Bienvenido!"}, "status": "info", "lsKey": "unique-local-storage-key"}'
 PRIVACY_POLICY_URL=https://vocdoni.io/privacy
 TERMS_OF_SERVICE_URL=https://vocdoni.io/terms

--- a/src/importmeta.d.ts
+++ b/src/importmeta.d.ts
@@ -31,7 +31,7 @@ interface ImportMeta {
     TERMS_OF_SERVICE_URL: string
     WHATSAPP_PHONE_NUMBER: string
     LANGUAGES: Record<string, string>
-    PLAUSIBLE_CLIENT_ID: string
+    ANALYTICS_CLIENT_ID: string
     SHARED_CENSUS_ALWAYS_VISIBLE_TEXT?: Record<string, string>
     SHARED_CENSUS_DISCONNECTED_TEXT?: Record<string, string>
     SHARED_CENSUS_CONNECTED_TEXT?: Record<string, string>

--- a/src/utils/analytics.test.ts
+++ b/src/utils/analytics.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockPlausibleInit = vi.fn()
+const mockPlausibleTrack = vi.fn()
+
+vi.mock('@plausible-analytics/tracker', () => ({
+  init: mockPlausibleInit,
+  track: mockPlausibleTrack,
+}))
+
+const mockGtmInitialize = vi.fn()
+const mockGtmDataLayer = vi.fn()
+
+vi.mock('react-gtm-module', () => ({
+  default: {
+    initialize: mockGtmInitialize,
+    dataLayer: mockGtmDataLayer,
+  },
+}))
+
+describe('analytics initialization', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockPlausibleInit.mockClear()
+    mockPlausibleTrack.mockClear()
+    mockGtmInitialize.mockClear()
+    mockGtmDataLayer.mockClear()
+    import.meta.env.ANALYTICS_CLIENT_ID = ''
+  })
+
+  afterEach(() => {
+    import.meta.env.ANALYTICS_CLIENT_ID = ''
+  })
+
+  it('adds analytics client id to plausible custom properties on init', async () => {
+    import.meta.env.ANALYTICS_CLIENT_ID = 'client-1'
+    const { initializePlausible } = await import('./analytics')
+
+    initializePlausible({ domain: 'example.com' })
+
+    expect(mockPlausibleInit).toHaveBeenCalledTimes(1)
+    const config = mockPlausibleInit.mock.calls[0][0]
+    expect(config.customProperties).toEqual({ client: 'client-1' })
+  })
+
+  it('sets analytics client id in the GTM dataLayer on init', async () => {
+    import.meta.env.ANALYTICS_CLIENT_ID = 'client-1'
+    const { initializeGTM } = await import('./analytics')
+
+    initializeGTM({ gtmId: 'GTM-XXXX' })
+
+    expect(mockGtmInitialize).toHaveBeenCalledTimes(1)
+    expect(mockGtmDataLayer).toHaveBeenCalledWith({
+      dataLayer: { client: 'client-1' },
+    })
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -101,7 +101,7 @@ const viteconfig = ({ mode }) => {
       'import.meta.env.BUTTON_COLOR_SCHEME': JSON.stringify(process.env.BUTTON_COLOR_SCHEME || 'black'),
       'import.meta.env.WHATSAPP_PHONE_NUMBER': JSON.stringify(process.env.WHATSAPP_PHONE_NUMBER || '+34 621 501 155'),
       'import.meta.env.LANGUAGES': JSON.stringify(languagesSlice),
-      'import.meta.env.PLAUSIBLE_CLIENT_ID': JSON.stringify(process.env.PLAUSIBLE_CLIENT_ID || ''),
+      'import.meta.env.ANALYTICS_CLIENT_ID': JSON.stringify(process.env.ANALYTICS_CLIENT_ID || ''),
     },
     plugins: [
       tsconfigPaths(),


### PR DESCRIPTION
Also, renamed the env var to be more generic, since it can be used by both analytics providers.