### PR TITLE
chore(layout): remove SDK and Developer Portal links from footer

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+store-dir=/root/.pnpm-store

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-store-dir=/root/.pnpm-store

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -69,25 +69,6 @@ const Footer = ({ simplified }: { simplified?: boolean }) => {
               <Link
                 fontWeight='bold'
                 variant='footer'
-                href='https://developer.vocdoni.io/sdk'
-                target='_blank'
-                rel='noopener noreferrer'
-              >
-                SDK
-              </Link>
-              <Link
-                fontWeight='bold'
-                variant='footer'
-                href='https://developer.vocdoni.io'
-                whiteSpace='nowrap'
-                target='_blank'
-                rel='noopener noreferrer'
-              >
-                {t('footer.developer_portal')}
-              </Link>
-              <Link
-                fontWeight='bold'
-                variant='footer'
                 href='https://blog.vocdoni.io'
                 target='_blank'
                 rel='noopener noreferrer'

--- a/src/i18n/locales/ca/common.json
+++ b/src/i18n/locales/ca/common.json
@@ -362,7 +362,6 @@
   "footer": {
     "company": "Empresa",
     "contact": "Contacte",
-    "developer_portal": "Portal de Desenvolupadors",
     "footer_subtitle": "El Protocol de Votació Global",
     "terms_and_privacy": "<link1>Termes d'ús</link1> i <link2>Política de privacitat</link2>"
   },

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -359,7 +359,6 @@
   "footer": {
     "company": "Company",
     "contact": "Contact",
-    "developer_portal": "Developer Portal",
     "footer_subtitle": "The Global Voting Protocol",
     "terms_and_privacy": "<link1>Terms of use</link1> & <link2>Privacy Policy</link2>"
   },

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -362,7 +362,6 @@
   "footer": {
     "company": "Compañía",
     "contact": "Contacto",
-    "developer_portal": "Portal de desarrolladores",
     "footer_subtitle": "El protocolo global de votación",
     "terms_and_privacy": "<link1>Términos de uso</link1> y <link2>Política de privacidad</link2>"
   },

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -362,7 +362,6 @@
   "footer": {
     "company": "Azienda",
     "contact": "Contatti",
-    "developer_portal": "Portale sviluppatori",
     "footer_subtitle": "Il protocollo di voto globale",
     "terms_and_privacy": "<link1>Termini d'uso</link1> & <link2>Privacy Policy</link2>"
   },


### PR DESCRIPTION
## Summary

Remove the `SDK` and `Developer Portal` links from the footer component until the redesigned footer is ready. All other footer links (Vocdoni, Contact, Blog, social icons, terms/privacy) remain unchanged.

## Linked issue

Closes #1655

## Changes

- **`src/components/Layout/Footer.tsx`**: Removed the `SDK` and `Developer Portal` `<Link>` elements from the footer. The surrounding layout (Vocdoni, Contact, Blog links) is unaffected.
- **`src/i18n/locales/{en,es,ca,it}/common.json`**: Removed the unused `footer.developer_portal` translation key from all four locale files.

## Tests run

- `pnpm lint` — TypeScript and Prettier checks pass.
- `pnpm test` — all Vitest tests pass.
- `pnpm translations` — locale extraction confirms no dangling keys remain.

## Risks and review focus

- Verify the footer renders correctly with the remaining three links (Vocdoni, Contact, Blog) and that no layout gaps or separator artifacts appear.

## Notes for maintainers

- The `SDK` link used a hardcoded string rather than an i18n key, so only `developer_portal` needed cleanup in the locale files.
- The `.npmrc` file in this diff (`store-dir=/root/.pnpm-store`) is a CI environment artifact and should be excluded from the merge or added to `.gitignore` if it was committed unintentionally.