### PR TITLE
Simplify interface by removing the top navigation bar

### DIFF
--- a/src/components/Memberbase/index.tsx
+++ b/src/components/Memberbase/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { generatePath, Outlet, useLocation, useNavigate, useOutletContext } from 'react-router-dom'
 import { Heading, SubHeading } from '~components/shared/Dashboard/Contents'
-import { DashboardLayoutContext } from '~elements/LayoutDashboard'
+
 import { Routes } from '~routes'
 
 export type MemberbaseTabsContext = {
@@ -13,7 +13,7 @@ export type MemberbaseTabsContext = {
   setSearch: (search: string) => void
   debouncedSearch: string
   submitSearch: () => void
-} & DashboardLayoutContext
+}
 
 export type JobId = string | null
 
@@ -21,7 +21,7 @@ export const MemberbaseTabs = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const location = useLocation()
-  const { setBreadcrumb } = useOutletContext<DashboardLayoutContext>()
+
   const [jobId, setJobIdState] = useState<JobId>(() => localStorage.getItem('memberbaseImportJobId'))
   const [search, setSearch] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState(search)
@@ -81,7 +81,7 @@ export const MemberbaseTabs = () => {
             <Tab key={index}>{item.label}</Tab>
           ))}
         </TabList>
-        <Outlet context={{ setBreadcrumb, setJobId, jobId, search, setSearch, debouncedSearch, submitSearch }} />
+        <Outlet context={{ setJobId, jobId, search, setSearch, debouncedSearch, submitSearch }} />
       </Tabs>
     </>
   )

--- a/src/components/Process/Create/index.tsx
+++ b/src/components/Process/Create/index.tsx
@@ -950,9 +950,8 @@ const ProcessCreateView = () => {
             position='sticky'
             top={0}
             p={2}
-            bg='rgba(255, 255, 255, 0.8)'
-            _dark={{ bg: 'rgba(0, 0, 0, 0.8)' }}
-            backdropFilter='blur(10px)'
+            bg='white'
+            _dark={{ bg: 'gray.800' }}
             zIndex={99}
           >
             {effectiveDraftId && (

--- a/src/components/Process/Create/index.tsx
+++ b/src/components/Process/Create/index.tsx
@@ -946,7 +946,15 @@ const ProcessCreateView = () => {
           paddingBottom={4}
         >
           {/* Top bar with draft status and sidebar toggle */}
-          <HStack position='sticky' top='64px' p={2} bg='chakra.body.bg' zIndex='contents'>
+          <HStack
+            position='sticky'
+            top={0}
+            p={2}
+            bg='rgba(255, 255, 255, 0.8)'
+            _dark={{ bg: 'rgba(0, 0, 0, 0.8)' }}
+            backdropFilter='blur(10px)'
+            zIndex={99}
+          >
             {effectiveDraftId && (
               <Box px={3} py={1} borderRadius='full' bg='gray.100' _dark={{ bg: 'whiteAlpha.200' }} fontSize='sm'>
                 <Trans i18nKey='process.create.status.draft'>Draft</Trans>

--- a/src/components/Process/Create/index.tsx
+++ b/src/components/Process/Create/index.tsx
@@ -946,14 +946,7 @@ const ProcessCreateView = () => {
           paddingBottom={4}
         >
           {/* Top bar with draft status and sidebar toggle */}
-          <HStack
-            position='sticky'
-            top={0}
-            p={2}
-            bg='white'
-            _dark={{ bg: 'gray.800' }}
-            zIndex={99}
-          >
+          <HStack position='sticky' top={0} p={2} bg='white' _dark={{ bg: 'gray.800' }} zIndex={99}>
             {effectiveDraftId && (
               <Box px={3} py={1} borderRadius='full' bg='gray.100' _dark={{ bg: 'whiteAlpha.200' }} fontSize='sm'>
                 <Trans i18nKey='process.create.status.draft'>Draft</Trans>

--- a/src/components/Process/Create/index.tsx
+++ b/src/components/Process/Create/index.tsx
@@ -946,7 +946,7 @@ const ProcessCreateView = () => {
           paddingBottom={4}
         >
           {/* Top bar with draft status and sidebar toggle */}
-          <HStack position='sticky' top={0} p={2} bg='white' _dark={{ bg: 'gray.800' }} zIndex={99}>
+          <HStack position='sticky' top={0} py={3} px={2} bg='chakra-body-bg' zIndex='sticky'>
             {effectiveDraftId && (
               <Box px={3} py={1} borderRadius='full' bg='gray.100' _dark={{ bg: 'whiteAlpha.200' }} fontSize='sm'>
                 <Trans i18nKey='process.create.status.draft'>Draft</Trans>

--- a/src/components/shared/Dashboard/Contents.tsx
+++ b/src/components/shared/Dashboard/Contents.tsx
@@ -28,7 +28,7 @@ export const DashboardBox = (props: BoxProps) => (
 )
 
 export const DashboardContents = (props: BoxProps) => (
-  <Flex flexDirection={'column'} maxW='1536px' w='full' mx='auto' p={6} {...props} />
+  <Flex flexDirection={'column'} maxW='1536px' w='full' mx='auto' px={6} pt={20} pb={6} {...props} />
 )
 
 export const DashboardSection = (props: BoxProps) => (
@@ -73,7 +73,7 @@ export const Sidebar = ({ show, ...props }: SidebarProps) => (
     style={{
       position: 'fixed',
       right: 0,
-      top: 65,
+      top: 0,
       bottom: 0,
       width: null, // to override chakra's default width
       zIndex: 10,

--- a/src/elements/LayoutDashboard.tsx
+++ b/src/elements/LayoutDashboard.tsx
@@ -10,12 +10,10 @@ import AnnouncementBanner from '~components/shared/Layout/AnnouncementBanner'
 import { LocalStorageKeys, MaxWindowWidth } from '~constants'
 import { Routes } from '~routes'
 import { DashboardBookerModalButton } from '~shared/Dashboard/Booker'
-import Breadcrumb, { BreadcrumbItem } from '~shared/Dashboard/Breadcrumb'
+
 import DashboardMenu from '~shared/Dashboard/Menu'
 
-export type DashboardLayoutContext = {
-  setBreadcrumb: (items: BreadcrumbItem[]) => void
-}
+
 
 export type DashboardLayoutContextType = {
   reduced: boolean
@@ -24,7 +22,7 @@ export type DashboardLayoutContextType = {
 export const DashboardLayoutContext = createContext<DashboardLayoutContextType | undefined>(undefined)
 
 const LayoutDashboard: React.FC = () => {
-  const [breadcrumb, setBreadcrumb] = useState<BreadcrumbItem[]>([])
+
   const { isOpen, onOpen, onClose } = useDisclosure()
   const isMobile = useBreakpointValue({ base: true, md: false })
   const [reduced, setReduced] = useLocalStorage(LocalStorageKeys.DashboardMenuReduced, false)
@@ -55,7 +53,7 @@ const LayoutDashboard: React.FC = () => {
               />
             </Box>
 
-            <Outlet context={{ setBreadcrumb } satisfies DashboardLayoutContext} />
+            <Outlet />
           </Flex>
         </Flex>
       </DashboardLayoutProviders>

--- a/src/elements/LayoutDashboard.tsx
+++ b/src/elements/LayoutDashboard.tsx
@@ -13,8 +13,6 @@ import { DashboardBookerModalButton } from '~shared/Dashboard/Booker'
 
 import DashboardMenu from '~shared/Dashboard/Menu'
 
-
-
 export type DashboardLayoutContextType = {
   reduced: boolean
 }
@@ -22,7 +20,6 @@ export type DashboardLayoutContextType = {
 export const DashboardLayoutContext = createContext<DashboardLayoutContextType | undefined>(undefined)
 
 const LayoutDashboard: React.FC = () => {
-
   const { isOpen, onOpen, onClose } = useDisclosure()
   const isMobile = useBreakpointValue({ base: true, md: false })
   const [reduced, setReduced] = useLocalStorage(LocalStorageKeys.DashboardMenuReduced, false)

--- a/src/elements/LayoutDashboard.tsx
+++ b/src/elements/LayoutDashboard.tsx
@@ -42,24 +42,10 @@ const LayoutDashboard: React.FC = () => {
           {/* Sidebar for large screens */}
           <DashboardMenu isOpen={isOpen} onClose={onClose} />
 
-          <Flex flex='1 1 0' flexDirection='column' minW={0}>
+          <Flex flex='1 1 0' flexDirection='column' minW={0} position='relative'>
             <AnnouncementBanner />
-            {/* Top Menu */}
-            <Box
-              position='sticky'
-              borderBottom='1px solid'
-              borderColor='table.border'
-              bgColor='chakra.body.bg'
-              top={0}
-              pr={4}
-              pl={{ base: 4, md: 2 }}
-              gap={4}
-              display='flex'
-              h={16}
-              flexShrink={0}
-              alignItems='center'
-              zIndex={100}
-            >
+            {/* Sidebar Toggle Button - Relocated */}
+            <Box position='absolute' top={4} left={{ base: 4, md: 2 }} zIndex={100}>
               <IconButton
                 icon={<LuPanelLeft />}
                 aria-label={t('menu.open')}
@@ -67,36 +53,8 @@ const LayoutDashboard: React.FC = () => {
                 size='xs'
                 onClick={isMobile ? onOpen : () => setReduced((prev) => !prev)}
               />
-
-              <Box borderRight='1px solid' borderRightColor='table.border' h={6} />
-
-              <Breadcrumb breadcrumb={breadcrumb} setBreadcrumb={setBreadcrumb} />
-
-              <Flex gap={2} ml='auto' alignItems='center'>
-                <DashboardBookerModalButton
-                  leftIcon={<Icon as={LuCircleHelp} />}
-                  iconSpacing={{ base: 0, lg: 2 }}
-                  colorScheme='gray'
-                  variant='solid'
-                  size='sm'
-                >
-                  <Text as='span' display={{ base: 'none', lg: 'flex' }} fontSize='sm'>
-                    <Trans i18nKey='do_you_need_help'>Do you need help?</Trans>
-                  </Text>
-                </DashboardBookerModalButton>
-                <Button
-                  as={ReactRouterLink}
-                  to={generatePath(Routes.processes.create)}
-                  leftIcon={<Icon as={LuPlus} />}
-                  iconSpacing={{ base: 0, lg: 2 }}
-                  size='sm'
-                >
-                  <Text as='span' fontSize='sm' display={{ base: 'none', lg: 'flex' }}>
-                    <Trans i18nKey='new_voting'>New vote</Trans>
-                  </Text>
-                </Button>
-              </Flex>
             </Box>
+
             <Outlet context={{ setBreadcrumb } satisfies DashboardLayoutContext} />
           </Flex>
         </Flex>

--- a/src/elements/dashboard/index.tsx
+++ b/src/elements/dashboard/index.tsx
@@ -5,8 +5,6 @@ import { DashboardLayoutContext } from '~elements/LayoutDashboard'
 import { DashboardContents } from '~shared/Dashboard/Contents'
 
 const Dashboard = () => {
-
-
   return (
     <DashboardContents>
       <OrganizationDashboard />

--- a/src/elements/dashboard/index.tsx
+++ b/src/elements/dashboard/index.tsx
@@ -5,11 +5,7 @@ import { DashboardLayoutContext } from '~elements/LayoutDashboard'
 import { DashboardContents } from '~shared/Dashboard/Contents'
 
 const Dashboard = () => {
-  const { setBreadcrumb } = useOutletContext<DashboardLayoutContext>()
 
-  useEffect(() => {
-    setBreadcrumb([])
-  }, [setBreadcrumb])
 
   return (
     <DashboardContents>

--- a/src/elements/dashboard/memberbase/groups.tsx
+++ b/src/elements/dashboard/memberbase/groups.tsx
@@ -3,10 +3,8 @@ import { useTranslation } from 'react-i18next'
 import { useOutletContext } from 'react-router-dom'
 import GroupsBoard from '~components/Memberbase/GroupsBoard'
 
-
 const Groups = () => {
   const { t } = useTranslation()
-
 
   return <GroupsBoard />
 }

--- a/src/elements/dashboard/memberbase/groups.tsx
+++ b/src/elements/dashboard/memberbase/groups.tsx
@@ -2,19 +2,11 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useOutletContext } from 'react-router-dom'
 import GroupsBoard from '~components/Memberbase/GroupsBoard'
-import { DashboardLayoutContext } from '~elements/LayoutDashboard'
-import { Routes } from '~routes'
+
 
 const Groups = () => {
   const { t } = useTranslation()
-  const { setBreadcrumb } = useOutletContext<DashboardLayoutContext>()
 
-  useEffect(() => {
-    setBreadcrumb([
-      { title: t('memberbase.title', { defaultValue: 'Memberbase' }), route: Routes.dashboard.memberbase.base },
-      { title: t('memberbase.groups.title', { defaultValue: 'Groups' }) },
-    ])
-  }, [setBreadcrumb])
 
   return <GroupsBoard />
 }

--- a/src/elements/dashboard/memberbase/members.tsx
+++ b/src/elements/dashboard/memberbase/members.tsx
@@ -58,7 +58,7 @@ export const useMemberColumns = () => {
 const Members = () => {
   const { t } = useTranslation()
   const columns = useMemberColumns()
-  const { setBreadcrumb, debouncedSearch } = useOutletContext<MemberbaseTabsContext>()
+  const { debouncedSearch } = useOutletContext<MemberbaseTabsContext>()
   const { data, isLoading, isFetching, error } = usePaginatedMembers({ search: debouncedSearch })
 
   const members = data?.members || []
@@ -70,12 +70,7 @@ const Members = () => {
     nextPage: null,
   }
 
-  useEffect(() => {
-    setBreadcrumb([
-      { title: t('memberbase.title', { defaultValue: 'Memberbase' }), route: Routes.dashboard.memberbase.base },
-      { title: t('memberbase.members.title', { defaultValue: 'Members' }) },
-    ])
-  }, [setBreadcrumb])
+
 
   return (
     <TableProvider data={members} initialColumns={columns} isLoading={isLoading} isFetching={isFetching} error={error}>

--- a/src/elements/dashboard/memberbase/members.tsx
+++ b/src/elements/dashboard/memberbase/members.tsx
@@ -70,8 +70,6 @@ const Members = () => {
     nextPage: null,
   }
 
-
-
   return (
     <TableProvider data={members} initialColumns={columns} isLoading={isLoading} isFetching={isFetching} error={error}>
       <RoutedPaginationProvider path={Routes.dashboard.memberbase.members} initialPage={1} pagination={pagination}>

--- a/src/elements/dashboard/organization/create.tsx
+++ b/src/elements/dashboard/organization/create.tsx
@@ -10,10 +10,8 @@ const DashBoardCreateOrg = () => {
   const { t } = useTranslation()
   const [onSuccessRoute, setOnSuccessRoute] = useState<To>(Routes.dashboard.base)
 
-
   // Set layout title and subtitle and back button
   useEffect(() => {
-
     if (window.history.state.idx) {
       setOnSuccessRoute(-1 as unknown)
     }

--- a/src/elements/dashboard/organization/create.tsx
+++ b/src/elements/dashboard/organization/create.tsx
@@ -2,23 +2,18 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { To, useOutletContext } from 'react-router-dom'
 import { OrganizationCreate } from '~components/Organization/Create'
-import { DashboardLayoutContext } from '~elements/LayoutDashboard'
+
 import { DashboardContents } from '~shared/Dashboard/Contents'
 import { Routes } from '~src/router/routes'
 
 const DashBoardCreateOrg = () => {
   const { t } = useTranslation()
   const [onSuccessRoute, setOnSuccessRoute] = useState<To>(Routes.dashboard.base)
-  const { setBreadcrumb } = useOutletContext<DashboardLayoutContext>()
+
 
   // Set layout title and subtitle and back button
   useEffect(() => {
-    setBreadcrumb([
-      {
-        title: t('create_org.title', { defaultValue: 'Tell us about your organization' }),
-        route: Routes.dashboard.organizationCreate,
-      },
-    ])
+
     if (window.history.state.idx) {
       setOnSuccessRoute(-1 as unknown)
     }

--- a/src/elements/dashboard/processes/create.tsx
+++ b/src/elements/dashboard/processes/create.tsx
@@ -8,15 +8,7 @@ import { DashboardLayoutContext } from '~elements/LayoutDashboard'
 
 const ProcessCreatePage = () => {
   const { t } = useTranslation()
-  const { setBreadcrumb } = useOutletContext<DashboardLayoutContext>()
 
-  useEffect(() => {
-    setBreadcrumb([
-      {
-        title: t('create_process', { defaultValue: 'Create process' }),
-      },
-    ])
-  }, [setBreadcrumb])
 
   return (
     <PricingModalProvider>

--- a/src/elements/dashboard/processes/create.tsx
+++ b/src/elements/dashboard/processes/create.tsx
@@ -9,7 +9,6 @@ import { DashboardLayoutContext } from '~elements/LayoutDashboard'
 const ProcessCreatePage = () => {
   const { t } = useTranslation()
 
-
   return (
     <PricingModalProvider>
       <TemplateProvider>

--- a/src/elements/dashboard/processes/index.tsx
+++ b/src/elements/dashboard/processes/index.tsx
@@ -3,13 +3,13 @@ import { ElectionStatus } from '@vocdoni/sdk'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { generatePath, matchPath, Outlet, useLocation, useNavigate, useOutletContext } from 'react-router-dom'
-import { DashboardLayoutContext } from '~elements/LayoutDashboard'
+
 import { Routes } from '~routes'
 import { DashboardContents, Heading, SubHeading } from '~shared/Dashboard/Contents'
 
 const OrganizationVotings = () => {
   const { t } = useTranslation()
-  const { setBreadcrumb } = useOutletContext<DashboardLayoutContext>()
+
   const navigate = useNavigate()
   const location = useLocation()
   const menuItems = [
@@ -32,13 +32,7 @@ const OrganizationVotings = () => {
   const currentTabIndex = isDrafts ? 2 : isEnded ? 1 : 0
 
   // Set page title
-  useEffect(() => {
-    setBreadcrumb([
-      {
-        title: t('voting_processes', { defaultValue: 'Voting processes' }),
-      },
-    ])
-  }, [setBreadcrumb])
+
 
   return (
     <DashboardContents>
@@ -58,7 +52,7 @@ const OrganizationVotings = () => {
             <Tab key={index}>{item.label}</Tab>
           ))}
         </TabList>
-        <Outlet context={{ setBreadcrumb }} />
+        <Outlet />
       </Tabs>
     </DashboardContents>
   )

--- a/src/elements/dashboard/processes/index.tsx
+++ b/src/elements/dashboard/processes/index.tsx
@@ -33,7 +33,6 @@ const OrganizationVotings = () => {
 
   // Set page title
 
-
   return (
     <DashboardContents>
       <Heading textTransform='capitalize'>{t('voting_processes')}</Heading>

--- a/src/elements/dashboard/processes/view.tsx
+++ b/src/elements/dashboard/processes/view.tsx
@@ -21,7 +21,6 @@ const DashboardProcessViewElement = () => {
     if (organization.address !== election.organizationId) {
       return navigate(generatePath(Routes.processes.view, { id: election.id }))
     }
-
   }, [organization, election])
 
   return (

--- a/src/elements/dashboard/processes/view.tsx
+++ b/src/elements/dashboard/processes/view.tsx
@@ -5,14 +5,14 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { generatePath, useLoaderData, useNavigate, useOutletContext } from 'react-router-dom'
 import { ProcessView } from '~components/Process/Dashboard/ProcessView'
-import { DashboardLayoutContext } from '~elements/LayoutDashboard'
+
 import { Routes } from '~src/router/routes'
 
 const DashboardProcessViewElement = () => {
   const { organization } = useOrganization()
   const { t } = useTranslation()
   const election = useLoaderData() as PublishedElection
-  const { setBreadcrumb } = useOutletContext<DashboardLayoutContext>()
+
   const navigate = useNavigate()
 
   // redirect to public view if not an owner (may need changes when org roles are in effect)
@@ -21,15 +21,7 @@ const DashboardProcessViewElement = () => {
     if (organization.address !== election.organizationId) {
       return navigate(generatePath(Routes.processes.view, { id: election.id }))
     }
-    setBreadcrumb([
-      {
-        title: t('voting_processes', { defaultValue: 'Voting processes' }),
-        route: Routes.dashboard.processes.base,
-      },
-      {
-        title: election.title.default,
-      },
-    ])
+
   }, [organization, election])
 
   return (

--- a/src/elements/dashboard/profile.tsx
+++ b/src/elements/dashboard/profile.tsx
@@ -2,18 +2,12 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useOutletContext } from 'react-router-dom'
 import { AccountEdit } from '~components/Account/Edit'
-import { DashboardLayoutContext } from '~elements/LayoutDashboard'
-import { Routes } from '~routes'
+
 import { DashboardContents } from '~shared/Dashboard/Contents'
 
 const Profile = () => {
   const { t } = useTranslation()
-  const { setBreadcrumb } = useOutletContext<DashboardLayoutContext>()
 
-  // Set layout variables
-  useEffect(() => {
-    setBreadcrumb([{ title: t('profile.title'), route: Routes.dashboard.profile }])
-  }, [setBreadcrumb])
 
   return (
     <DashboardContents>

--- a/src/elements/dashboard/profile.tsx
+++ b/src/elements/dashboard/profile.tsx
@@ -8,7 +8,6 @@ import { DashboardContents } from '~shared/Dashboard/Contents'
 const Profile = () => {
   const { t } = useTranslation()
 
-
   return (
     <DashboardContents>
       <AccountEdit />

--- a/src/elements/dashboard/settings.tsx
+++ b/src/elements/dashboard/settings.tsx
@@ -19,7 +19,6 @@ const Settings = () => {
   const { t } = useTranslation()
   const { isLoading, isError, error, organization } = useSaasAccount()
 
-
   const navigate = useNavigate()
   const location = useLocation()
 
@@ -48,7 +47,6 @@ const Settings = () => {
   )
 
   // Set layout variables
-
 
   return (
     <DashboardContents>

--- a/src/elements/dashboard/settings.tsx
+++ b/src/elements/dashboard/settings.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Outlet, useLocation, useNavigate, useOutletContext } from 'react-router-dom'
 import { useSaasAccount } from '~components/Account/SaasAccountProvider'
-import { DashboardLayoutContext } from '~elements/LayoutDashboard'
+
 import { DashboardContents, Heading, SubHeading } from '~shared/Dashboard/Contents'
 import QueryDataLayout from '~shared/Layout/QueryDataLayout'
 import { Routes } from '~src/router/routes'
@@ -18,7 +18,7 @@ type MenuItem = {
 const Settings = () => {
   const { t } = useTranslation()
   const { isLoading, isError, error, organization } = useSaasAccount()
-  const { setBreadcrumb } = useOutletContext<DashboardLayoutContext>()
+
 
   const navigate = useNavigate()
   const location = useLocation()
@@ -48,15 +48,7 @@ const Settings = () => {
   )
 
   // Set layout variables
-  useEffect(() => {
-    const currentTab = menuItems[currentTabIndex] || menuItems[0]
-    setBreadcrumb([
-      { title: t('settings', { defaultValue: 'Settings' }), route: Routes.dashboard.settings.base },
-      {
-        title: currentTab.label,
-      },
-    ])
-  }, [setBreadcrumb, currentTabIndex])
+
 
   return (
     <DashboardContents>

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -278,7 +278,6 @@
   "description": "Descripció",
   "discount": "Descompte",
   "do_it_later": "Fes-ho més tard",
-  "do_you_need_help": "Necessites ajuda?",
   "draft_processes": "Esborranys",
   "drafts": {
     "clone": "Clonar esborrany",

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -205,7 +205,6 @@
     "subtitle": "Aquesta informació ens ajuda a personalitzar la teva experiència",
     "title": "Crea la teva organització"
   },
-  "create_process": "Crea un procés",
   "csp": {
     "authenticate": "Identifica't",
     "code_info": "Rebràs un codi únic al mitjà seleccionat per verificar la teva identitat i completar l'autenticació",
@@ -1588,8 +1587,7 @@
   },
   "profile": {
     "error": "No s'ha pogut actualitzar el perfil",
-    "success": "Perfil actualitzat correctament",
-    "title": "Perfil"
+    "success": "Perfil actualitzat correctament"
   },
   "promo_code": "Codi promocional",
   "promo_code_required": "Cal introduir un codi",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -202,7 +202,6 @@
     "subtitle": "Cut cost, Save Time: Secure, Private, and GDPR Compliant",
     "title": "Tell us about your organization"
   },
-  "create_process": "Create process",
   "csp": {
     "authenticate": "Identify",
     "code_info": "You will receive a unique code on the selected medium to verify your identity and complete authentication",
@@ -1564,8 +1563,7 @@
   },
   "profile": {
     "error": "Failed to update profile",
-    "success": "Profile updated successfully",
-    "title": "Profile"
+    "success": "Profile updated successfully"
   },
   "promo_code": "Promotion Code",
   "promo_code_required": "Promotion code is required",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -275,7 +275,6 @@
   "description": "Description",
   "discount": "Discount",
   "do_it_later": "Do it later",
-  "do_you_need_help": "Do you need help?",
   "draft_processes": "Drafts",
   "drafts": {
     "clone": "Clone Draft",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -205,7 +205,6 @@
     "subtitle": "Reduce costes, ahorra tiempo: seguro, privado y conforme al RGPD",
     "title": "Cuéntanos sobre tu organización"
   },
-  "create_process": "Crear proceso",
   "csp": {
     "authenticate": "Identificarse",
     "code_info": "Recibirás un código único en el medio seleccionado para verificar tu identidad y completar la autenticación.",
@@ -1588,8 +1587,7 @@
   },
   "profile": {
     "error": "Error al actualizar el perfil",
-    "success": "Perfil actualizado correctamente",
-    "title": "Perfil"
+    "success": "Perfil actualizado correctamente"
   },
   "promo_code": "Código promocional",
   "promo_code_required": "El código es obligatorio",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -278,7 +278,6 @@
   "description": "Descripción",
   "discount": "Descuento",
   "do_it_later": "Hacerlo más tarde",
-  "do_you_need_help": "¿Necesitas ayuda?",
   "draft_processes": "Borradores",
   "drafts": {
     "clone": "Clonar borrador",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -278,7 +278,6 @@
   "description": "Descrizione",
   "discount": "Sconto",
   "do_it_later": "Fallo più tardi",
-  "do_you_need_help": "Ti serve aiuto?",
   "draft_processes": "Bozze",
   "drafts": {
     "clone": "Clona bozza",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -205,7 +205,6 @@
     "subtitle": "Taglia i costi, risparmia tempo: sicuro, privato e conforme al GDPR",
     "title": "Parlaci della tua organizzazione"
   },
-  "create_process": "Crea processo",
   "csp": {
     "authenticate": "Identifica",
     "code_info": "Si riceverà un codice univoco sul mezzo selezionato per verificare l'identità e completare l'autenticazione",
@@ -1588,8 +1587,7 @@
   },
   "profile": {
     "error": "Errore durante l'aggiornamento del profilo",
-    "success": "Profilo aggiornato con successo",
-    "title": "Profilo"
+    "success": "Profilo aggiornato con successo"
   },
   "promo_code": "Codice Promozione",
   "promo_code_required": "Il codice promozione è obbligatorio",

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -55,6 +55,7 @@ export const theme = extendTheme(vtheme, {
     background: 0,
     contents: 1,
     sidebar: 2,
+    sticky: 100,
     modal: 1400,
     hovering: 1500,
   },


### PR DESCRIPTION
The top navigation bar has been removed to create a cleaner, more focused user experience.

This reduces visual noise for users and streamlines development by decreasing the number of UI elements that require layout and responsiveness adjustments.

This aligns with the future product requirements for version 2.3.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines the dashboard by eliminating the top navbar and breadcrumb system, simplifying page contexts and adjusting layout spacing.
> 
> - Removes `Breadcrumb`/`setBreadcrumb` usage across dashboard pages (processes, memberbase, settings, profile, org create, process view) and stops passing it via `Outlet` context
> - Relocates the sidebar toggle to an absolute button within the content area; removes the previous sticky top menu in `LayoutDashboard`
> - Updates `DashboardContents` padding (`pt=20`) and `Sidebar` slide origin (`top: 0`); adjusts Process Create top bar to `position: sticky; top: 0`, new padding/bg, and higher `zIndex`
> - Adds `zIndices.sticky` to theme for consistent layering
> - Minor UI/translation cleanup: drops unused i18n keys (e.g., `create_process`, `do_you_need_help`, `profile.title`) and removes related strings
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef20a54b872f0a21030bd2492796a4bb46c77a94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->