### PR TITLE
Stage 2.2.3

### DIFF
--- a/src/components/Process/CSP/Step0.test.tsx
+++ b/src/components/Process/CSP/Step0.test.tsx
@@ -88,9 +88,9 @@ describe('Step0Base crisp integration', () => {
     await fillAndSubmit()
 
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith(['set', 'user:memberNumber', '123'])
-      expect(push).toHaveBeenCalledWith(['set', 'user:name', 'Alice'])
-      expect(push).toHaveBeenCalledWith(['set', 'user:email', 'alice@example.com'])
+      expect(push).toHaveBeenCalledWith(['set', 'session:memberNumber', '123'])
+      expect(push).toHaveBeenCalledWith(['set', 'session:name', 'Alice'])
+      expect(push).toHaveBeenCalledWith(['set', 'session:email', 'alice@example.com'])
     })
   })
 
@@ -127,5 +127,28 @@ describe('Step0Base crisp integration', () => {
     })
 
     expect(push).not.toHaveBeenCalled()
+  })
+
+  it('does not block step progression when crisp push fails', async () => {
+    import.meta.env.CRISP_WEBSITE_ID = 'test-id'
+    const push = vi.fn(() => {
+      throw new Error('invalid')
+    })
+    setupCrisp(push)
+    mockMutateAsync.mockResolvedValue({ authToken: 'token-1' })
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    render(<Step0Base election={{} as any} />)
+
+    await fillAndSubmit()
+
+    await waitFor(() => {
+      expect(mockSetCurrentStep).toHaveBeenCalledWith(1)
+    })
+
+    expect(push).toHaveBeenCalled()
+    expect(consoleSpy).toHaveBeenCalled()
+    consoleSpy.mockRestore()
   })
 })

--- a/src/components/Process/CSP/Step0.test.tsx
+++ b/src/components/Process/CSP/Step0.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, waitFor } from '~src/test-utils'
 import { Step0Base } from './Step0'
 
@@ -88,7 +88,7 @@ describe('Step0Base crisp integration', () => {
     await fillAndSubmit()
 
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith(['set', 'user:nickname', '123'])
+      expect(push).toHaveBeenCalledWith(['set', 'user:nickname', ['memberNumber 123']])
     })
 
     expect(push).toHaveBeenCalledTimes(1)

--- a/src/components/Process/CSP/Step0.test.tsx
+++ b/src/components/Process/CSP/Step0.test.tsx
@@ -88,10 +88,10 @@ describe('Step0Base crisp integration', () => {
     await fillAndSubmit()
 
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith(['set', 'session:memberNumber', '123'])
-      expect(push).toHaveBeenCalledWith(['set', 'session:name', 'Alice'])
-      expect(push).toHaveBeenCalledWith(['set', 'session:email', 'alice@example.com'])
+      expect(push).toHaveBeenCalledWith(['set', 'user:nickname', '123'])
     })
+
+    expect(push).toHaveBeenCalledTimes(1)
   })
 
   it('does not push to crisp when auth fails', async () => {

--- a/src/components/Process/CSP/Step0.tsx
+++ b/src/components/Process/CSP/Step0.tsx
@@ -72,16 +72,24 @@ export const Step0Base = ({ election }: { election: PublishedElection }) => {
         return
       }
 
-      const w = window as Window & { $crisp?: CrispQueue }
+      const w = window as Window
       if (!w.$crisp || typeof w.$crisp.push !== 'function') {
         return
       }
 
-      Object.entries(fields).forEach(([key, value]) => {
-        if (typeof value === 'string' && value.length > 0) {
-          w.$crisp.push(['set', `user:${key}`, value])
-        }
-      })
+      try {
+        Object.entries(fields).forEach(([key, value]) => {
+          if (typeof value === 'string' && value.length > 0) {
+            try {
+              w.$crisp.push(['set', `session:${key}`, value])
+            } catch (error) {
+              console.error('Crisp push failed:', error)
+            }
+          }
+        })
+      } catch (error) {
+        console.error('Crisp push failed:', error)
+      }
     }
 
     try {

--- a/src/components/Process/CSP/Step0.tsx
+++ b/src/components/Process/CSP/Step0.tsx
@@ -78,15 +78,17 @@ export const Step0Base = ({ election }: { election: PublishedElection }) => {
       }
 
       try {
-        Object.entries(fields).forEach(([key, value]) => {
-          if (typeof value === 'string' && value.length > 0) {
-            try {
-              w.$crisp.push(['set', `session:${key}`, value])
-            } catch (error) {
-              console.error('Crisp push failed:', error)
-            }
-          }
-        })
+        const firstEntry = Object.entries(fields).find(([, value]) => typeof value === 'string' && value.length > 0)
+        if (!firstEntry) {
+          return
+        }
+
+        const [, value] = firstEntry
+        try {
+          w.$crisp.push(['set', 'user:nickname', value as string])
+        } catch (error) {
+          console.error('Crisp push failed:', error)
+        }
       } catch (error) {
         console.error('Crisp push failed:', error)
       }

--- a/src/components/Process/CSP/Step0.tsx
+++ b/src/components/Process/CSP/Step0.tsx
@@ -83,9 +83,9 @@ export const Step0Base = ({ election }: { election: PublishedElection }) => {
           return
         }
 
-        const [, value] = firstEntry
+        const [field, value] = firstEntry
         try {
-          w.$crisp.push(['set', 'user:nickname', value as string])
+          w.$crisp.push(['set', 'user:nickname', [`${field} ${value}` as string]])
         } catch (error) {
           console.error('Crisp push failed:', error)
         }

--- a/src/i18n/components.tsx
+++ b/src/i18n/components.tsx
@@ -32,6 +32,7 @@ export const translations = (t: TFunction<string, string>) => ({
     sign: t('cc.vote.sign').toString(),
     voted_description: t('cc.vote.voted_description').toString(),
     voted_title: t('cc.vote.voted_title').toString(),
+    weight: t('cc.vote.weight').toString(),
   },
   empty: t('cc.empty').toString(),
   errors: {

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -145,7 +145,8 @@
       "confirm": "Confirma les teves seleccions:",
       "sign": "Signa abans de votar",
       "voted_description": "Per verificar el teu vot, pots utilitzar aquesta identificació única: {{ id }}",
-      "voted_title": "El teu vot s'ha registrat amb èxit!"
+      "voted_title": "El teu vot s'ha registrat amb èxit!",
+      "weight": "El teu poder de vot és: "
     }
   },
   "census_size": "Mida del cens",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -142,7 +142,8 @@
       "confirm": "Please confirm your choices:",
       "sign": "Sign first",
       "voted_description": "To verify your vote, you can use this unique identifier: {{ id }}",
-      "voted_title": "Your vote was successfully cast!"
+      "voted_title": "Your vote was successfully cast!",
+      "weight": "Your voting power is: "
     }
   },
   "census_size": "Census size",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -145,7 +145,8 @@
       "confirm": "Confirma tus opciones:",
       "sign": "Firmar primero",
       "voted_description": "Para verificar tu voto, puedes usar este identificador único: {{ id }}",
-      "voted_title": "¡Tu voto se ha emitido correctamente!"
+      "voted_title": "¡Tu voto se ha emitido correctamente!",
+      "weight": "Tu poder de voto es: "
     }
   },
   "census_size": "Tamaño del censo",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -145,7 +145,8 @@
       "confirm": "Confermare le scelte:",
       "sign": "Firma prima",
       "voted_description": "Per verificare il voto, è possibile utilizzare questo identificatore univoco: {{ id }}",
-      "voted_title": "Voto espresso con successo!"
+      "voted_title": "Voto espresso con successo!",
+      "weight": "Il tuo potere di voto è: "
     }
   },
   "census_size": "Dimensione del censimento",


### PR DESCRIPTION
This is a hotfix with minor changes.

This pull request introduces improvements to the Crisp chat integration in the voting process, adds better error handling, and extends internationalization support for displaying voting power. The most important changes are grouped below:

**Crisp Integration & Error Handling:**

* Refactored the Crisp push logic in `Step0Base` to only send a single `user:nickname` event with the first valid field, and wrapped the push in error handling to prevent step progression from being blocked if Crisp fails. Errors are now logged to the console.
* Updated tests in `Step0.test.tsx` to verify the new Crisp push behavior, including that only one push is made, and added a test to ensure step progression is not blocked on Crisp push failure. [[1]](diffhunk://#diff-5890675c1da11aa87998fc0b6dab30c67f37141abc47c14af5d2eae8e48b9eb2L91-R94) [[2]](diffhunk://#diff-5890675c1da11aa87998fc0b6dab30c67f37141abc47c14af5d2eae8e48b9eb2R131-R153)

**Internationalization:**

* Added a new translation key `weight` to display voting power in the UI, updating translation files for Catalan, English, Spanish, and Italian. [[1]](diffhunk://#diff-16b799dfada00fbc2638edcaa53b8341029a4a7269f21d10763aea671005b39aR35) [[2]](diffhunk://#diff-57df87d637a41556624c6359bc7666727216abc8ff4c32d5559acf0e99cf612bL148-R149) [[3]](diffhunk://#diff-86d6ad78f4bfa98b2f9fc37e63d2f4c94b23dc54736ab069327947546c55ccd0L145-R146) [[4]](diffhunk://#diff-581cafae589f127d1df75c001f7d6b39daaa697a2e5e19bb6386caa3462810abL148-R149) [[5]](diffhunk://#diff-66604ad1a09167c4e1cfde3794c38d07a3b6373a9fd6c46c59f071e2aa3687efL148-R149)

**Test Code Quality:**

* Minor reordering of imports in `Step0.test.tsx` for consistency.