### PR TITLE
fix(create process): respect extendedInfo flag

### DIFF
--- a/src/components/Process/Create/index.test.tsx
+++ b/src/components/Process/Create/index.test.tsx
@@ -651,6 +651,7 @@ describe('useFormToElectionMapper', () => {
 
       const form: Process = {
         ...mockForm,
+        extendedInfo: true,
         questions: [
           {
             title: 'Question',
@@ -670,6 +671,33 @@ describe('useFormToElectionMapper', () => {
       const choice = election.questions[0].choices[0]
       expect(choice.meta?.description).toBe('Option description')
       expect(choice.meta?.image).toEqual({ default: 'https://example.com/image.png' })
+    })
+
+    it('should NOT include metadata when extendedInfo is false', () => {
+      const { result } = renderHook(() => useFormToElectionMapper())
+      const mapper = result.current
+
+      const form: Process = {
+        ...mockForm,
+        extendedInfo: false,
+        questions: [
+          {
+            title: 'Question',
+            description: 'Description',
+            options: [
+              {
+                option: 'Option without metadata',
+                description: 'This should be ignored',
+                image: 'https://example.com/image.png',
+              },
+            ],
+          },
+        ],
+      }
+
+      const election = mapper(form, mockCensus)
+      const choice = election.questions[0].choices[0]
+      expect(choice.meta).toBeUndefined()
     })
   })
 

--- a/src/components/Process/Create/index.tsx
+++ b/src/components/Process/Create/index.tsx
@@ -539,14 +539,22 @@ export const useFormToElectionMapper = () => {
           ({
             title: { default: question.title },
             description: { default: question.description },
-            choices: question.options.map((q: Option, i: number) => ({
-              title: { default: q.option },
-              value: i,
-              meta: {
-                description: q.description,
-                image: { default: q.image },
-              },
-            })),
+            choices: question.options.map((q: Option, i: number) => {
+              const choice: IQuestion['choices'][number] = {
+                title: { default: q.option },
+                value: i,
+              }
+
+              // Only include meta when extendedInfo is enabled
+              if (form.extendedInfo) {
+                choice.meta = {
+                  description: q.description,
+                  image: { default: q.image },
+                }
+              }
+
+              return choice
+            }),
           }) as IQuestion
       ),
       startDate,


### PR DESCRIPTION
- When extendedInfo is disabled, don't include metadata (description/image) for choices
- This fixes issue #1621 where cloned processes retained extended info even when disabled
- Updated existing test to explicitly set extendedInfo: true
- Added new test to verify empty meta object when extendedInfo is false

closes #1621 