### PR TITLE
fix(theme): allow long SHA vote IDs to wrap in Voted description

### DIFF
--- a/src/theme/react-components/election.tsx
+++ b/src/theme/react-components/election.tsx
@@ -399,9 +399,7 @@ export const electionComponents: ComponentsPartialDefinition = {
       >
         <Alert.Indicator css={styles.icon} />
         <Alert.Title css={styles.title}>{t('vote.voted_title')}</Alert.Title>
-        <Alert.Description truncate maxW='100%' whiteSpace='initial' css={styles.description}>
-          {description}
-        </Alert.Description>
+        <Alert.Description css={styles.description}>{description}</Alert.Description>
       </Alert.Root>
     )
   }),

--- a/src/theme/recipes/election.test.ts
+++ b/src/theme/recipes/election.test.ts
@@ -1,7 +1,13 @@
-import { ElectionResults } from './election'
+import { ElectionResults, Voted } from './election'
 
 describe('ElectionResults recipe', () => {
   it('keeps result questions stacked vertically', () => {
     expect(ElectionResults.base.wrapper.gridTemplateColumns).toBe('1fr')
+  })
+})
+
+describe('Voted recipe', () => {
+  it('allows long SHA vote IDs to wrap in the description', () => {
+    expect(Voted.base.description.overflowWrap).toBe('anywhere')
   })
 })

--- a/src/theme/recipes/election.ts
+++ b/src/theme/recipes/election.ts
@@ -416,6 +416,9 @@ export const SpreadsheetAccess = defineSlotRecipe({
 export const Voted = defineSlotRecipe({
   slots: votedAnatomy,
   base: {
+    description: {
+      overflowWrap: 'anywhere',
+    },
     link: {
       whiteSpace: 'normal',
       overflowWrap: 'anywhere',


### PR DESCRIPTION
## Summary

The `Voted` component's `Alert.Description` had three conflicting CSS props that prevented the vote ID (a long SHA) from wrapping, causing the public-facing voting page to lose its responsive layout:

- `truncate` sets `overflow: hidden; white-space: nowrap; text-overflow: ellipsis`
- `whiteSpace='initial'` overrides the `nowrap` back to browser default — making `text-overflow: ellipsis` impossible to trigger
- `maxW='100%'` gives a percentage width, which doesn't provide a computed pixel value for `overflow: hidden` to clip against in flex containers

The result was `overflow: hidden` active with normal text wrapping, so the SHA overflowed rather than clipping or wrapping cleanly.

The fix removes those three props and adds `overflowWrap: 'anywhere'` to the `Voted` recipe's `description` slot — consistent with the `link` slot which already used this approach.

## Linked issue

Closes #1657

## Changes

- `src/theme/react-components/election.tsx`: remove `truncate maxW='100%' whiteSpace='initial'` from `Alert.Description`; rely on `css={styles.description}` from the recipe instead
- `src/theme/recipes/election.ts`: add `description: { overflowWrap: 'anywhere' }` to the `Voted` recipe base, alongside the existing `link` slot which already had the same property
- `src/theme/recipes/election.test.ts`: add a test asserting the `description` slot carries `overflowWrap: 'anywhere'`

## Tests run

```
pnpm lint   → tsc + prettier: all passed
pnpm test   → 112 test files, 425 passed, 2 skipped
pnpm build  → ✓ built in ~900ms
```

## Risks and review focus

Low risk — purely presentational change scoped to one slot in one recipe. The `Voted` component is only rendered after a successful vote submission. No logic, state, or API interactions are touched. The `overflowWrap: 'anywhere'` value matches what the `link` slot already uses, so the SHA content inside the `<a>` element renders consistently with its anchor.

## Notes for maintainers

The `link` slot in the `Voted` recipe already had `overflowWrap: 'anywhere'` and `whiteSpace: 'normal'`, but those styles were never surfacing because the parent `Alert.Description` had `overflow: hidden` (from `truncate`) suppressing the child layout. Removing the conflicting props from the component and adding the same property to the `description` slot fixes both levels.
