### PR TITLE
fix(docker): set NODE_OPTIONS heap limit for 512MB container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ FROM node:22-slim AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000
+ENV NODE_OPTIONS="--max-old-space-size=328"
 
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/node_modules ./node_modules


### PR DESCRIPTION
| what  | memory  |
|---|---|
|   V8 old space (heap)  |  384MB ← --max-old-space-size  |
|   V8 new space (young gen)  |  ~32MB |
|  Node.js buffers, native bindings, libc  | ~64MB  |
| OS overhead (slim container) | ~32MB|
| **Total** | ~512Mb |