### PR TITLE
chore(i18n): remove duplicated FAQ entry in Spanish locale

### DIFF
--- a/src/components/Auth/Subscription.tsx
+++ b/src/components/Auth/Subscription.tsx
@@ -45,7 +45,8 @@ const SubscriptionProviderComponent: React.FC<{ children: ReactNode }> = ({ chil
   const { account } = useClient()
 
   // Fetch organization subscription details
-  // TODO: In the future, this may be merged with the role permissions (not yet defined)
+  // TODO: In the future, this may be merged with the role permissions (not yet defined).
+  // Tracked in: https://github.com/vocdoni/ui-scaffold/issues/1510
   const {
     data: subscription,
     isFetching,

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -723,10 +723,6 @@
         "description": "Vocdoni admite diversos métodos de autenticación, como correo electrónico, eID, código por SMS, firma electrónica o integración con sistemas de identificación existentes.",
         "title": "¿Cómo puedo asegurarme de que solo voten las personas autorizadas?"
       },
-      "faq_27": {
-        "description": "Ofrecemos asistencia técnica y herramientas de recuperación para garantizar que todos los votantes puedan ejercer su derecho al voto sin dificultades.",
-        "title": "¿Qué ocurre si un votante tiene problemas técnicos durante la votación?"
-      },
       "faq_28": {
         "description": "Censo cerrado: solo pueden votar las personas registradas previamente en el censo. Censo abierto: cualquier persona que cumpla determinados criterios (por ejemplo, verificación eID) puede votar.",
         "title": "¿Cuál es la diferencia entre un censo cerrado y uno abierto?"


### PR DESCRIPTION
This PR removes a duplicated FAQ entry () from . The same question/answer exists later as  with a more informative description, so removing the duplicate avoids confusion and keeps the locale file cleaner.\n\nRelated: #1509