### PR TITLE
fix(Process Create): disable canAbstain feature completely

### DIFF
--- a/src/components/Process/Create/index.test.tsx
+++ b/src/components/Process/Create/index.test.tsx
@@ -354,7 +354,7 @@ describe('useFormToElectionMapper', () => {
       expect(election.maxNumberOfChoices).toBe(4)
     })
 
-    it('should set canAbstain to true when minNumberOfChoices is 0', () => {
+    it('should always set canAbstain to false', () => {
       const { result } = renderHook(() => useFormToElectionMapper())
       const mapper = result.current
 
@@ -366,10 +366,10 @@ describe('useFormToElectionMapper', () => {
       }
 
       const election = mapper(form, mockCensus) as MultiChoiceElection
-      expect(election.canAbstain).toBe(true)
+      expect(election.canAbstain).toBe(false)
     })
 
-    it('should set canAbstain to false when minNumberOfChoices is greater than 0', () => {
+    it('should always set canAbstain to false regardless of minNumberOfChoices', () => {
       const { result } = renderHook(() => useFormToElectionMapper())
       const mapper = result.current
 

--- a/src/components/Process/Create/index.tsx
+++ b/src/components/Process/Create/index.tsx
@@ -570,7 +570,7 @@ export const useFormToElectionMapper = () => {
     if (form.questionType === SelectorTypes.Multiple) {
       return MultiChoiceElection.from({
         ...base,
-        canAbstain: form.minNumberOfChoices === 0,
+        canAbstain: false,
         maxNumberOfChoices: form.maxNumberOfChoices > 0 ? form.maxNumberOfChoices : form.questions[0].options.length,
         minNumberOfChoices: form.minNumberOfChoices ?? 0,
       })


### PR DESCRIPTION
- Change canAbstain to always be false in useFormToElectionMapper
- Update tests to reflect the new behavior

The canAbstain feature is confusing and never used, so we're disabling it entirely.

closes #1622 