### PR TITLE
Improvementes for Chakra v3

### DIFF
--- a/src/components/Pagination/PaginatedTableFooter.test.tsx
+++ b/src/components/Pagination/PaginatedTableFooter.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '~src/test-utils'
+import type { ReactNode } from 'react'
+import RoutedPaginatedTableFooter from './PaginatedTableFooter'
+
+const mockUseRoutedPagination = vi.fn()
+
+const serializeResponsiveProp = (value: unknown) => {
+  if (value == null) return ''
+  return typeof value === 'string' ? value : JSON.stringify(value)
+}
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual<typeof import('@chakra-ui/react')>('@chakra-ui/react')
+  const React = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    ...actual,
+    Box: ({
+      children,
+      display,
+      flexDirection,
+      flexWrap,
+      alignItems,
+      justifyContent,
+      ...props
+    }: {
+      children?: ReactNode
+      display?: unknown
+      flexDirection?: unknown
+      flexWrap?: unknown
+      alignItems?: unknown
+      justifyContent?: unknown
+      [key: string]: unknown
+    }) =>
+      React.createElement(
+        'div',
+        {
+          'data-display': serializeResponsiveProp(display),
+          'data-flex-direction': serializeResponsiveProp(flexDirection),
+          'data-flex-wrap': serializeResponsiveProp(flexWrap),
+          'data-align-items': serializeResponsiveProp(alignItems),
+          'data-justify-content': serializeResponsiveProp(justifyContent),
+          ...props,
+        },
+        children
+      ),
+    Text: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) =>
+      React.createElement('span', props, children),
+  }
+})
+
+vi.mock('@vocdoni/react-components/pagination', () => ({
+  RoutedPagination: () => <div>Pagination</div>,
+  Pagination: () => <div>Pagination</div>,
+  usePagination: () => ({ pagination: null, initialPage: 1 }),
+  useRoutedPagination: () => mockUseRoutedPagination(),
+}))
+
+vi.mock('./RowsPerPageSelect', () => ({
+  default: () => <div>RowsPerPageSelect</div>,
+}))
+
+describe('RoutedPaginatedTableFooter', () => {
+  beforeEach(() => {
+    mockUseRoutedPagination.mockReturnValue({
+      initialPage: 1,
+      pagination: {
+        currentPage: 1,
+        lastPage: 3,
+      },
+    })
+  })
+
+  it('uses wrapping rows instead of a forced mobile column layout', () => {
+    const { container } = render(<RoutedPaginatedTableFooter />)
+
+    expect(screen.getByText('RowsPerPageSelect')).toBeInTheDocument()
+    expect(screen.getByText('Pagination')).toBeInTheDocument()
+
+    const wrappers = container.querySelectorAll('div[data-display="flex"]')
+    const [root, controls] = Array.from(wrappers)
+
+    expect(root).toHaveAttribute('data-flex-direction', 'row')
+    expect(root).toHaveAttribute('data-flex-wrap', 'wrap')
+    expect(controls).toHaveAttribute('data-flex-direction', 'row')
+    expect(controls).toHaveAttribute('data-flex-wrap', 'wrap')
+  })
+})

--- a/src/components/Pagination/PaginatedTableFooter.tsx
+++ b/src/components/Pagination/PaginatedTableFooter.tsx
@@ -20,18 +20,14 @@ const RoutedPaginatedTableFooter = () => {
   return (
     <Box
       display='flex'
-      flexDirection={{ base: 'column', md: 'row' }}
-      alignItems={{ base: 'flex-start', md: 'center' }}
+      flexDirection='row'
+      flexWrap='wrap'
+      alignItems='center'
       gap={5}
-      justifyContent='space-between'
+      justifyContent={{ base: 'flex-start', md: 'space-between' }}
     >
       <RowsPerPageSelect />
-      <Box
-        display='flex'
-        flexDirection={{ base: 'column', md: 'row' }}
-        alignItems={{ base: 'flex-start', md: 'center' }}
-        gap={5}
-      >
+      <Box display='flex' flexDirection='row' flexWrap='wrap' alignItems='center' gap={5}>
         <Text fontSize='sm'>
           <Trans i18nKey='pagination.page_out_of' values={{ page, total }}>
             Page {{ page }} of {{ total }}
@@ -58,8 +54,8 @@ export const PaginatedTableFooter = () => {
   const total = initialPage === 0 ? pagination.lastPage + 1 : pagination.lastPage
 
   return (
-    <Box display='flex' flexDirection='row' alignItems='center' gap={5} justifyContent='space-between'>
-      <Box display='flex' flexDirection='row' alignItems='center' gap={5}>
+    <Box display='flex' flexDirection='row' flexWrap='wrap' alignItems='center' gap={5} justifyContent='space-between'>
+      <Box display='flex' flexDirection='row' flexWrap='wrap' alignItems='center' gap={5}>
         <Text fontSize='sm'>
           <Trans i18nKey='pagination.page_out_of' values={{ page, total }}>
             Page {{ page }} of {{ total }}

--- a/src/components/Process/Create/MainContent/ExtendedQuestionEditor.test.tsx
+++ b/src/components/Process/Create/MainContent/ExtendedQuestionEditor.test.tsx
@@ -60,4 +60,31 @@ describe('ExtendedQuestionEditor', () => {
     expect(screen.getByTestId('image-uploader')).toBeTruthy()
     expect(container.querySelectorAll('[data-choice-card]')).toHaveLength(1)
   })
+
+  it('renders option titles with semibold value and placeholder styles', () => {
+    const questionOptions = [{ id: 'opt-1' }]
+
+    render(<ExtendedQuestionEditor index={0} questionOptions={questionOptions} append={vi.fn()} remove={vi.fn()} />, {
+      wrapper: Wrapper,
+    })
+
+    const [optionInput] = screen.getAllByRole('textbox')
+    const inputClassName =
+      optionInput
+        .getAttribute('class')
+        ?.split(' ')
+        .find((className) => className.startsWith('css-')) ?? ''
+
+    expect(optionInput).toHaveStyle({ fontWeight: 'var(--chakra-font-weights-semibold)' })
+    expect(inputClassName).toBeTruthy()
+
+    const styleTags = Array.from(document.head.querySelectorAll('style'))
+      .map((tag) => tag.textContent ?? '')
+      .join('\n')
+
+    expect(styleTags).toContain(`.${inputClassName}::placeholder`)
+    expect(styleTags).toMatch(
+      new RegExp(`\\.${inputClassName}::placeholder[^}]*font-weight:var\\(--chakra-font-weights-semibold\\)`)
+    )
+  })
 })

--- a/src/components/Process/Create/MainContent/ExtendedQuestionEditor.test.tsx
+++ b/src/components/Process/Create/MainContent/ExtendedQuestionEditor.test.tsx
@@ -2,6 +2,23 @@ import { FormProvider, useForm } from 'react-hook-form'
 import { render, screen } from '~src/test-utils'
 import ExtendedQuestionEditor from './ExtendedQuestionEditor'
 
+const mockInput = vi.fn()
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual<typeof import('@chakra-ui/react')>('@chakra-ui/react')
+  const React = await vi.importActual<typeof import('react')>('react')
+  const Input = React.forwardRef<HTMLInputElement, Record<string, unknown>>((props, ref) => {
+    mockInput(props)
+    return React.createElement('input', { ...props, ref })
+  })
+  Input.displayName = 'Input'
+
+  return {
+    ...actual,
+    Input,
+  }
+})
+
 vi.mock('@dnd-kit/sortable', () => ({
   useSortable: () => ({
     attributes: {},
@@ -49,6 +66,10 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => {
 }
 
 describe('ExtendedQuestionEditor', () => {
+  beforeEach(() => {
+    mockInput.mockClear()
+  })
+
   it('renders options using choice card wrappers', () => {
     const questionOptions = [{ id: 'opt-1' }]
 
@@ -69,22 +90,13 @@ describe('ExtendedQuestionEditor', () => {
     })
 
     const [optionInput] = screen.getAllByRole('textbox')
-    const inputClassName =
-      optionInput
-        .getAttribute('class')
-        ?.split(' ')
-        .find((className) => className.startsWith('css-')) ?? ''
+    expect(optionInput).toBeInTheDocument()
 
-    expect(optionInput).toHaveStyle({ fontWeight: 'var(--chakra-font-weights-semibold)' })
-    expect(inputClassName).toBeTruthy()
-
-    const styleTags = Array.from(document.head.querySelectorAll('style'))
-      .map((tag) => tag.textContent ?? '')
-      .join('\n')
-
-    expect(styleTags).toContain(`.${inputClassName}::placeholder`)
-    expect(styleTags).toMatch(
-      new RegExp(`\\.${inputClassName}::placeholder[^}]*font-weight:var\\(--chakra-font-weights-semibold\\)`)
+    expect(mockInput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fontWeight: 'semibold',
+        _placeholder: { fontWeight: 'semibold' },
+      })
     )
   })
 })

--- a/src/components/Process/Create/MainContent/ExtendedQuestionEditor.tsx
+++ b/src/components/Process/Create/MainContent/ExtendedQuestionEditor.tsx
@@ -153,8 +153,9 @@ const SortableExtendedOption = ({
                   number: optionIndex + 1,
                 })
               }
-              fontWeight='bold'
+              fontWeight='semibold'
               fontSize='md'
+              _placeholder={{ fontWeight: 'semibold' }}
               {...register(`questions.${questionIndex}.options.${optionIndex}.option`, {
                 required: t('form.error.required', 'This field is required'),
               })}

--- a/src/components/Process/Create/MainContent/QuestionForm.tsx
+++ b/src/components/Process/Create/MainContent/QuestionForm.tsx
@@ -93,7 +93,7 @@ export const QuestionForm = ({ index, onRemove, questionId }: QuestionFormProps)
             </Box>
           )}
 
-          <VStack flex='1' align='stretch' gap={2} mb={6}>
+          <VStack flex='1' align='stretch' gap={2}>
             <Text fontSize='sm' color='texts.subtle'>
               {t('process.create.question.question_number', {
                 defaultValue: 'Question {{index}} of {{total}}',

--- a/src/components/Process/Dashboard/ProcessesTable.tsx
+++ b/src/components/Process/Dashboard/ProcessesTable.tsx
@@ -1,4 +1,4 @@
-import { Box, Icon, IconButton, Link, Menu, MenuPositioner, Table, Tag, Text } from '@chakra-ui/react'
+import { Box, Icon, IconButton, Link, Menu, MenuPositioner, Portal, Table, Tag, Text } from '@chakra-ui/react'
 import { ElectionProvider, ElectionStatusBadge, QuestionsTypeBadge, useElection } from '@vocdoni/react-components'
 import { ElectionStatus, ensure0x, InvalidElection, PublishedElection } from '@vocdoni/sdk'
 import { Trans, useTranslation } from 'react-i18next'
@@ -118,32 +118,34 @@ const ProcessContextMenu = () => {
           <LuEllipsisVertical />
         </IconButton>
       </Menu.Trigger>
-      <MenuPositioner>
-        <Menu.Content>
-          <Menu.Item value='more-info' asChild>
-            <RouterLink to={generatePath(Routes.dashboard.process, { id: ensure0x(election.id) })}>
-              <Icon as={LuInfo} boxSize={4} />
-              <Trans i18nKey='process_context.more_info'>More info</Trans>
-            </RouterLink>
-          </Menu.Item>
-          <Menu.Item value='public-voting-page' asChild>
-            <RouterLink to={generatePath(Routes.processes.view, { id: ensure0x(election.id) })} target='_blank'>
-              <Icon as={LuExternalLink} boxSize={4} />
-              <Trans i18nKey='process_context.public_voting_page'>Public voting page</Trans>
-            </RouterLink>
-          </Menu.Item>
-          <Menu.Item value='explorer' asChild>
-            <a href={`${client.explorerUrl}/process/${election.id}`} target='_blank' rel='noopener noreferrer'>
-              <Icon as={LuSearch} boxSize={4} />
-              <Trans i18nKey='process_context.explorer'>Explorer</Trans>
-            </a>
-          </Menu.Item>
-          <Menu.Item value='clone-draft' onClick={cloneAsDraft}>
-            <Icon as={LuCopy} boxSize={4} />
-            <Trans i18nKey='process_context.clone_as_draft'>Clone as draft</Trans>
-          </Menu.Item>
-        </Menu.Content>
-      </MenuPositioner>
+      <Portal>
+        <MenuPositioner>
+          <Menu.Content>
+            <Menu.Item value='more-info' asChild>
+              <RouterLink to={generatePath(Routes.dashboard.process, { id: ensure0x(election.id) })}>
+                <Icon as={LuInfo} boxSize={4} />
+                <Trans i18nKey='process_context.more_info'>More info</Trans>
+              </RouterLink>
+            </Menu.Item>
+            <Menu.Item value='public-voting-page' asChild>
+              <RouterLink to={generatePath(Routes.processes.view, { id: ensure0x(election.id) })} target='_blank'>
+                <Icon as={LuExternalLink} boxSize={4} />
+                <Trans i18nKey='process_context.public_voting_page'>Public voting page</Trans>
+              </RouterLink>
+            </Menu.Item>
+            <Menu.Item value='explorer' asChild>
+              <a href={`${client.explorerUrl}/process/${election.id}`} target='_blank' rel='noopener noreferrer'>
+                <Icon as={LuSearch} boxSize={4} />
+                <Trans i18nKey='process_context.explorer'>Explorer</Trans>
+              </a>
+            </Menu.Item>
+            <Menu.Item value='clone-draft' onClick={cloneAsDraft}>
+              <Icon as={LuCopy} boxSize={4} />
+              <Trans i18nKey='process_context.clone_as_draft'>Clone as draft</Trans>
+            </Menu.Item>
+          </Menu.Content>
+        </MenuPositioner>
+      </Portal>
     </Menu.Root>
   )
 }

--- a/src/components/Process/Dashboard/use-clone-as-draft.test.ts
+++ b/src/components/Process/Dashboard/use-clone-as-draft.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
-import { InvalidElection, PublishedElection } from '@vocdoni/sdk'
+import { ElectionResultsTypeNames, InvalidElection, PublishedElection } from '@vocdoni/sdk'
 import { mockUseElection } from '~src/test-utils'
 import { setReactProvidersMock } from '~src/test-utils-react-providers-mock'
 import { useCloneAsDraft } from './use-clone-as-draft'
@@ -45,6 +45,7 @@ vi.mock('../Create', () => ({
     maxNumberOfChoices: null,
     minNumberOfChoices: null,
     resultVisibility: 'hidden',
+    weightedVote: false,
     voterPrivacy: 'public',
     groupId: '',
     census: null,
@@ -72,7 +73,13 @@ function createMockElection(
     title: string
     description?: string
     image?: string
-  }>
+  }>,
+  overrides: Partial<
+    PublishedElection & {
+      minNumberOfChoices?: number
+      maxNumberOfChoices?: number
+    }
+  > = {}
 ): PublishedElection {
   return {
     id: '0x1234567890abcdef',
@@ -101,7 +108,12 @@ function createMockElection(
       },
     ],
     electionType: { secretUntilTheEnd: false },
-  } as PublishedElection
+    resultsType: {
+      name: ElectionResultsTypeNames.SINGLE_CHOICE_MULTIQUESTION,
+      properties: {},
+    },
+    ...overrides,
+  } as unknown as PublishedElection
 }
 
 describe('useCloneAsDraft', () => {
@@ -592,6 +604,69 @@ describe('useCloneAsDraft', () => {
         expect(call.metadata.questions).toHaveLength(2)
         expect(call.metadata.questions[0].title).toBe('Question 1')
         expect(call.metadata.questions[1].title).toBe('Question 2')
+      })
+    })
+
+    it('should preserve weighted voting when cloning a weighted election', async () => {
+      mockElection = createMockElection([{ title: 'Option 1' }])
+      mockMutateAsync.mockResolvedValue('draft-123')
+
+      setReactProvidersMock({
+        useElection: () =>
+          mockUseElection({
+            election: mockElection,
+            isWeighted: true,
+            client: { explorerUrl: 'https://explorer.example.com' },
+          }),
+      })
+
+      const { result } = renderHook(() => useCloneAsDraft())
+
+      await act(async () => {
+        await result.current.cloneAsDraft()
+      })
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            metadata: expect.objectContaining({
+              weightedVote: true,
+            }),
+          })
+        )
+      })
+    })
+
+    it('should preserve multi-choice settings and limits when cloning a multi-choice election', async () => {
+      mockElection = createMockElection([{ title: 'Option 1' }, { title: 'Option 2' }, { title: 'Option 3' }], {
+        resultsType: {
+          name: ElectionResultsTypeNames.MULTIPLE_CHOICE,
+          properties: {
+            numChoices: {
+              min: 1,
+              max: 2,
+            },
+          },
+        } as PublishedElection['resultsType'],
+      })
+      mockMutateAsync.mockResolvedValue('draft-123')
+
+      const { result } = renderHook(() => useCloneAsDraft())
+
+      await act(async () => {
+        await result.current.cloneAsDraft()
+      })
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            metadata: expect.objectContaining({
+              questionType: ElectionResultsTypeNames.MULTIPLE_CHOICE,
+              minNumberOfChoices: 1,
+              maxNumberOfChoices: 2,
+            }),
+          })
+        )
       })
     })
   })

--- a/src/components/Process/Dashboard/use-clone-as-draft.ts
+++ b/src/components/Process/Dashboard/use-clone-as-draft.ts
@@ -1,5 +1,5 @@
 import { useElection } from '@vocdoni/react-components'
-import { ensure0x, InvalidElection } from '@vocdoni/sdk'
+import { ElectionResultsTypeNames, ensure0x, InvalidElection } from '@vocdoni/sdk'
 import { useTranslation } from 'react-i18next'
 import { createSearchParams, generatePath, useNavigate } from 'react-router-dom'
 import { useSubscription } from '~components/Auth/Subscription'
@@ -7,13 +7,13 @@ import { useToast } from '~components/Toast'
 import { SubscriptionPermission } from '~constants'
 import { Routes } from '~src/router/routes'
 import { useCreateProcess } from '../Create'
-import { defaultProcessValues } from '../Create/common'
+import { defaultProcessValues, SelectorTypes } from '../Create/common'
 
 export const useCloneAsDraft = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const toast = useToast()
-  const { election } = useElection()
+  const { election, isWeighted } = useElection()
   const createProcess = useCreateProcess()
   const { permission } = useSubscription()
   const limit = permission(SubscriptionPermission.Drafts)
@@ -24,12 +24,27 @@ export const useCloneAsDraft = () => {
     const extendedInfo = election.questions.some((question) =>
       question.choices.some(({ meta }) => meta && (meta.description || meta.image?.default))
     )
+    const questionType =
+      election.resultsType?.name === ElectionResultsTypeNames.MULTIPLE_CHOICE
+        ? SelectorTypes.Multiple
+        : SelectorTypes.Single
+    const choiceLimits = (
+      election.resultsType?.properties as { numChoices?: { min?: number; max?: number } } | undefined
+    )?.numChoices
 
     const metadata = {
       ...defaultProcessValues,
       title: election.title.default,
       description: election.description.default,
       extendedInfo,
+      questionType,
+      minNumberOfChoices: questionType === SelectorTypes.Multiple ? (choiceLimits?.min ?? 0) : null,
+      maxNumberOfChoices:
+        questionType === SelectorTypes.Multiple
+          ? (choiceLimits?.max ?? election.questions[0]?.choices.length ?? null)
+          : null,
+      resultVisibility: election.electionType.secretUntilTheEnd ? ('hidden' as const) : ('live' as const),
+      weightedVote: Boolean(isWeighted),
       questions: election.questions.map((question) => {
         return {
           title: question.title.default,

--- a/src/components/Spreadsheet/Preview.tsx
+++ b/src/components/Spreadsheet/Preview.tsx
@@ -40,7 +40,7 @@ export const CsvPreview = ({ manager, upload }: CsvPreviewProps) => {
             </List.Item>
           ))}
         </List.Root>
-        <Button colorPalette='primary' border='1px solid' flexShrink={0} {...upload}>
+        <Button variant='outline' flexShrink={0} {...upload}>
           {t('form.process_create.spreadsheet.preview.upload_new_list')}
         </Button>
       </AlertDescription>

--- a/src/elements/dashboard/processes/drafts-ui.test.tsx
+++ b/src/elements/dashboard/processes/drafts-ui.test.tsx
@@ -65,6 +65,8 @@ describe('DraftsContextMenu', () => {
 
     expect(screen.getByText('Edit Draft')).toBeInTheDocument()
     expect(container).not.toContainElement(screen.getByText('Edit Draft'))
-    expect(screen.getByText('Delete Draft').closest('[role=\"menuitem\"]')).toHaveAttribute('data-danger')
+    expect(screen.getByText('Delete Draft').closest('[role="menuitem"]')).toHaveStyle({
+      color: 'var(--chakra-colors-fg-error)',
+    })
   })
 })

--- a/src/elements/dashboard/processes/drafts-ui.test.tsx
+++ b/src/elements/dashboard/processes/drafts-ui.test.tsx
@@ -49,7 +49,7 @@ describe('DraftsContextMenu', () => {
   it('renders the edit draft action when opened', async () => {
     const user = userEvent.setup()
 
-    render(
+    const { container } = render(
       <TestMemoryRouter>
         <DraftsContextMenu
           draft={{
@@ -64,5 +64,7 @@ describe('DraftsContextMenu', () => {
     await user.click(trigger)
 
     expect(screen.getByText('Edit Draft')).toBeInTheDocument()
+    expect(container).not.toContainElement(screen.getByText('Edit Draft'))
+    expect(screen.getByText('Delete Draft').closest('[role=\"menuitem\"]')).toHaveAttribute('data-danger')
   })
 })

--- a/src/elements/dashboard/processes/drafts.tsx
+++ b/src/elements/dashboard/processes/drafts.tsx
@@ -9,6 +9,7 @@ import {
   MenuRoot,
   MenuSeparator,
   MenuTrigger,
+  Portal,
   Progress,
   Table,
 } from '@chakra-ui/react'
@@ -215,36 +216,38 @@ export const DraftsContextMenu = ({ draft }: { draft: Draft }) => {
           <Icon as={LuEllipsisVertical} />
         </IconButton>
       </MenuTrigger>
-      <MenuPositioner>
-        <MenuContent>
-          <MenuItem value='edit' asChild>
-            <RouterLink
-              to={{
-                pathname: generatePath(Routes.processes.create),
-                search: createSearchParams({ draftId: draft.id }).toString(),
-              }}
-            >
+      <Portal>
+        <MenuPositioner>
+          <MenuContent>
+            <MenuItem value='edit' asChild>
+              <RouterLink
+                to={{
+                  pathname: generatePath(Routes.processes.create),
+                  search: createSearchParams({ draftId: draft.id }).toString(),
+                }}
+              >
+                <HStack gap={2} align='center'>
+                  <Icon as={LuPencil} boxSize={4} />
+                  <span>{t('drafts.edit', { defaultValue: 'Edit Draft' })}</span>
+                </HStack>
+              </RouterLink>
+            </MenuItem>
+            <MenuItem value='clone' onClick={cloneDraft}>
               <HStack gap={2} align='center'>
-                <Icon as={LuPencil} boxSize={4} />
-                <span>{t('drafts.edit', { defaultValue: 'Edit Draft' })}</span>
+                <Icon as={LuCopy} boxSize={4} />
+                <span>{t('drafts.clone', { defaultValue: 'Clone Draft' })}</span>
               </HStack>
-            </RouterLink>
-          </MenuItem>
-          <MenuItem value='clone' onClick={cloneDraft}>
-            <HStack gap={2} align='center'>
-              <Icon as={LuCopy} boxSize={4} />
-              <span>{t('drafts.clone', { defaultValue: 'Clone Draft' })}</span>
-            </HStack>
-          </MenuItem>
-          <MenuSeparator />
-          <MenuItem value='delete' color='red.400' onClick={deleteDraft}>
-            <HStack gap={2} align='center'>
-              <Icon as={LuTrash} boxSize={4} />
-              <span>{t('drafts.delete', { defaultValue: 'Delete Draft' })}</span>
-            </HStack>
-          </MenuItem>
-        </MenuContent>
-      </MenuPositioner>
+            </MenuItem>
+            <MenuSeparator />
+            <MenuItem value='delete' color='fg.error' onClick={deleteDraft}>
+              <HStack gap={2} align='center'>
+                <Icon as={LuTrash} boxSize={4} />
+                <span>{t('drafts.delete', { defaultValue: 'Delete Draft' })}</span>
+              </HStack>
+            </MenuItem>
+          </MenuContent>
+        </MenuPositioner>
+      </Portal>
     </MenuRoot>
   )
 }

--- a/src/i18n/locales/ca/common.json
+++ b/src/i18n/locales/ca/common.json
@@ -1221,7 +1221,7 @@
     },
     "success_modal": {
       "btn": "Finalitzar",
-      "text": "<p>El teu vot ha estat emès i emmagatzemat de forma segura a la cadena de blocs de Vocdoni. <verify>Pots comprovar-ho aquí</verify>.</p><p>La democràcia és important, la pots compartir amb la teva comunitat i amics:</p>",
+      "text": "<p>El teu vot ha estat emès i emmagatzemat de forma segura amb la tecnologia de Vocdoni. <verify>Pots comprovar-ho aquí</verify>.</p>",
       "title": "Vot emès correctament!"
     },
     "template": {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1199,7 +1199,7 @@
     },
     "success_modal": {
       "btn": "Close",
-      "text": "<p>We've securely processed and stored your vote on our Blockchain. <verify>Verify your vote</verify>.</p>",
+      "text": "<p>Your vote has been securely cast and stored using Vocdoni's technology. <verify>You can verify it here</verify>.</p>",
       "title": "Vote submitted!"
     },
     "template": {

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1221,7 +1221,7 @@
     },
     "success_modal": {
       "btn": "Cerrar",
-      "text": "<p>Hemos procesado y almacenado tu voto de forma segura en nuestra Blockchain. <verify>Verifica tu voto</verify>.</p>",
+      "text": "<p>Tu voto ha sido emitido y almacenado de forma segura con la tecnología de Vocdoni. <verify>Puedes comprobarlo aquí</verify>.</p>",
       "title": "¡Voto enviado!"
     },
     "template": {

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -1221,7 +1221,7 @@
     },
     "success_modal": {
       "btn": "Chiudi",
-      "text": "<p>Abbiamo elaborato e archiviato in modo sicuro il tuo voto sulla nostra Blockchain. <verify>Verifica il tuo voto</verify>.</p>",
+      "text": "<p>Il tuo voto è stato espresso e memorizzato in modo sicuro con la tecnologia di Vocdoni. <verify>Puoi verificarlo qui</verify>.</p>",
       "title": "Voto inviato!"
     },
     "template": {

--- a/src/theme/editor.test.ts
+++ b/src/theme/editor.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import editor from './editor'
+
+describe('editor theme', () => {
+  it('resets lexical paragraph margins for form-like fields', () => {
+    expect(editor['& .lexical-paragraph']).toMatchObject({
+      textStyle: 'sm',
+      margin: 0,
+    })
+  })
+})

--- a/src/theme/editor.ts
+++ b/src/theme/editor.ts
@@ -68,8 +68,8 @@ const editor: SystemStyleObject = {
     fontSize: 'md',
   },
   '& .lexical-paragraph': {
-    fontSize: 'md',
-    lineHeight: '24px',
+    textStyle: 'sm',
+    margin: 0,
   },
 }
 

--- a/src/theme/react-components/election.QuestionsConfirmation.test.tsx
+++ b/src/theme/react-components/election.QuestionsConfirmation.test.tsx
@@ -29,6 +29,25 @@ describe('electionComponents.QuestionsConfirmation', () => {
     expect(screen.getByText('Double check')).toBeInTheDocument()
     expect(screen.getByText(/Abstain/)).toBeInTheDocument()
   })
+
+  it('renders multichoice answers as stacked text without list styling', () => {
+    const { container } = render(
+      <DialogHost>
+        <QuestionsConfirmation
+          election={{ title: { default: 'Election' } } as any}
+          answers={{}}
+          answersView={[{ question: 'Pick toppings', answers: ['Olives', 'Mushrooms'] }]}
+          onConfirm={() => {}}
+          onCancel={() => {}}
+        />
+      </DialogHost>
+    )
+
+    expect(screen.queryByRole('list')).not.toBeInTheDocument()
+    expect(container.querySelectorAll('li')).toHaveLength(0)
+    expect(screen.getByText('Olives')).toBeInTheDocument()
+    expect(screen.getByText('Mushrooms')).toBeInTheDocument()
+  })
 })
 
 function DialogHost({ children }: { children: ReactNode }) {

--- a/src/theme/react-components/election.tsx
+++ b/src/theme/react-components/election.tsx
@@ -356,13 +356,13 @@ export const electionComponents: ComponentsPartialDefinition = {
                     {item.answers.length <= 1 ? (
                       <Text color='texts.subtle'>{item.answers[0] || '-'}</Text>
                     ) : (
-                      <List.Root display='flex' flexDirection='column' gap={1} pl={4} listStyleType='disc'>
+                      <Flex direction='column' gap={1}>
                         {item.answers.map((answer, answerIndex) => (
-                          <List.Item key={`${item.question}-${index}-${answerIndex}`}>
-                            <Text color='texts.subtle'>{answer}</Text>
-                          </List.Item>
+                          <Text key={`${item.question}-${index}-${answerIndex}`} color='texts.subtle'>
+                            {answer}
+                          </Text>
                         ))}
-                      </List.Root>
+                      </Flex>
                     )}
                   </Flex>
                 </Flex>

--- a/src/theme/recipes/election.ts
+++ b/src/theme/recipes/election.ts
@@ -406,6 +406,9 @@ export const QuestionsTypeBadge = defineSlotRecipe({
 export const SpreadsheetAccess = defineSlotRecipe({
   slots: spreadsheetAccessAnatomy,
   base: {
+    button: {
+      w: 'full',
+    },
     close: {
       display: 'none',
     },


### PR DESCRIPTION
closes #1590 

- Cloning a voting process does not retain the voting method configuration (For example, if the original process is set to multiple-choice, the duplicated draft defaults to single-choice and selection limits are not copied)

- Ensure the spacing between the question description and the following element matches the spacing used between other elements in the same card. #ref3

- Make sure that the cards match the style of the cards in the public-facing voting page (e.g. font sizes, the title must be in bold,...). This should apply to the rest of the public-facing voting page and the dashboard. Let's talk properly about it because we should work a bit more in deep so we have a final consistent version. I'll give more instructions. #ref5

-  The spreadsheet "upload again" button (in dashboard) should be outlined, not solid.

- SpreadsheetAccess login button does not share styles with other login buttons (it's not filling the full width)

- Confirm vote modal is weird in multichoice elections (looks good in all other cases).

-  On mobile devices, pagination looks broken with everything in a column, even though it should be in a single row.