### PR TITLE
fix(explorer): pin the dev explorer URL to the one-dev network

### DIFF
--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -84,6 +84,13 @@ const LocalizedProviders = ({ initialLanguage }: { initialLanguage: string }) =>
       const normalized = normalizePublicLanguageCandidate(next, supportedLanguages)
       if (!normalized) return
 
+      // Re-selecting the active language is a no-op; avoids a duplicate history entry.
+      const currentUrlLanguage = normalizePublicLanguageCandidate(
+        window.location.pathname.split('/')[1] ?? '',
+        supportedLanguages
+      )
+      if (normalized === currentUrlLanguage) return
+
       persistPublicLanguagePreferenceClient(normalized, {
         supportedLanguages,
         storage: window.localStorage,
@@ -94,12 +101,15 @@ const LocalizedProviders = ({ initialLanguage }: { initialLanguage: string }) =>
 
       // Swap the visible URL language prefix without navigating/reloading; the
       // basename change below re-points the router at the already-updated URL.
+      // Use pushState (not replaceState) so the switch is a real history entry the
+      // user can navigate back from — the popstate listener above re-syncs the
+      // language from the URL on back/forward.
       const target = localizePublicPath({
         pathname: window.location.pathname,
         language: normalized,
         supportedLanguages,
       })
-      window.history.replaceState(window.history.state, '', `${target}${window.location.search}${window.location.hash}`)
+      window.history.pushState(null, '', `${target}${window.location.search}${window.location.hash}`)
 
       setLanguageState(normalized)
     },

--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -1,6 +1,6 @@
 import { Signer } from '@ethersproject/abstract-signer'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { ComponentsProvider } from '@vocdoni/react-components'
+import { ComponentsProvider, useClient } from '@vocdoni/react-components'
 import { setDefaultOptions } from 'date-fns'
 import { PropsWithChildren, useCallback, useEffect, useMemo, useState } from 'react'
 import { I18nextProvider, useTranslation } from 'react-i18next'
@@ -178,12 +178,31 @@ const SaasProviders = ({ children }: PropsWithChildren<{}>) => (
   </AuthProvider>
 )
 
+// ClientOptions has no explorerUrl field, so the dev explorer override resolved
+// in getVocdoniClientConfig can't be passed to ClientProvider. Apply it onto the
+// provider's client instance (the one the "Open in explorer" links read via
+// useClient) after creation, mirroring createVocdoniSdkClient.
+const ExplorerUrlSync = ({ explorerUrl }: { explorerUrl?: string }) => {
+  const { client } = useClient()
+
+  useEffect(() => {
+    if (explorerUrl && client) {
+      client.explorerUrl = explorerUrl
+    }
+  }, [client, explorerUrl])
+
+  return null
+}
+
 const AppRuntimeProviders = ({ children }: PropsWithChildren) => {
   const { data } = useWalletClient()
   const { i18n } = useTranslation()
   const { VOCDONI_ENVIRONMENT } = useAppEnv()
   const locale = datesLocale(i18n.language)
-  const { clientEnv, options } = useMemo(() => getVocdoniClientConfig(VOCDONI_ENVIRONMENT), [VOCDONI_ENVIRONMENT])
+  const { clientEnv, options, explorerUrl } = useMemo(
+    () => getVocdoniClientConfig(VOCDONI_ENVIRONMENT),
+    [VOCDONI_ENVIRONMENT]
+  )
 
   const signer = data ? walletClientToSigner(data) : null
 
@@ -195,6 +214,7 @@ const AppRuntimeProviders = ({ children }: PropsWithChildren) => {
     <RainbowKitTheme>
       <ComponentsProvider components={uiScaffoldComponents}>
         <ClientProvider env={clientEnv} signer={signer as Signer} options={options}>
+          <ExplorerUrlSync explorerUrl={explorerUrl} />
           <ConnectionToastProvider>
             <SaasProviders>
               <AnalyticsProvider>

--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -2,7 +2,7 @@ import { Signer } from '@ethersproject/abstract-signer'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ComponentsProvider } from '@vocdoni/react-components'
 import { setDefaultOptions } from 'date-fns'
-import { PropsWithChildren, useEffect, useMemo, useState } from 'react'
+import { PropsWithChildren, useCallback, useEffect, useMemo, useState } from 'react'
 import { I18nextProvider, useTranslation } from 'react-i18next'
 import { usePageContext } from 'vike-react/usePageContext'
 import { useWalletClient, WagmiProvider } from 'wagmi'
@@ -12,8 +12,15 @@ import { UnauthorizedApiError } from '~components/Auth/api'
 import { AuthProvider } from '~components/Auth/AuthContext'
 import { SubscriptionProvider } from '~components/Auth/Subscription'
 import { CookieConsent } from '~components/Cookies/CookieConsent'
+import { hasAcceptedCookieConsent } from '~components/Cookies/utils'
 import { ConnectionToastProvider } from '~components/Layout/ConnectionToast'
 import { walletClientToSigner } from '~constants/wagmi-adapters'
+import { LanguageRoutingContext } from '~i18n/LanguageRoutingContext'
+import {
+  localizePublicPath,
+  normalizePublicLanguageCandidate,
+  persistPublicLanguagePreferenceClient,
+} from '~i18n/public-language'
 import { uiScaffoldComponents } from '~theme/react-components'
 import { AppEnvProvider, normalizeLanguages, useAppEnv } from './app-env'
 import { buildAppEnv } from './app-env-build'
@@ -39,11 +46,76 @@ export const createAppQueryClient = () =>
     },
   })
 
-export const Providers = ({ basename, language }: { basename?: string; language?: string } = {}) => (
-  <AppProviders language={language}>
-    <RoutesProvider basename={basename} />
-  </AppProviders>
-)
+export const Providers = ({ basename, language }: { basename?: string; language?: string } = {}) =>
+  language ? (
+    // Localized (Vike `/:lang/...` catch-all) entry: language lives in client
+    // state so it can be switched in place without a full page reload.
+    <LocalizedProviders initialLanguage={language} />
+  ) : (
+    // Non-localized entry (e.g. the legacy SPA mount): keep the previous behavior.
+    <AppProviders>
+      <RoutesProvider basename={basename} />
+    </AppProviders>
+  )
+
+const LocalizedProviders = ({ initialLanguage }: { initialLanguage: string }) => {
+  const pageContext = usePageContext()
+  const appEnv = pageContext?.globalContext?.appEnv ?? buildAppEnv({})
+  const supportedLanguages = useMemo(() => Object.keys(normalizeLanguages(appEnv.LANGUAGES)), [appEnv.LANGUAGES])
+
+  const [language, setLanguageState] = useState(initialLanguage)
+
+  // Keep the active language in sync with the URL on browser back/forward across
+  // localized prefixes, so the router basename and i18n follow the address bar.
+  useEffect(() => {
+    const sync = () => {
+      const urlLanguage = normalizePublicLanguageCandidate(
+        window.location.pathname.split('/')[1] ?? '',
+        supportedLanguages
+      )
+      if (urlLanguage) setLanguageState(urlLanguage)
+    }
+    window.addEventListener('popstate', sync)
+    return () => window.removeEventListener('popstate', sync)
+  }, [supportedLanguages])
+
+  const setLanguage = useCallback(
+    (next: string) => {
+      const normalized = normalizePublicLanguageCandidate(next, supportedLanguages)
+      if (!normalized) return
+
+      persistPublicLanguagePreferenceClient(normalized, {
+        supportedLanguages,
+        storage: window.localStorage,
+        cookieEnabled: hasAcceptedCookieConsent(),
+        document,
+        location: window.location,
+      })
+
+      // Swap the visible URL language prefix without navigating/reloading; the
+      // basename change below re-points the router at the already-updated URL.
+      const target = localizePublicPath({
+        pathname: window.location.pathname,
+        language: normalized,
+        supportedLanguages,
+      })
+      window.history.replaceState(window.history.state, '', `${target}${window.location.search}${window.location.hash}`)
+
+      setLanguageState(normalized)
+    },
+    [supportedLanguages]
+  )
+
+  const routingValue = useMemo(() => ({ language, setLanguage }), [language, setLanguage])
+
+  return (
+    <LanguageRoutingContext.Provider value={routingValue}>
+      <AppProviders language={language}>
+        <RoutesProvider basename={`/${language}`} />
+      </AppProviders>
+    </LanguageRoutingContext.Provider>
+  )
+}
 
 export const AppProviders = ({
   children,
@@ -61,6 +133,12 @@ export const AppProviders = ({
 
   const [client] = useState(() => queryClient ?? createAppQueryClient())
 
+  // The i18n instance is created once (seeded with the initial language) and is
+  // NOT recreated when the language changes — otherwise every language switch
+  // would remount the whole provider tree and drop the query cache. Subsequent
+  // changes go through i18n.changeLanguage in the effect below, which re-renders
+  // translated components in place. `language` is intentionally omitted from the
+  // deps for this reason.
   const i18nInstance = useMemo(() => {
     const supportedLanguages = Object.keys(normalizeLanguages(appEnv.LANGUAGES))
     const languageOptions = { supportedLanguages, fallbackLanguage: supportedLanguages[0] }
@@ -68,7 +146,14 @@ export const AppProviders = ({
     if (!language) return getBaseI18n(languageOptions)
 
     return createPageI18nInstance(language, languageOptions)
-  }, [language, appEnv.LANGUAGES])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [appEnv.LANGUAGES])
+
+  useEffect(() => {
+    if (language && i18nInstance.language !== language) {
+      i18nInstance.changeLanguage(language)
+    }
+  }, [language, i18nInstance])
 
   return (
     <AppEnvProvider value={appEnv}>

--- a/src/components/Navbar/LanguagesList.tsx
+++ b/src/components/Navbar/LanguagesList.tsx
@@ -49,25 +49,35 @@ export const LanguagesList = ({
   const { navigateToLanguage, currentLanguage } = usePublicLanguageRouting({ publicLanguageLinks })
 
   const languages = useLanguagesEnv()
-  const languageEntries = Object.entries(languages).sort(([, a], [, b]) => a.localeCompare(b))
+  // Sort by language code rather than label: the labels are native names, so a
+  // non-Latin script like Greek ('Ελληνικά') would always collate to the end.
+  // The code ('el') keeps it within the Latin alphabet ordering instead.
+  const languageEntries = Object.entries(languages).sort(([a], [b]) => a.localeCompare(b))
 
   return (
     <>
-      {languageEntries.map(([k]) => (
-        <MenuItem
-          key={k}
-          value={k}
-          onClick={() => void navigateToLanguage(k)}
-          closeOnSelect={closeOnSelect}
-          w='full'
-          display='flex'
-          justifyContent={closeOnSelect ? 'center' : 'start'}
-          fontWeight={k === currentLanguage ? 'bold' : ''}
-          borderRadius='none'
-        >
-          {k.toUpperCase()}
-        </MenuItem>
-      ))}
+      {languageEntries.map(([k, label]) => {
+        // Case-insensitive so a region-variant active language (e.g. 'pt-BR')
+        // still matches its 'pt-br' key.
+        const isSelected = k.toLowerCase() === currentLanguage?.toLowerCase()
+
+        return (
+          <MenuItem
+            key={k}
+            value={k}
+            onClick={() => void navigateToLanguage(k)}
+            closeOnSelect={closeOnSelect}
+            w='full'
+            display='flex'
+            justifyContent='start'
+            fontWeight={isSelected ? 'bold' : ''}
+            bg={isSelected ? 'bg.emphasized' : undefined}
+            borderRadius='none'
+          >
+            {label}
+          </MenuItem>
+        )
+      })}
     </>
   )
 }
@@ -83,7 +93,7 @@ export const LanguagesMenu = ({ publicLanguageLinks, ...props }: { publicLanguag
   }
 
   return (
-    <MenuRoot onOpenChange={({ open }) => setIsOpen(open)}>
+    <MenuRoot positioning={{ placement: 'bottom-end' }} onOpenChange={({ open }) => setIsOpen(open)}>
       <MenuTrigger asChild>
         <Button
           aria-label={t('menu.burger_aria_label')}
@@ -98,7 +108,7 @@ export const LanguagesMenu = ({ publicLanguageLinks, ...props }: { publicLanguag
         </Button>
       </MenuTrigger>
       <MenuPositioner>
-        <MenuContent minW={16} mt={2}>
+        <MenuContent minW={16} mt={2} maxH='15rem' overflowY='auto'>
           <LanguagesList closeOnSelect={true} publicLanguageLinks={publicLanguageLinks} />
         </MenuContent>
       </MenuPositioner>
@@ -135,9 +145,12 @@ export const LanguageListDashboard = ({ ...props }) => {
       value: key,
       label,
     }))
-    .sort((a, b) => a.label.localeCompare(b.label))
+    // Sort by code, not label, so non-Latin native names (e.g. Greek 'Ελληνικά')
+    // collate within the alphabet instead of being pushed to the end.
+    .sort((a, b) => a.value.localeCompare(b.value))
 
   const selectedLanguage = languageOptions.find((opt) => opt.value === i18n.language)
+  const longestLabelLength = languageOptions.reduce((max, opt) => Math.max(max, opt.label.length), 0)
 
   return (
     <FormControl w='full' display='flex' justifyContent='space-between' alignItems='center' flexDir='row' {...props}>
@@ -159,7 +172,7 @@ export const LanguageListDashboard = ({ ...props }) => {
         placeholder={t('form.choose_an_option', { defaultValue: 'Choose an option' })}
         menuPlacement='top'
         formatOptionLabel={LanguageOptionLabel}
-        chakraStyles={languagesListSelectStyles}
+        chakraStyles={languagesListSelectStyles(longestLabelLength)}
       />
     </FormControl>
   )

--- a/src/components/Navbar/LanguagesList.tsx
+++ b/src/components/Navbar/LanguagesList.tsx
@@ -18,7 +18,6 @@ import { FaGlobeAmericas } from 'react-icons/fa'
 import { LuCheck } from 'react-icons/lu'
 import { RiArrowDownSLine, RiArrowUpSLine } from 'react-icons/ri'
 import { Select } from '~components/Form/Select'
-import i18n from '~i18n'
 import { navigateToPublicLanguage, usePublicLanguageRouting } from '~i18n/usePublicLanguageRouting'
 import { useLanguagesEnv } from '~src/app-env'
 import { languagesListSelectStyles } from '~theme/selectStyles'
@@ -120,20 +119,24 @@ interface LanguageOption {
   label: string
 }
 
-const LanguageOptionLabel = ({ value, label }, { context }) => {
-  const isSelected = value === i18n.language
-
-  return (
-    <Flex alignItems='center' gap={2} w='full' px={1}>
-      {context === 'menu' && (
-        <Box w='1rem' display='flex' alignItems='center' justifyContent='center'>
-          {isSelected && <Icon as={LuCheck} boxSize='3' />}
-        </Box>
-      )}
-      <Text w='full'>{label}</Text>
-    </Flex>
-  )
-}
+const LanguageOptionLabel = ({
+  label,
+  isSelected,
+  context,
+}: {
+  label: string
+  isSelected: boolean
+  context?: string
+}) => (
+  <Flex alignItems='center' gap={2} w='full' px={1}>
+    {context === 'menu' && (
+      <Box w='1rem' display='flex' alignItems='center' justifyContent='center'>
+        {isSelected && <Icon as={LuCheck} boxSize='3' />}
+      </Box>
+    )}
+    <Text w='full'>{label}</Text>
+  </Flex>
+)
 
 export const LanguageListDashboard = ({ ...props }) => {
   const { t, i18n } = useTranslation()
@@ -171,7 +174,15 @@ export const LanguageListDashboard = ({ ...props }) => {
         size='sm'
         placeholder={t('form.choose_an_option', { defaultValue: 'Choose an option' })}
         menuPlacement='top'
-        formatOptionLabel={LanguageOptionLabel}
+        formatOptionLabel={(option: LanguageOption, meta) => (
+          // Compare against the active (hook) i18n language so the checkmark
+          // follows in-place language switches, not the base i18n instance.
+          <LanguageOptionLabel
+            label={option.label}
+            isSelected={option.value === i18n.language}
+            context={meta.context}
+          />
+        )}
         chakraStyles={languagesListSelectStyles(longestLabelLength)}
       />
     </FormControl>

--- a/src/components/Process/Create/index.tsx
+++ b/src/components/Process/Create/index.tsx
@@ -14,7 +14,7 @@ import {
   Text,
   VStack,
 } from '@chakra-ui/react'
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLocalStorage } from '@uidotdev/usehooks'
 import { useClient, useOrganization } from '@vocdoni/react-components'
 import {
@@ -58,6 +58,7 @@ import { Web3Address } from '~components/Process/Census/Web3'
 import { useToast } from '~components/Toast'
 import { SubscriptionPermission } from '~constants'
 import { useDeleteDraft } from '~elements/dashboard/processes/drafts'
+import { QueryKeys } from '~queries/keys'
 import { Routes } from '~routes'
 import { SetupStepIds, useOrganizationSetup } from '~src/queries/organization'
 import { AnalyticsEvents } from '~utils/analytics'
@@ -626,6 +627,7 @@ const ProcessCreateView = () => {
   const openConfirmationModal = () => setLeaveConfirmationOpen(true)
   const { organization } = useOrganization()
   const { client } = useClient()
+  const queryClient = useQueryClient()
   const { isSubmitting, isSubmitSuccessful, isDirty } = methods.formState
   const { setStepDoneAsync } = useOrganizationSetup()
   const processBundleMutation = useProcessBundle()
@@ -821,6 +823,17 @@ const ProcessCreateView = () => {
       }
 
       await setStepDoneAsync(SetupStepIds.firstVoteCreation)
+
+      // Drop the cached elections pages so the processes index reflects the new
+      // vote without a full page refresh. The index loads through a route loader
+      // backed by ensureQueryData, which returns cached data without refetching
+      // when it is merely marked stale — so invalidateQueries isn't enough here.
+      // Removing the entries forces the loader to fetch fresh data on its next
+      // navigation. The key omits the pagination params so every paginated/status
+      // variant is evicted.
+      queryClient.removeQueries({
+        queryKey: QueryKeys.organization.elections(account.address),
+      })
 
       trackPlausibleEvent({ name: AnalyticsEvents.ProcessCreated })
 

--- a/src/elements/PublicPage.title.test.tsx
+++ b/src/elements/PublicPage.title.test.tsx
@@ -59,7 +59,13 @@ describe('SSR public pages title handling', () => {
   it('does not mutate document.title when rendering the process SSR page', () => {
     document.title = 'Initial title'
 
-    render(<PublicProcessPage election={new PublishedElection({} as any)} organization={{ address: '0xabc' } as any} />)
+    render(
+      <PublicProcessPage
+        id='0x0'
+        election={new PublishedElection({} as any)}
+        organization={{ address: '0xabc' } as any}
+      />
+    )
 
     expect(screen.getByText('process-view')).toBeInTheDocument()
     expect(screen.getByText('legal-notice')).toBeInTheDocument()

--- a/src/elements/dashboard/processes/view.tsx
+++ b/src/elements/dashboard/processes/view.tsx
@@ -22,6 +22,7 @@ const DashboardProcessViewElement = () => {
     <OrganizationProvider id={election.organizationId}>
       <ElectionProvider
         election={election}
+        id={election.id}
         fetchCensus
         queryOptions={{
           refetchInterval: 15_000,

--- a/src/elements/processes/PublicPage.tsx
+++ b/src/elements/processes/PublicPage.tsx
@@ -5,11 +5,12 @@ import { ProcessView as ProcessViewComponent } from '~components/Process/View'
 import type { OrganizationData } from '~src/ssr/public-pages'
 
 type PublicProcessPageProps = {
+  id: string
   election: PublishedElection
   organization?: OrganizationData
 }
 
-const PublicProcessPage = ({ election, organization }: PublicProcessPageProps) => {
+const PublicProcessPage = ({ id, election, organization }: PublicProcessPageProps) => {
   const organizationProviderProps = organization
     ? { organization: organization as any }
     : { id: election.organizationId }
@@ -18,9 +19,13 @@ const PublicProcessPage = ({ election, organization }: PublicProcessPageProps) =
     <OrganizationProvider {...organizationProviderProps}>
       <ElectionProvider
         election={election}
+        // The election comes from Vike SSR serialization, which drops the SDK's
+        // `id` getter (only `_id` survives), so `election.id` is undefined here.
+        // Use the route-param id so the provider query is enabled and refetches.
+        id={id}
         fetchCensus
         queryOptions={{
-          refetchInterval: 15_000,
+          refetchInterval: 30_000,
         }}
       >
         <ProcessViewComponent />

--- a/src/elements/processes/PublicSummary.tsx
+++ b/src/elements/processes/PublicSummary.tsx
@@ -5,11 +5,12 @@ import { ProcessSummary as ProcessSummaryComponent } from '~components/Process/S
 import type { OrganizationData } from '~src/ssr/public-pages'
 
 type PublicProcessSummaryViewProps = {
+  id: string
   election: PublishedElection
   organization?: OrganizationData
 }
 
-const PublicProcessSummaryView = ({ election, organization }: PublicProcessSummaryViewProps) => {
+const PublicProcessSummaryView = ({ id, election, organization }: PublicProcessSummaryViewProps) => {
   const organizationProviderProps = organization
     ? { organization: organization as any }
     : { id: election.organizationId }
@@ -18,6 +19,10 @@ const PublicProcessSummaryView = ({ election, organization }: PublicProcessSumma
     <OrganizationProvider {...organizationProviderProps}>
       <ElectionProvider
         election={election}
+        // The election comes from Vike SSR serialization, which drops the SDK's
+        // `id` getter (only `_id` survives), so `election.id` is undefined here.
+        // Use the route-param id so the provider query is enabled and refetches.
+        id={id}
         queryOptions={{
           refetchInterval: 30_000,
         }}

--- a/src/elements/processes/view.tsx
+++ b/src/elements/processes/view.tsx
@@ -5,7 +5,9 @@ import PublicProcessPage from './PublicPage'
 const Process = () => {
   const election = useLoaderData() as PublishedElection
 
-  return <PublicProcessPage election={election} />
+  // From a react-router loader the election is a live PublishedElection instance,
+  // so its `id` getter works here (unlike the Vike SSR-serialized path).
+  return <PublicProcessPage id={election.id} election={election} />
 }
 
 export default Process

--- a/src/i18n/LanguageRoutingContext.ts
+++ b/src/i18n/LanguageRoutingContext.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react'
+
+export type LanguageRoutingContextValue = {
+  /** The currently active language driving i18n and the router basename. */
+  language: string
+  /**
+   * Switches the language without a full page reload. Used on client-rendered
+   * (react-router) routes: it changes i18n, updates the URL language prefix via
+   * the history API and swaps the router basename in place. Vike SSR public
+   * pages keep navigating (reloading) because the server renders the localized
+   * content — see usePublicLanguageRouting.
+   */
+  setLanguage: (language: string) => void
+}
+
+export const LanguageRoutingContext = createContext<LanguageRoutingContextValue | null>(null)
+
+export const useLanguageRouting = () => useContext(LanguageRoutingContext)

--- a/src/i18n/usePublicLanguageRouting.ts
+++ b/src/i18n/usePublicLanguageRouting.ts
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { hasAcceptedCookieConsent } from '~components/Cookies/utils'
 import { useLanguagesEnv } from '~src/app-env'
+import { useLanguageRouting } from './LanguageRoutingContext'
 import { localizePublicPath, persistPublicLanguagePreferenceClient } from './public-language'
 
 const defaultNavigate = (url: string) => window.location.assign(url)
@@ -61,16 +62,30 @@ export const usePublicLanguageRouting = ({
 } = {}) => {
   const { i18n } = useTranslation()
   const supportedLanguages = Object.keys(useLanguagesEnv())
+  const languageRouting = useLanguageRouting()
 
   return {
     currentLanguage: i18n.language,
-    navigateToLanguage: (language: string) =>
-      navigateToPublicLanguage({
+    navigateToLanguage: (language: string) => {
+      const hasPublicLink = Boolean(publicLanguageLinks?.[language])
+
+      // Client-rendered (react-router) routes switch in place, without a full
+      // page reload. Fall back to a localized URL navigation when the target is
+      // a Vike SSR public page (its server must re-render the localized content),
+      // when an explicit navigate override is given (e.g. tests), or when there
+      // is no routing context available.
+      if (languageRouting && !hasPublicLink && !navigate) {
+        languageRouting.setLanguage(language)
+        return
+      }
+
+      return navigateToPublicLanguage({
         language,
         supportedLanguages,
         publicLanguageLinks,
         navigate,
         changeLanguage: i18n.changeLanguage.bind(i18n),
-      }),
+      })
+    },
   }
 }

--- a/src/pages/@lang/@catchAll/+Page.tsx
+++ b/src/pages/@lang/@catchAll/+Page.tsx
@@ -10,5 +10,7 @@ export default function Page() {
     pathname: pageContext.urlPathname,
   })
 
-  return <Providers language={language} basename={`/${language}`} />
+  // Providers derives the router basename from the language and keeps it in
+  // client state so it can be switched in place without a full reload.
+  return <Providers language={language} />
 }

--- a/src/pages/shared/PublicProcessPage.tsx
+++ b/src/pages/shared/PublicProcessPage.tsx
@@ -32,7 +32,7 @@ export default function PublicProcessPage() {
         enableChat={false}
         showDashboardButton={false}
       >
-        <PublicProcessView election={data.election} organization={data.organization} />
+        <PublicProcessView id={data.id} election={data.election} organization={data.organization} />
       </PublicLayout>
     </AppProviders>
   )

--- a/src/pages/shared/PublicProcessSummaryPage.tsx
+++ b/src/pages/shared/PublicProcessSummaryPage.tsx
@@ -32,7 +32,7 @@ export default function PublicProcessSummaryPage() {
         enableChat={false}
         showDashboardButton={false}
       >
-        <PublicProcessSummaryView election={data.election} organization={data.organization} />
+        <PublicProcessSummaryView id={data.id} election={data.election} organization={data.organization} />
       </PublicLayout>
     </AppProviders>
   )

--- a/src/providers/vocdoni-client-config.test.ts
+++ b/src/providers/vocdoni-client-config.test.ts
@@ -17,6 +17,7 @@ describe('getVocdoniClientConfig', () => {
       options: {
         api_url: 'https://one-dev.vocdoni.net/v2',
       },
+      explorerUrl: 'https://one-dev.explorer.vote',
     })
   })
 })

--- a/src/providers/vocdoni-client-config.ts
+++ b/src/providers/vocdoni-client-config.ts
@@ -7,19 +7,31 @@ export const getVocdoniClientConfig = (environment: string = 'dev') => {
   const normalizedEnvironment = environment.toLowerCase()
   const clientEnv: EnvOptions = normalizedEnvironment === 'prod' ? EnvOptions.PROD : EnvOptions.DEV
   const options: { api_url?: string } = {}
+  let explorerUrl: string | undefined
 
   if (clientEnv === EnvOptions.DEV) {
     options.api_url = 'https://one-dev.vocdoni.net/v2'
+    // The SDK defaults the dev explorer to https://dev.explorer.vote, which does
+    // not know about the one-dev (vocone) network we point the api_url to. Pin it
+    // to the matching one-dev explorer so links resolve instead of returning
+    // "election not found".
+    explorerUrl = 'https://one-dev.explorer.vote'
   }
 
-  return { clientEnv, options }
+  return { clientEnv, options, explorerUrl }
 }
 
 export const createVocdoniSdkClient = (environment?: string) => {
-  const { clientEnv, options } = getVocdoniClientConfig(environment)
+  const { clientEnv, options, explorerUrl } = getVocdoniClientConfig(environment)
 
-  return new VocdoniSDKClient({
+  const client = new VocdoniSDKClient({
     env: clientEnv,
     ...options,
   })
+
+  if (explorerUrl) {
+    client.explorerUrl = explorerUrl
+  }
+
+  return client
 }

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { useAuthRoutes, useCreateOrganizationRoutes } from './routes/auth'
 import { useDashboardRoutes } from './routes/dashboard'
@@ -11,9 +12,18 @@ export const RoutesProvider = ({ basename }: { basename?: string }) => {
   const dashboard = useDashboardRoutes()
   const createOrganizationRoute = useCreateOrganizationRoutes()
 
-  const router = createBrowserRouter([home, root, auth, dashboard, createOrganizationRoute], {
-    basename: basename ?? import.meta.env.BASE_URL,
-  })
+  const resolvedBasename = basename ?? import.meta.env.BASE_URL
 
-  return <RouterProvider router={router} future={{ v7_startTransition: true }} />
+  // Recreate the router only when the basename (language prefix) changes, so a
+  // language switch swaps it in place instead of forcing a full reload. The
+  // route trees are static, so capturing them once on (re)creation is intended.
+  const router = useMemo(
+    () => createBrowserRouter([home, root, auth, dashboard, createOrganizationRoute], { basename: resolvedBasename }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [resolvedBasename]
+  )
+
+  // Key by basename: RouterProvider ignores a changed `router` prop, so remount
+  // it when the language prefix changes to adopt the new basename.
+  return <RouterProvider key={resolvedBasename} router={router} future={{ v7_startTransition: true }} />
 }

--- a/src/theme/react-components/election.tsx
+++ b/src/theme/react-components/election.tsx
@@ -28,7 +28,7 @@ import {
   useSlotRecipe,
 } from '@chakra-ui/react'
 import { type ComponentsPartialDefinition, defineComponent } from '@vocdoni/react-components'
-import { ChangeEvent, useState } from 'react'
+import { ChangeEvent, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FaCircleCheck } from 'react-icons/fa6'
 import { Markdown } from '~components/ui/Markdown'
@@ -129,19 +129,35 @@ export const electionComponents: ComponentsPartialDefinition = {
       const styles = recipe({ layout, context })
       const [isOpen, setIsOpen] = useState(false)
       const [loaded, setLoaded] = useState(false)
+      const imageRef = useRef<HTMLImageElement>(null)
 
       const imageDefault = image?.default
       const imageThumbnail = image?.thumbnail ?? imageDefault
       const hasImage = Boolean(imageThumbnail)
 
+      // An image can already be fully loaded before React attaches `onLoad` — it
+      // happens with cached responses and, on SSR pages, with images the browser
+      // started fetching from the server-rendered markup before hydration. In
+      // those cases `onLoad` never fires, leaving the Skeleton overlay covering an
+      // image that is actually present (matching the "url is there, hovering shows
+      // it, but it stays grey" reports). Reconcile against the DOM `complete` flag.
+      useEffect(() => {
+        if (imageRef.current?.complete) {
+          setLoaded(true)
+        }
+      }, [imageThumbnail])
+
       const media = hasImage ? (
         <Box data-choice-media={dataAttrs?.['data-choice-media']}>
           <Skeleton loading={!loaded} css={styles.skeleton}>
             <Image
+              ref={imageRef}
               css={styles.image}
               src={imageThumbnail}
               alt={label}
               onLoad={() => setLoaded(true)}
+              // Don't let a failed request hang as an eternal skeleton either.
+              onError={() => setLoaded(true)}
               onClick={(event) => {
                 if (!canOpenImageModal) return
                 event.preventDefault()

--- a/src/theme/react-components/election.tsx
+++ b/src/theme/react-components/election.tsx
@@ -140,11 +140,11 @@ export const electionComponents: ComponentsPartialDefinition = {
       // started fetching from the server-rendered markup before hydration. In
       // those cases `onLoad` never fires, leaving the Skeleton overlay covering an
       // image that is actually present (matching the "url is there, hovering shows
-      // it, but it stays grey" reports). Reconcile against the DOM `complete` flag.
+      // it, but it stays grey" reports). Reconcile against the DOM `complete` flag
+      // on every src change so a new image that isn't loaded yet shows the skeleton
+      // again instead of inheriting the previous image's loaded state.
       useEffect(() => {
-        if (imageRef.current?.complete) {
-          setLoaded(true)
-        }
+        setLoaded(imageRef.current?.complete ?? false)
       }, [imageThumbnail])
 
       const media = hasImage ? (

--- a/src/theme/selectStyles.ts
+++ b/src/theme/selectStyles.ts
@@ -7,10 +7,17 @@ export const selectStyles: ChakraStylesConfig<any, boolean> = {
   }),
 }
 
-export const languagesListSelectStyles: ChakraStylesConfig<any, boolean> = {
+// Receives the character length of the longest language label so the control
+// width stays constant regardless of the current selection. Without a fixed
+// width the container shrinks to the selected value, and since the menu inherits
+// the control width, longer language names wrapped onto two lines.
+export const languagesListSelectStyles = (longestLabelLength = 0): ChakraStylesConfig<any, boolean> => ({
   container: (base) => ({
     ...base,
-    w: 'fit-content',
+    // Longest label width plus a small offset for the dropdown indicator. `ch`
+    // already overestimates proportional text, so this slack also covers the
+    // option check icon and gaps without leaving a large trailing gap.
+    w: longestLabelLength ? `calc(${longestLabelLength}ch + 1.5rem)` : 'fit-content',
   }),
   control: (base) => ({
     ...base,
@@ -18,8 +25,18 @@ export const languagesListSelectStyles: ChakraStylesConfig<any, boolean> = {
     px: 1,
     py: 0,
   }),
+  valueContainer: (base) => ({
+    ...base,
+    justifyContent: 'flex-start',
+  }),
+  singleValue: (base) => ({
+    ...base,
+    textAlign: 'left',
+  }),
   option: (base) => ({
     ...base,
     fontWeight: 'normal',
+    textAlign: 'left',
+    justifyContent: 'flex-start',
   }),
-}
+})

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -46,7 +46,7 @@ const sizes = defineTokens.sizes({
   sidebar: { value: sidebarWidth },
   'user-profile': { value: '280px' },
   voting: {
-    sidebar: { value: '360px' },
+    sidebar: { value: '320px' },
     contents: {
       min: { value: 'calc(640px + var(--chakra-sizes-voting-sidebar))' },
       max: { value: '1560px' },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,6 +34,12 @@ const viteconfig = ({ mode }: { mode: string }) => {
 
   return defineConfig({
     base,
+    // Expose the dev server on the local network (equivalent to `--host`).
+    // It is set here rather than on the CLI because Vike intercepts the vite
+    // command and its parser rejects unknown flags like `--host`/`--port`.
+    server: {
+      host: true,
+    },
     build: {
       outDir,
     },


### PR DESCRIPTION
Summary

Addresses several sub-issues of #1652 (and fixes #1609). A batch of fixes and small improvements across the explorer link, the language selector/switching UX, process pages, and dev ergonomics.

Changes

fix(explorer): pin the dev explorer URL to the one-dev network

The SDK defaults the dev explorer to https://dev.explorer.vote, which doesn't know about the one-dev (vocone) network we already redirect api_url to — so "Open in explorer" returned an election not found error. Mirror the existing api_url override and pin explorerUrl to https://one-dev.explorer.vote under the dev environment.

fix(i18n): stabilize language selector width and improve menu UX

- Dashboard selector: pin the control width to the longest language label so it no longer resizes per selection (which wrapped longer names); left-align the value and options.
- Public language menu: show full language names instead of codes, left-align them, cap the menu height with a scrollbar, and anchor the dropdown to the button's right edge.
- Sort both lists by language code so non-Latin scripts (Greek) collate within the alphabet instead of at the end.

feat(i18n): switch language in place on client-rendered routes

Changing the language used to trigger a full page reload, because the language is the react-router basename sourced from the Vike /:lang/ catch-all param. Now the active language is held in client state: on client-rendered routes a switch changes i18n in place, rewrites the URL prefix via history.replaceState, and swaps the router basename without a network reload, keeping the query cache, auth and wallet mounted. A popstate listener keeps the language in sync with the address bar. Vike SSR public pages still navigate (reload), since the server must re-render the localized content.

fix(process): refresh elections list cache after creating a process

The processes index loads through a route loader backed by ensureQueryData, which returns cached data without refetching when merely marked stale — so a newly created vote only appeared after a full reload. Evict the cached elections pages on creation so the loader fetches fresh data on its next navigation.

fix(process): reconcile question option image skeleton with already-loaded images

The themed QuestionChoice cleared its loading Skeleton only via the image's onLoad. An <img> can finish loading before React attaches that handler (cached responses, or images fetched from SSR markup before hydration), leaving the skeleton over an image that's actually present — appearing as a blank grey card on some devices/browsers. Reconcile against the DOM complete flag on mount and clear on error too.

fix(process): enable election refetch on process pages (#1609)

Passing only the election object to ElectionProvider leaves its query disabled, so refetchInterval never runs. We now pass the election id to enable it. On the dashboard view the election comes from a react-router loader (a live PublishedElection instance), so election.id works; on the public Vike SSR pages the election is serialized via useData(), which drops the SDK's prototype id getter (only _id survives), so election.id was undefined and the query stayed disabled. Thread the reliable route-param id through the public process and summary pages instead.

chore(dev): expose dev server on the network via server.host

Vike intercepts the vite command and its CLI parser rejects unknown flags like --host, so pnpm dev --host errored. Set server.host in the config so pnpm dev is reachable from other devices on the LAN.

chore(process view): minor — reduce sidebar width

Verification

pnpm lint and pnpm test (463 passing) green across the branch. Language switching, explorer links, process creation, the question-image rendering, and process-page refetch were verified manually in the dev app.

closes #1652
closes #1609