### PR TITLE
fix(pdf): resolve asset paths for react-pdf in tests

### DIFF
--- a/src/components/Process/VotingReportPdf.test.tsx
+++ b/src/components/Process/VotingReportPdf.test.tsx
@@ -259,7 +259,7 @@ describe('VotingReportPdf', () => {
 
     expect(headerChildren[0]).toMatchObject({
       props: {
-        src: '/assets/logo_vocdoni.png',
+        src: `${process.cwd()}/public/assets/logo_vocdoni.png`,
       },
     })
 
@@ -294,7 +294,7 @@ describe('VotingReportPdf', () => {
 
     expect(pageBrandChildren[0]).toMatchObject({
       props: {
-        src: '/assets/vocdoni_icon.png',
+        src: `${process.cwd()}/public/assets/vocdoni_icon.png`,
       },
     })
 

--- a/src/components/Process/VotingReportPdf.tsx
+++ b/src/components/Process/VotingReportPdf.tsx
@@ -8,10 +8,17 @@ import { useTranslation } from 'react-i18next'
 import { LuFileDown } from 'react-icons/lu'
 import { useToast } from '~components/Toast'
 
+import logoImport from '/assets/logo_vocdoni.png'
+import iconImport from '/assets/vocdoni_icon.png'
+
 const { pdf, Document, Image, Page, StyleSheet, Text: PdfText, View } = ReactPDF
 
-const vocdoniLogo = '/assets/logo_vocdoni.png'
-const vocdoniIcon = '/assets/vocdoni_icon.png'
+// @react-pdf/renderer uses Node's fs to read images, so it needs real filesystem paths.
+// In the test environment Vite resolves asset imports to URL strings (e.g. /assets/…)
+// which Node cannot open; use process.cwd() to build the actual path instead.
+const assetBase = import.meta.env.VITEST ? `${process.cwd()}/public` : ''
+const vocdoniLogo = assetBase ? `${assetBase}/assets/logo_vocdoni.png` : logoImport
+const vocdoniIcon = assetBase ? `${assetBase}/assets/vocdoni_icon.png` : iconImport
 
 type VotingReportPdfProps = {
   election?: PublishedElection | InvalidElection | null

--- a/src/importmeta.d.ts
+++ b/src/importmeta.d.ts
@@ -3,6 +3,7 @@ interface ImportMeta {
     NODE_ENV: string
     DEV: boolean
     BASE_URL: string
+    VITEST: true | undefined
     VOCDONI_ENVIRONMENT: string
     CUSTOM_ORGANIZATION_DOMAINS: {
       [key: string]: string


### PR DESCRIPTION
@react-pdf/renderer uses Node's fs to read images and needs real filesystem paths. Vite resolves asset imports to URL strings at runtime (e.g. /assets/logo_vocdoni.png) which Node cannot open via fs.open().

Switch to proper Vite imports (import from '/assets/...') and add a VITEST-gated fallback that builds the absolute path via process.cwd() so the renderer can find the files under public/assets/ during tests.

Update VotingReportPdf.test.tsx assertions to match the resolved paths.