### PR TITLE
fix(auth): prevent undefined placeholder in 2FA pin input

### DIFF
--- a/src/components/Auth/Verify.test.tsx
+++ b/src/components/Auth/Verify.test.tsx
@@ -1,0 +1,202 @@
+import type { ChangeEvent, ReactNode } from 'react'
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '~src/test-utils'
+import { VerificationPending } from './Verify'
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual<typeof import('@chakra-ui/react')>('@chakra-ui/react')
+  const React = await vi.importActual<typeof import('react')>('react')
+
+  type PinInputContextValue = {
+    count: number
+    value: string[]
+    onValueChange?: (details: { value: string[]; valueAsString: string }) => void
+  }
+
+  const PinInputContext = React.createContext<PinInputContextValue>({
+    count: 6,
+    value: [],
+  })
+
+  const PinInputRoot = ({
+    children,
+    count = 6,
+    onValueChange,
+    value = [],
+    ...props
+  }: {
+    children: ReactNode
+    count?: number
+    onValueChange?: (details: { value: string[]; valueAsString: string }) => void
+    value?: string[]
+  }) => (
+    <PinInputContext.Provider value={{ count, onValueChange, value }}>
+      <div {...props}>{children}</div>
+    </PinInputContext.Provider>
+  )
+
+  const PinInputControl = ({ children, ...props }: { children: ReactNode }) => <div {...props}>{children}</div>
+
+  const PinInputInput = ({ index, ...props }: { index: number }) => {
+    const { count, onValueChange, value } = React.useContext(PinInputContext)
+
+    const updateValue = (next: string[]) => {
+      onValueChange?.({
+        value: next,
+        valueAsString: next.join(''),
+      })
+    }
+
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+      const rawValue = event.currentTarget.value ?? ''
+      const nextValue = Array.from({ length: count }, (_, currentIndex) => value[currentIndex] ?? '')
+
+      if (rawValue.length > 1) {
+        rawValue
+          .slice(0, count)
+          .split('')
+          .forEach((char, currentIndex) => {
+            nextValue[currentIndex] = char
+          })
+      } else {
+        nextValue[index] = rawValue
+      }
+
+      updateValue(nextValue)
+    }
+
+    return (
+      <input
+        aria-label={`pin code ${index + 1} of ${count}`}
+        onChange={handleChange}
+        type='text'
+        value={value[index] ?? ''}
+        {...props}
+      />
+    )
+  }
+
+  return {
+    ...actual,
+    PinInputControl,
+    PinInputInput,
+    PinInputRoot,
+  }
+})
+
+const verifyAsyncMock = vi.fn()
+const navigateMock = vi.fn()
+const toastMock = vi.fn()
+
+vi.mock('~components/Auth/useAuth', () => ({
+  useAuth: () => ({
+    mailVerify: {
+      mutateAsync: verifyAsyncMock,
+      isPending: false,
+      isError: false,
+    },
+  }),
+}))
+
+vi.mock('~components/Auth/authQueries', () => ({
+  useResendVerificationMail: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isSuccess: false,
+  }),
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useOutletContext: () => ({
+      setTitle: vi.fn(),
+      setSubtitle: vi.fn(),
+    }),
+  }
+})
+
+vi.mock('~components/Toast', async () => {
+  const actual = await vi.importActual<typeof import('~components/Toast')>('~components/Toast')
+  return {
+    ...actual,
+    useToast: () => toastMock,
+  }
+})
+
+const getPinInputs = () => screen.getAllByRole<HTMLInputElement>('textbox', { name: /pin code \d of 6/i })
+
+describe('VerificationPending', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    verifyAsyncMock.mockResolvedValue(undefined)
+  })
+
+  it('renders 6 pin input fields', async () => {
+    render(<VerificationPending email='test@example.com' />)
+
+    await waitFor(() => {
+      expect(getPinInputs()).toHaveLength(6)
+    })
+  })
+
+  it('does not render undefined values when pasting the pin code', async () => {
+    const user = userEvent.setup()
+    render(<VerificationPending email='test@example.com' />)
+
+    const pinInputs = getPinInputs()
+    await user.click(pinInputs[0])
+    await user.paste('123456')
+
+    await waitFor(() => {
+      const values = getPinInputs().map((input) => input.value)
+
+      expect(values).toEqual(['1', '2', '3', '4', '5', '6'])
+      expect(values).not.toContain('undefined')
+      expect(screen.queryByDisplayValue('undefined')).not.toBeInTheDocument()
+    })
+  })
+
+  it('preserves the deleted position instead of compacting the remaining digits', async () => {
+    const user = userEvent.setup()
+    render(<VerificationPending email='test@example.com' />)
+
+    const pinInputs = getPinInputs()
+
+    for (const [index, digit] of ['1', '2', '3', '4', '5', '6'].entries()) {
+      await user.click(pinInputs[index])
+      await user.type(pinInputs[index], digit)
+    }
+
+    await user.click(pinInputs[1])
+    await user.clear(pinInputs[1])
+
+    await waitFor(() => {
+      const values = getPinInputs().map((input) => input.value)
+
+      expect(values).toEqual(['1', '', '3', '4', '5', '6'])
+      expect(values).not.toContain('undefined')
+    })
+  })
+
+  it('submits the full code when all 6 digits are entered sequentially', async () => {
+    const user = userEvent.setup()
+    render(<VerificationPending email='test@example.com' />)
+
+    const pinInputs = getPinInputs()
+
+    for (const [index, digit] of ['1', '2', '3', '4', '5', '6'].entries()) {
+      await user.click(pinInputs[index])
+      await user.type(pinInputs[index], digit)
+    }
+
+    await waitFor(() => {
+      expect(verifyAsyncMock).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        code: '123456',
+      })
+    })
+  })
+})

--- a/src/components/Auth/Verify.tsx
+++ b/src/components/Auth/Verify.tsx
@@ -31,14 +31,16 @@ const VerifyForm = ({ email, initialCode = '', autoSubmit = false }: VerifyFormP
   const toast = useToast()
   const navigate = useNavigate()
   const { t } = useTranslation()
-  const [code, setCode] = useState(initialCode)
+  const [code, setCode] = useState<string[]>(() => Array.from({ length: 6 }, (_, i) => initialCode[i] ?? ''))
   const {
     mailVerify: { mutateAsync: verifyAsync, isPending: isVerifyPending, isError: isVerifyError },
   } = useAuth()
 
+  const codeString = code.join('')
+
   const verify = useCallback(async () => {
     try {
-      await verifyAsync({ email, code })
+      await verifyAsync({ email, code: codeString })
       toast({
         type: 'success',
         title: t('verify_mail.success', { defaultValue: 'Email verified successfully' }),
@@ -58,16 +60,16 @@ const VerifyForm = ({ email, initialCode = '', autoSubmit = false }: VerifyFormP
         closable: true,
       })
     }
-  }, [code, email, verifyAsync, navigate, t, toast])
+  }, [codeString, email, verifyAsync, navigate, t, toast])
 
   // Auto-submit if code is provided and autoSubmit is true, or when all 6 characters are entered
   useEffect(() => {
-    if ((autoSubmit && code) || (!autoSubmit && code?.length === 6)) {
+    if ((autoSubmit && codeString) || (!autoSubmit && code.every((c) => c.trim() !== ''))) {
       verify()
     }
-  }, [autoSubmit, code])
+  }, [autoSubmit, codeString])
 
-  if (autoSubmit && code && !isVerifyError) {
+  if (autoSubmit && codeString && !isVerifyError) {
     return (
       <Box height={'100px'}>
         <Loading minHeight={1} />
@@ -79,8 +81,13 @@ const VerifyForm = ({ email, initialCode = '', autoSubmit = false }: VerifyFormP
     <>
       <HStack width='100%' justifyContent='space-between'>
         <PinInputRoot
-          value={code.split('')}
-          onValueChange={(details) => setCode(details.valueAsString)}
+          value={code}
+          onValueChange={({ value, valueAsString }) => {
+            const next = Array.isArray(value)
+              ? Array.from({ length: 6 }, (_, i) => value[i] ?? '')
+              : Array.from({ length: 6 }, (_, i) => (valueAsString ?? '')[i] ?? '')
+            setCode(next)
+          }}
           disabled={autoSubmit}
           type='alphanumeric'
           autoFocus
@@ -94,7 +101,12 @@ const VerifyForm = ({ email, initialCode = '', autoSubmit = false }: VerifyFormP
         </PinInputRoot>
       </HStack>
       <Box>
-        <Button disabled={!code || (autoSubmit && isVerifyPending)} loading={isVerifyPending} onClick={verify} w='full'>
+        <Button
+          disabled={code.every((c) => c === '') || (autoSubmit && isVerifyPending)}
+          loading={isVerifyPending}
+          onClick={verify}
+          w='full'
+        >
           <Trans i18nKey={'verify.verify_code'}>Verify</Trans>
         </Button>
       </Box>


### PR DESCRIPTION
Store the verification code as a fixed-length string[] instead of a plain string so PinInputRoot always receives a 6-element array. The previous code.split('') approach produced a shorter array after deletion, causing zag to set inputEl.value = undefined on out-of-range slots, which coerced to the literal string "undefined" in the DOM.

The onValueChange handler now normalises the incoming value with `?? ''` at each index, mirroring the established pattern in CSP/Step1.tsx.

Closes #1696