### PR TITLE
feat(integrator): integrator dashboard for managed organizations

### DIFF
--- a/src/components/Auth/api.ts
+++ b/src/components/Auth/api.ts
@@ -22,6 +22,8 @@ export enum ApiEndpoints {
   OrganizationPendingUsers = 'organizations/{address}/users/pending',
   OrganizationPendingUser = 'organizations/{address}/users/pending/{inviteId}',
   Organizations = 'organizations',
+  Integrator = 'organizations/{address}/integrator',
+  ManagedOrganizations = 'organizations/{address}/managed',
   OrganizationsRoles = 'organizations/roles',
   OrganizationsTypes = 'organizations/types',
   OrganizationSubscription = 'organizations/{address}/subscription',
@@ -66,6 +68,9 @@ export enum ErrorCode {
   UserNotVerified = 40014,
   UserAlreadyVerified = 40015,
   DraftLimitReached = 40031,
+  NotAnIntegrator = 40153,
+  MaxManagedOrgsReached = 40154,
+  IntegratorQuotaExceeded = 40155,
 }
 
 interface IApiError {

--- a/src/components/Dashboard/Menu/index.test.tsx
+++ b/src/components/Dashboard/Menu/index.test.tsx
@@ -30,6 +30,10 @@ vi.mock('./Options', () => ({
   DashboardMenuOptions: () => <div>MenuOptions</div>,
 }))
 
+vi.mock('~queries/integrator', () => ({
+  useIntegratorInfo: () => ({ data: undefined }),
+}))
+
 const renderMenu = (reduced: boolean, onToggleReduced = vi.fn()) =>
   render(
     <DashboardLayoutContext.Provider value={{ reduced } as any}>

--- a/src/components/Dashboard/Menu/index.tsx
+++ b/src/components/Dashboard/Menu/index.tsx
@@ -21,6 +21,8 @@ import { VocdoniLogo } from '~components/Layout/Logo'
 import { DashboardLayoutContext } from '~elements/LayoutDashboard'
 import { useTutorials } from '~src/queries/organization'
 import { Routes } from '~src/router/routes'
+import { IntegratorMenuOptions } from '~components/Integrator/MenuOptions'
+import { useIntegratorInfo } from '~queries/integrator'
 import { DashboardBookerModalButton } from '../Booker'
 import { DashboardMenuOptions } from './Options'
 import UserProfile from './UserProfile'
@@ -129,6 +131,9 @@ const DashboardMenuContent = ({
   const { reduced } = useContext(DashboardLayoutContext)
   const { t } = useTranslation()
   const [isTouchLike] = useMediaQuery(['(hover: none), (pointer: coarse)'])
+  // Integrators get a different app: no "new vote" action and a dedicated navigation.
+  const { data: integrator } = useIntegratorInfo()
+  const isIntegrator = !!integrator?.enabled
 
   return (
     <>
@@ -181,20 +186,22 @@ const DashboardMenuContent = ({
             <Icon as={LuPanelLeft} />
           </IconButton>
         </Flex>
-        <Button asChild w='full' minW={0} mt={'8px'} mb={'32px'} size={'xs'}>
-          <RouterLink to={generatePath(Routes.processes.create)}>
-            <HStack gap={reduced ? 0 : 2}>
-              <Icon as={LuPlus} boxSize={4} />
-              {!reduced && (
-                <Text as='span'>
-                  <Trans i18nKey='new_vote'>New vote</Trans>
-                </Text>
-              )}
-            </HStack>
-          </RouterLink>
-        </Button>
+        {!isIntegrator && (
+          <Button asChild w='full' minW={0} mt={'8px'} mb={'32px'} size={'xs'}>
+            <RouterLink to={generatePath(Routes.processes.create)}>
+              <HStack gap={reduced ? 0 : 2}>
+                <Icon as={LuPlus} boxSize={4} />
+                {!reduced && (
+                  <Text as='span'>
+                    <Trans i18nKey='new_vote'>New vote</Trans>
+                  </Text>
+                )}
+              </HStack>
+            </RouterLink>
+          </Button>
+        )}
 
-        <DashboardMenuOptions />
+        {isIntegrator ? <IntegratorMenuOptions /> : <DashboardMenuOptions />}
       </Box>
       <Box mt='auto'>
         <SidebarTutorial />

--- a/src/components/Integrator/CreateManagedOrganizationModal.tsx
+++ b/src/components/Integrator/CreateManagedOrganizationModal.tsx
@@ -1,0 +1,224 @@
+import {
+  Button,
+  FieldRoot as FormControl,
+  FieldErrorText as FormErrorMessage,
+  FieldLabel as FormLabel,
+  HStack,
+  Icon,
+  Input,
+  Switch,
+  useDisclosure,
+  VStack,
+} from '@chakra-ui/react'
+import { useEffect } from 'react'
+import { Controller, FormProvider, useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { LuPlus } from 'react-icons/lu'
+import { ApiError, ErrorCode, getApiErrorMessage } from '~components/Auth/api'
+import { ModalForm, useModalForm } from '~components/Form/ModalForm'
+import { MembershipSizeSelector, OrganizationTypeSelector } from '~components/Layout/SaasSelector'
+import { useToast } from '~components/Toast'
+import {
+  CreateManagedOrganizationBody,
+  useCreateManagedOrganization,
+  useIntegratorInfo,
+  useIsIntegratorAdmin,
+} from '~queries/integrator'
+
+type FormData = {
+  type: string
+  website?: string
+  size?: string
+  color?: string
+  subdomain?: string
+  country?: string
+  timezone?: string
+  ownerEmail?: string
+  communications?: boolean
+}
+
+// Drop empty optional fields so we don't send empty strings the backend would have to interpret.
+const buildBody = (values: FormData): CreateManagedOrganizationBody => {
+  const body: CreateManagedOrganizationBody = { type: values.type }
+  if (values.website) body.website = values.website
+  if (values.size) body.size = values.size
+  if (values.color) body.color = values.color
+  if (values.subdomain) body.subdomain = values.subdomain
+  if (values.country) body.country = values.country
+  if (values.timezone) body.timezone = values.timezone
+  if (values.ownerEmail) body.ownerEmail = values.ownerEmail
+  body.communications = !!values.communications
+  return body
+}
+
+const CreateManagedOrganizationForm = () => {
+  const { t } = useTranslation()
+  const toast = useToast()
+  const createManagedOrg = useCreateManagedOrganization()
+  const methods = useForm<FormData>()
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors, isSubmitting },
+  } = methods
+  const { formRef, setIsSubmitting, onClose } = useModalForm()
+
+  useEffect(() => {
+    setIsSubmitting(isSubmitting)
+  }, [isSubmitting, setIsSubmitting])
+
+  const onSubmit = async (values: FormData) => {
+    try {
+      await createManagedOrg.mutateAsync(buildBody(values))
+      toast({
+        title: t('integrator.create.success', { defaultValue: 'Organization created successfully' }),
+        type: 'success',
+        duration: 5000,
+        closable: true,
+      })
+      reset()
+      onClose()
+    } catch (error) {
+      const code = error instanceof ApiError ? error.apiError?.code : undefined
+      let description = getApiErrorMessage(error)
+      if (code === ErrorCode.MaxManagedOrgsReached) {
+        description = t('integrator.create.limit_reached', {
+          defaultValue: "You've reached your managed-organization limit.",
+        })
+      } else if (code === ErrorCode.IntegratorQuotaExceeded) {
+        description = t('integrator.create.quota_exceeded', {
+          defaultValue: "You've reached your integrator quota.",
+        })
+      }
+      toast({
+        title: t('integrator.create.error', { defaultValue: 'Failed to create organization' }),
+        description,
+        type: 'error',
+        duration: 5000,
+        closable: true,
+      })
+    }
+  }
+
+  return (
+    <FormProvider {...methods}>
+      <form
+        ref={formRef}
+        onSubmit={(e) => {
+          e.stopPropagation()
+          handleSubmit(onSubmit)(e)
+        }}
+      >
+        <VStack gap={4} align='stretch'>
+          <OrganizationTypeSelector name='type' required />
+          <MembershipSizeSelector name='size' />
+
+          <FormControl invalid={!!errors.website}>
+            <FormLabel>{t('integrator.create.website', { defaultValue: 'Website' })}</FormLabel>
+            <Input placeholder='https://...' {...register('website')} />
+            <FormErrorMessage>{errors.website?.message}</FormErrorMessage>
+          </FormControl>
+
+          <HStack gap={4} align='start'>
+            <FormControl invalid={!!errors.subdomain}>
+              <FormLabel>{t('integrator.create.subdomain', { defaultValue: 'Subdomain' })}</FormLabel>
+              <Input {...register('subdomain')} />
+            </FormControl>
+            <FormControl invalid={!!errors.color}>
+              <FormLabel>{t('integrator.create.color', { defaultValue: 'Brand color' })}</FormLabel>
+              <Input placeholder='#RRGGBB' {...register('color')} />
+            </FormControl>
+          </HStack>
+
+          <HStack gap={4} align='start'>
+            <FormControl invalid={!!errors.country}>
+              <FormLabel>{t('integrator.create.country', { defaultValue: 'Country' })}</FormLabel>
+              <Input
+                placeholder={t('integrator.create.country_placeholder', { defaultValue: 'e.g. ES' })}
+                {...register('country')}
+              />
+            </FormControl>
+            <FormControl invalid={!!errors.timezone}>
+              <FormLabel>{t('integrator.create.timezone', { defaultValue: 'Timezone' })}</FormLabel>
+              <Input placeholder='e.g. Europe/Madrid' {...register('timezone')} />
+            </FormControl>
+          </HStack>
+
+          <FormControl invalid={!!errors.ownerEmail}>
+            <FormLabel>{t('integrator.create.owner_email', { defaultValue: 'Owner email' })}</FormLabel>
+            <Input
+              type='email'
+              placeholder={t('integrator.create.owner_email_placeholder', {
+                defaultValue: 'Existing user to own the org (optional)',
+              })}
+              {...register('ownerEmail')}
+            />
+            <FormErrorMessage>{errors.ownerEmail?.message}</FormErrorMessage>
+          </FormControl>
+
+          <Controller
+            name='communications'
+            control={control}
+            render={({ field }) => (
+              <Switch.Root checked={!!field.value} onCheckedChange={({ checked }) => field.onChange(checked === true)}>
+                <Switch.HiddenInput />
+                <Switch.Control>
+                  <Switch.Thumb />
+                </Switch.Control>
+                <Switch.Label>
+                  {t('integrator.create.communications', { defaultValue: 'Enable communications' })}
+                </Switch.Label>
+              </Switch.Root>
+            )}
+          />
+        </VStack>
+      </form>
+    </FormProvider>
+  )
+}
+
+/**
+ * "Create managed organization" action. Rendered only for integrator admins (managers can view but
+ * not create). Disabled when the managed-orgs quota is already exhausted.
+ */
+export const CreateManagedOrganizationButton = () => {
+  const { t } = useTranslation()
+  const isAdmin = useIsIntegratorAdmin()
+  const { data: integrator } = useIntegratorInfo()
+  const { open: isOpen, onOpen, onClose } = useDisclosure()
+
+  if (!isAdmin) return null
+
+  const atLimit = !!integrator?.limits && integrator.usage.managedOrgs >= integrator.limits.maxManagedOrgs
+
+  return (
+    <>
+      <Button
+        onClick={onOpen}
+        disabled={atLimit}
+        size='sm'
+        title={
+          atLimit
+            ? t('integrator.create.limit_reached', { defaultValue: "You've reached your managed-organization limit." })
+            : undefined
+        }
+      >
+        <Icon as={LuPlus} boxSize={4} />
+        {t('integrator.create.action', { defaultValue: 'Create organization' })}
+      </Button>
+      <ModalForm
+        isOpen={isOpen}
+        onClose={onClose}
+        title={t('integrator.create.title', { defaultValue: 'Create managed organization' })}
+        subtitle={t('integrator.create.subtitle', {
+          defaultValue: 'Provision a new organization under your integrator account.',
+        })}
+        submitText={t('integrator.create.action', { defaultValue: 'Create organization' })}
+      >
+        <CreateManagedOrganizationForm />
+      </ModalForm>
+    </>
+  )
+}

--- a/src/components/Integrator/IntegratorProtectedRoute.tsx
+++ b/src/components/Integrator/IntegratorProtectedRoute.tsx
@@ -1,0 +1,29 @@
+import { Flex, Spinner } from '@chakra-ui/react'
+import { Navigate, Outlet } from 'react-router-dom'
+import { useIntegratorInfo } from '~queries/integrator'
+import { Routes } from '~src/router/routes'
+
+/**
+ * Guards the integrator-only section of the dashboard. While the integrator status is being
+ * resolved we show a spinner; organizations that are not integrators are bounced back to the
+ * regular dashboard so they never see the integrator app.
+ */
+const IntegratorProtectedRoute = () => {
+  const { data, isLoading } = useIntegratorInfo()
+
+  if (isLoading) {
+    return (
+      <Flex flex='1 1 0' align='center' justify='center' p={10}>
+        <Spinner />
+      </Flex>
+    )
+  }
+
+  if (!data?.enabled) {
+    return <Navigate to={Routes.dashboard.base} replace />
+  }
+
+  return <Outlet />
+}
+
+export default IntegratorProtectedRoute

--- a/src/components/Integrator/ManagedOrganizationsTable.tsx
+++ b/src/components/Integrator/ManagedOrganizationsTable.tsx
@@ -1,0 +1,79 @@
+import { Badge, Link, Table } from '@chakra-ui/react'
+import { useTranslation } from 'react-i18next'
+import { generatePath, Link as RouterLink } from 'react-router-dom'
+import RoutedPaginatedTableFooter from '~components/Pagination/PaginatedTableFooter'
+import { ManagedOrganization } from '~queries/integrator'
+import { Routes } from '~routes'
+
+const formatDate = (value: string) => {
+  if (!value) return '-'
+  const date = new Date(value)
+  return isNaN(date.getTime()) ? value : date.toLocaleDateString()
+}
+
+const shortAddress = (address: string) =>
+  address && address.length > 12 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address
+
+const ManagedOrganizationRow = ({ organization }: { organization: ManagedOrganization }) => {
+  const { t } = useTranslation()
+
+  return (
+    <Table.Row>
+      <Table.Cell>
+        <Link asChild _hover={{ textDecoration: 'underline' }} fontWeight='medium'>
+          <RouterLink to={generatePath(Routes.organization, { address: organization.address })}>
+            {shortAddress(organization.address)}
+          </RouterLink>
+        </Link>
+      </Table.Cell>
+      <Table.Cell>{organization.type || '-'}</Table.Cell>
+      <Table.Cell>{organization.country || '-'}</Table.Cell>
+      <Table.Cell>{formatDate(organization.createdAt)}</Table.Cell>
+      <Table.Cell>
+        {organization.active ? (
+          <Badge colorPalette='green' variant='subtle'>
+            {t('integrator.organizations.active', { defaultValue: 'Active' })}
+          </Badge>
+        ) : (
+          <Badge colorPalette='gray' variant='subtle'>
+            {t('integrator.organizations.inactive', { defaultValue: 'Inactive' })}
+          </Badge>
+        )}
+      </Table.Cell>
+    </Table.Row>
+  )
+}
+
+export const ManagedOrganizationsTable = ({ organizations }: { organizations: ManagedOrganization[] }) => {
+  const { t } = useTranslation()
+
+  return (
+    <Table.ScrollArea border='1px solid' borderColor='table.border' borderRadius='sm'>
+      <Table.Root variant='outline'>
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeader>
+              {t('integrator.organizations.address', { defaultValue: 'Address' })}
+            </Table.ColumnHeader>
+            <Table.ColumnHeader>{t('integrator.organizations.type', { defaultValue: 'Type' })}</Table.ColumnHeader>
+            <Table.ColumnHeader>
+              {t('integrator.organizations.country', { defaultValue: 'Country' })}
+            </Table.ColumnHeader>
+            <Table.ColumnHeader>
+              {t('integrator.organizations.created_at', { defaultValue: 'Created' })}
+            </Table.ColumnHeader>
+            <Table.ColumnHeader>{t('integrator.organizations.status', { defaultValue: 'Status' })}</Table.ColumnHeader>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {organizations.map((organization) => (
+            <ManagedOrganizationRow key={organization.address} organization={organization} />
+          ))}
+        </Table.Body>
+        <Table.Caption>
+          <RoutedPaginatedTableFooter />
+        </Table.Caption>
+      </Table.Root>
+    </Table.ScrollArea>
+  )
+}

--- a/src/components/Integrator/MenuOptions.tsx
+++ b/src/components/Integrator/MenuOptions.tsx
@@ -1,0 +1,84 @@
+import { Box, Flex, List, Text } from '@chakra-ui/react'
+import { useContext } from 'react'
+import { useTranslation } from 'react-i18next'
+import { LuBuilding2, LuGauge, LuLifeBuoy } from 'react-icons/lu'
+import { matchPath, useLocation } from 'react-router-dom'
+import { DashboardMenuItem, DashboardMenuItemButton } from '~components/Dashboard/Menu/Item'
+import { DashboardLayoutContext } from '~elements/LayoutDashboard'
+import { Routes } from '~src/router/routes'
+
+/**
+ * Sidebar navigation shown to integrator organizations. Integrators get a different app than
+ * regular orgs: no voting processes or memberbase, just their quota overview and the
+ * organizations they manage (plus the shared Help section).
+ */
+export const IntegratorMenuOptions = () => {
+  const { t } = useTranslation()
+  const location = useLocation()
+  const { reduced } = useContext(DashboardLayoutContext)
+
+  const menuItemsPlatform: DashboardMenuItem[] = [
+    {
+      label: t('integrator.menu.overview', { defaultValue: 'Overview' }),
+      icon: LuGauge,
+      route: Routes.dashboard.integrator.base,
+      activeMatch: [{ path: Routes.dashboard.integrator.base, end: true }],
+    },
+    {
+      label: t('integrator.menu.organizations', { defaultValue: 'Managed organizations' }),
+      icon: LuBuilding2,
+      route: Routes.dashboard.integrator.organizations,
+      activeMatch: [{ path: Routes.dashboard.integrator.organizations, end: false }],
+    },
+  ]
+  const menuItemsHelp: DashboardMenuItem[] = [
+    {
+      label: t('support'),
+      icon: LuLifeBuoy,
+      route: Routes.dashboard.settings.support,
+    },
+  ]
+
+  return (
+    <Flex flexDirection={'column'} gap={8}>
+      <Box>
+        {!reduced && (
+          <Text mx={2} mb={2} fontWeight={'bold'} fontSize='xs'>
+            {t('integrator.menu.section', { defaultValue: 'Integrator' })}
+          </Text>
+        )}
+        <List.Root display='flex' flexDirection='column' listStyleType='none' ml={0}>
+          {menuItemsPlatform.map((item, index) => {
+            const activeMatch = item.activeMatch ?? (item.route ? [{ path: item.route, end: true }] : [])
+            const isActive = activeMatch.some((match) =>
+              Boolean(matchPath({ path: match.path, end: match.end ?? true }, location.pathname))
+            )
+
+            return (
+              <List.Item key={index}>
+                <DashboardMenuItemButton item={item} reduced={reduced} isActive={isActive} />
+              </List.Item>
+            )
+          })}
+        </List.Root>
+      </Box>
+      {!reduced && (
+        <Box>
+          <Text mx={2} mb={2} fontWeight={'bold'} fontSize='xs'>
+            {t('section.help', { defaultValue: 'Help' })}
+          </Text>
+
+          <List.Root display='flex' flexDirection='column' listStyleType='none' ml={0}>
+            {menuItemsHelp.map((item, index) => {
+              return (
+                <List.Item key={index}>
+                  <DashboardMenuItemButton item={item} reduced={reduced} />
+                </List.Item>
+              )
+            })}
+          </List.Root>
+        </Box>
+      )}
+    </Flex>
+  )
+}

--- a/src/components/Integrator/Overview.tsx
+++ b/src/components/Integrator/Overview.tsx
@@ -1,0 +1,67 @@
+import { Progress, SimpleGrid } from '@chakra-ui/react'
+import { useTranslation } from 'react-i18next'
+import { DashboardCardHeader } from '~components/Dashboard/Contents'
+import { ListStateAlert } from '~components/Feedback/ListStateAlert'
+import { useIntegratorInfo } from '~queries/integrator'
+import { QuotaCard } from './QuotaCard'
+
+/**
+ * Integrator overview: three quota cards (managed orgs, processes, census size) each showing
+ * usage against its limit. Reachable only through the integrator guard, so `enabled` is always
+ * true here, but we defend against a missing `limits` payload just in case.
+ */
+export const IntegratorOverview = () => {
+  const { t } = useTranslation()
+  const { data, isLoading, error } = useIntegratorInfo()
+
+  if (isLoading) {
+    return (
+      <Progress.Root size='xs' value={null} colorPalette='gray'>
+        <Progress.Track>
+          <Progress.Range />
+        </Progress.Track>
+      </Progress.Root>
+    )
+  }
+
+  if (error || !data?.limits) {
+    return (
+      <ListStateAlert
+        show
+        status='error'
+        title={t('integrator.overview.load_error', { defaultValue: 'Unable to load integrator quota' })}
+        description={error instanceof Error ? error.message : undefined}
+      />
+    )
+  }
+
+  const { limits, usage } = data
+
+  return (
+    <>
+      <DashboardCardHeader
+        title={t('integrator.overview.title', { defaultValue: 'Overview' })}
+        subtitle={t('integrator.overview.subtitle', {
+          defaultValue: 'Your integrator quota and current usage.',
+        })}
+      />
+      <SimpleGrid columns={{ base: 1, md: 3 }} gap={4}>
+        <QuotaCard
+          label={t('integrator.overview.managed_orgs', { defaultValue: 'Managed organizations' })}
+          usage={usage.managedOrgs}
+          limit={limits.maxManagedOrgs}
+        />
+        <QuotaCard
+          label={t('integrator.overview.managed_processes', { defaultValue: 'Voting processes' })}
+          usage={usage.managedProcesses}
+          limit={limits.maxManagedProcesses}
+        />
+        <QuotaCard
+          label={t('integrator.overview.managed_census', { defaultValue: 'Census size' })}
+          usage={usage.managedCensusSize}
+          limit={limits.maxManagedCensusSize}
+        />
+      </SimpleGrid>
+    </>
+  )
+}

--- a/src/components/Integrator/QuotaCard.tsx
+++ b/src/components/Integrator/QuotaCard.tsx
@@ -1,0 +1,48 @@
+import { Badge, Flex, HStack, Progress, Text } from '@chakra-ui/react'
+import { useTranslation } from 'react-i18next'
+import { DashboardBox } from '~components/Dashboard/Contents'
+
+type QuotaCardProps = {
+  label: string
+  usage: number
+  limit: number
+}
+
+/**
+ * Single quota metric: current usage over its limit with a progress bar. When the metric reaches
+ * or exceeds its limit it is visually flagged (red bar + "limit reached" badge).
+ */
+export const QuotaCard = ({ label, usage, limit }: QuotaCardProps) => {
+  const { t } = useTranslation()
+  const atLimit = limit > 0 && usage >= limit
+  // Cap the visual value at the limit so an over-quota metric still renders a full (not overflowing) bar.
+  const value = limit > 0 ? Math.min(usage, limit) : 0
+
+  return (
+    <DashboardBox gap={3}>
+      <Text fontSize='sm' color='texts.subtle' fontWeight='medium'>
+        {label}
+      </Text>
+      <HStack align='baseline' gap={1}>
+        <Text fontSize='3xl' fontWeight='bold' lineHeight='1'>
+          {usage}
+        </Text>
+        <Text fontSize='md' color='texts.subtle'>
+          / {limit}
+        </Text>
+      </HStack>
+      <Progress.Root value={value} max={limit > 0 ? limit : 1} size='sm' colorPalette={atLimit ? 'red' : 'blue'}>
+        <Progress.Track>
+          <Progress.Range />
+        </Progress.Track>
+      </Progress.Root>
+      <Flex minH='20px'>
+        {atLimit && (
+          <Badge colorPalette='red' variant='subtle'>
+            {t('integrator.overview.limit_reached', { defaultValue: 'Limit reached' })}
+          </Badge>
+        )}
+      </Flex>
+    </DashboardBox>
+  )
+}

--- a/src/elements/dashboard/index.tsx
+++ b/src/elements/dashboard/index.tsx
@@ -1,7 +1,32 @@
+import { Progress } from '@chakra-ui/react'
+import { Navigate } from 'react-router-dom'
 import { DashboardContents } from '~components/Dashboard/Contents'
 import OrganizationDashboard from '~components/Organization/Dashboard'
+import { useIntegratorInfo } from '~queries/integrator'
+import { Routes } from '~routes'
 
 const Dashboard = () => {
+  // Integrators and regular orgs share the login portal but land in different apps. Detect the
+  // current org's integrator status and route integrators to their dedicated dashboard. The loader
+  // avoids briefly flashing the regular dashboard before redirecting.
+  const { data, isLoading } = useIntegratorInfo()
+
+  if (isLoading) {
+    return (
+      <DashboardContents>
+        <Progress.Root size='xs' value={null} colorPalette='gray'>
+          <Progress.Track>
+            <Progress.Range />
+          </Progress.Track>
+        </Progress.Root>
+      </DashboardContents>
+    )
+  }
+
+  if (data?.enabled) {
+    return <Navigate to={Routes.dashboard.integrator.base} replace />
+  }
+
   return (
     <DashboardContents>
       <OrganizationDashboard />

--- a/src/elements/dashboard/integrator/index.tsx
+++ b/src/elements/dashboard/integrator/index.tsx
@@ -1,0 +1,12 @@
+import { DashboardContents } from '~components/Dashboard/Contents'
+import { IntegratorOverview } from '~components/Integrator/Overview'
+
+const IntegratorDashboard = () => {
+  return (
+    <DashboardContents>
+      <IntegratorOverview />
+    </DashboardContents>
+  )
+}
+
+export default IntegratorDashboard

--- a/src/elements/dashboard/integrator/organizations.tsx
+++ b/src/elements/dashboard/integrator/organizations.tsx
@@ -1,0 +1,76 @@
+import { Flex, Progress } from '@chakra-ui/react'
+import { RoutedPaginationProvider } from '@vocdoni/react-components/pagination'
+import { useTranslation } from 'react-i18next'
+import { DashboardCardHeader, DashboardContents } from '~components/Dashboard/Contents'
+import { ListStateAlert } from '~components/Feedback/ListStateAlert'
+import { CreateManagedOrganizationButton } from '~components/Integrator/CreateManagedOrganizationModal'
+import { ManagedOrganizationsTable } from '~components/Integrator/ManagedOrganizationsTable'
+import { usePaginatedManagedOrganizations } from '~queries/integrator'
+import { Routes } from '~routes'
+
+const ManagedOrganizations = () => {
+  const { t } = useTranslation()
+  const { data, isLoading, error } = usePaginatedManagedOrganizations()
+
+  const hasError = !!error && !isLoading
+  const isEmpty = (data?.organizations?.length ?? 0) === 0 && !isLoading && !hasError
+  const showAlert = hasError || isEmpty
+  const alertTitle = hasError
+    ? t('integrator.organizations.load_error', { defaultValue: 'Unable to load organizations' })
+    : t('integrator.organizations.empty', { defaultValue: 'No managed organizations yet' })
+  const alertDescription = hasError
+    ? error instanceof Error
+      ? error.message
+      : t('integrator.organizations.load_error_description', { defaultValue: 'Please try again.' })
+    : t('integrator.organizations.empty_description', {
+        defaultValue: 'Create an organization to start managing it.',
+      })
+
+  const pagination = data?.pagination || {
+    totalItems: 0,
+    currentPage: 0,
+    lastPage: 0,
+    previousPage: null,
+    nextPage: null,
+  }
+
+  return (
+    <DashboardContents>
+      <Flex justify='space-between' align='flex-start' gap={4} wrap='wrap'>
+        <DashboardCardHeader
+          title={t('integrator.organizations.title', { defaultValue: 'Managed organizations' })}
+          subtitle={t('integrator.organizations.subtitle', {
+            defaultValue: 'Organizations you manage on behalf of your customers.',
+          })}
+        />
+        <CreateManagedOrganizationButton />
+      </Flex>
+
+      {isLoading ? (
+        <Progress.Root size='xs' value={null} colorPalette='gray'>
+          <Progress.Track>
+            <Progress.Range />
+          </Progress.Track>
+        </Progress.Root>
+      ) : (
+        <RoutedPaginationProvider
+          initialPage={1}
+          path={Routes.dashboard.integrator.organizations}
+          pagination={pagination}
+        >
+          {showAlert && (
+            <ListStateAlert
+              show
+              status={hasError ? 'error' : 'info'}
+              title={alertTitle}
+              description={alertDescription}
+            />
+          )}
+          <ManagedOrganizationsTable organizations={data?.organizations ?? []} />
+        </RoutedPaginationProvider>
+      )}
+    </DashboardContents>
+  )
+}
+
+export default ManagedOrganizations

--- a/src/i18n/locales/ca/common.json
+++ b/src/i18n/locales/ca/common.json
@@ -755,6 +755,55 @@
     "view_errors_many": "",
     "view_errors_other": "Mostra {{count}} errors"
   },
+  "integrator": {
+    "create": {
+      "action": "Crea organització",
+      "color": "Color de marca",
+      "communications": "Activa les comunicacions",
+      "country": "País",
+      "country_placeholder": "p. ex. ES",
+      "error": "No s'ha pogut crear l'organització",
+      "limit_reached": "Has arribat al límit d'organitzacions gestionades.",
+      "owner_email": "Correu del propietari",
+      "owner_email_placeholder": "Usuari existent que en serà propietari (opcional)",
+      "quota_exceeded": "Has arribat a la teva quota d'integrador.",
+      "subdomain": "Subdomini",
+      "subtitle": "Proveeix una nova organització sota el teu compte d'integrador.",
+      "success": "Organització creada correctament",
+      "timezone": "Zona horària",
+      "title": "Crea una organització gestionada",
+      "website": "Lloc web"
+    },
+    "menu": {
+      "organizations": "Organitzacions gestionades",
+      "overview": "Resum",
+      "section": "Integrador"
+    },
+    "organizations": {
+      "active": "Activa",
+      "address": "Adreça",
+      "country": "País",
+      "created_at": "Creada",
+      "empty": "Encara no hi ha organitzacions gestionades",
+      "empty_description": "Crea una organització per començar a gestionar-la.",
+      "inactive": "Inactiva",
+      "load_error": "No s'han pogut carregar les organitzacions",
+      "load_error_description": "Torna-ho a provar.",
+      "status": "Estat",
+      "subtitle": "Organitzacions que gestiones en nom dels teus clients.",
+      "title": "Organitzacions gestionades",
+      "type": "Tipus"
+    },
+    "overview": {
+      "limit_reached": "Límit assolit",
+      "load_error": "No s'ha pogut carregar la quota d'integrador",
+      "managed_census": "Mida del cens",
+      "managed_orgs": "Organitzacions gestionades",
+      "managed_processes": "Processos de votació",
+      "subtitle": "La teva quota d'integrador i l'ús actual.",
+      "title": "Resum"
+    }
+  },
   "internal_server_error": "Error intern del servidor",
   "invalid_promo_code": "Codi de promoció no vàlid",
   "invite": {

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -747,6 +747,55 @@
     "view_errors_one": "{{count}} Fehler anzeigen",
     "view_errors_other": "{{count}} Fehler anzeigen"
   },
+  "integrator": {
+    "create": {
+      "action": "",
+      "color": "",
+      "communications": "",
+      "country": "",
+      "country_placeholder": "",
+      "error": "",
+      "limit_reached": "",
+      "owner_email": "",
+      "owner_email_placeholder": "",
+      "quota_exceeded": "",
+      "subdomain": "",
+      "subtitle": "",
+      "success": "",
+      "timezone": "",
+      "title": "",
+      "website": ""
+    },
+    "menu": {
+      "organizations": "",
+      "overview": "",
+      "section": ""
+    },
+    "organizations": {
+      "active": "",
+      "address": "",
+      "country": "",
+      "created_at": "",
+      "empty": "",
+      "empty_description": "",
+      "inactive": "",
+      "load_error": "",
+      "load_error_description": "",
+      "status": "",
+      "subtitle": "",
+      "title": "",
+      "type": ""
+    },
+    "overview": {
+      "limit_reached": "",
+      "load_error": "",
+      "managed_census": "",
+      "managed_orgs": "",
+      "managed_processes": "",
+      "subtitle": "",
+      "title": ""
+    }
+  },
   "internal_server_error": "Interner Serverfehler",
   "invalid_promo_code": "Ungültiger Aktionscode",
   "invite": {

--- a/src/i18n/locales/el/common.json
+++ b/src/i18n/locales/el/common.json
@@ -747,6 +747,55 @@
     "view_errors_one": "Προβολή {{count}} σφάλματος",
     "view_errors_other": "Προβολή {{count}} σφαλμάτων"
   },
+  "integrator": {
+    "create": {
+      "action": "",
+      "color": "",
+      "communications": "",
+      "country": "",
+      "country_placeholder": "",
+      "error": "",
+      "limit_reached": "",
+      "owner_email": "",
+      "owner_email_placeholder": "",
+      "quota_exceeded": "",
+      "subdomain": "",
+      "subtitle": "",
+      "success": "",
+      "timezone": "",
+      "title": "",
+      "website": ""
+    },
+    "menu": {
+      "organizations": "",
+      "overview": "",
+      "section": ""
+    },
+    "organizations": {
+      "active": "",
+      "address": "",
+      "country": "",
+      "created_at": "",
+      "empty": "",
+      "empty_description": "",
+      "inactive": "",
+      "load_error": "",
+      "load_error_description": "",
+      "status": "",
+      "subtitle": "",
+      "title": "",
+      "type": ""
+    },
+    "overview": {
+      "limit_reached": "",
+      "load_error": "",
+      "managed_census": "",
+      "managed_orgs": "",
+      "managed_processes": "",
+      "subtitle": "",
+      "title": ""
+    }
+  },
   "internal_server_error": "Εσωτερικό σφάλμα διακομιστή",
   "invalid_promo_code": "Μη έγκυρος κωδικός προσφοράς",
   "invite": {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -747,6 +747,55 @@
     "view_errors_one": "View {{count}} error",
     "view_errors_other": "View {{count}} errors"
   },
+  "integrator": {
+    "create": {
+      "action": "Create organization",
+      "color": "Brand color",
+      "communications": "Enable communications",
+      "country": "Country",
+      "country_placeholder": "e.g. ES",
+      "error": "Failed to create organization",
+      "limit_reached": "You've reached your managed-organization limit.",
+      "owner_email": "Owner email",
+      "owner_email_placeholder": "Existing user to own the org (optional)",
+      "quota_exceeded": "You've reached your integrator quota.",
+      "subdomain": "Subdomain",
+      "subtitle": "Provision a new organization under your integrator account.",
+      "success": "Organization created successfully",
+      "timezone": "Timezone",
+      "title": "Create managed organization",
+      "website": "Website"
+    },
+    "menu": {
+      "organizations": "Managed organizations",
+      "overview": "Overview",
+      "section": "Integrator"
+    },
+    "organizations": {
+      "active": "Active",
+      "address": "Address",
+      "country": "Country",
+      "created_at": "Created",
+      "empty": "No managed organizations yet",
+      "empty_description": "Create an organization to start managing it.",
+      "inactive": "Inactive",
+      "load_error": "Unable to load organizations",
+      "load_error_description": "Please try again.",
+      "status": "Status",
+      "subtitle": "Organizations you manage on behalf of your customers.",
+      "title": "Managed organizations",
+      "type": "Type"
+    },
+    "overview": {
+      "limit_reached": "Limit reached",
+      "load_error": "Unable to load integrator quota",
+      "managed_census": "Census size",
+      "managed_orgs": "Managed organizations",
+      "managed_processes": "Voting processes",
+      "subtitle": "Your integrator quota and current usage.",
+      "title": "Overview"
+    }
+  },
   "internal_server_error": "Internal server error",
   "invalid_promo_code": "Invalid promotion code",
   "invite": {

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -755,6 +755,55 @@
     "view_errors_many": "",
     "view_errors_other": "Ver {{count}} errores"
   },
+  "integrator": {
+    "create": {
+      "action": "Crear organización",
+      "color": "Color de marca",
+      "communications": "Habilitar comunicaciones",
+      "country": "País",
+      "country_placeholder": "p. ej. ES",
+      "error": "No se pudo crear la organización",
+      "limit_reached": "Has alcanzado tu límite de organizaciones gestionadas.",
+      "owner_email": "Correo del propietario",
+      "owner_email_placeholder": "Usuario existente que será propietario (opcional)",
+      "quota_exceeded": "Has alcanzado tu cuota de integrador.",
+      "subdomain": "Subdominio",
+      "subtitle": "Provisiona una nueva organización bajo tu cuenta de integrador.",
+      "success": "Organización creada correctamente",
+      "timezone": "Zona horaria",
+      "title": "Crear organización gestionada",
+      "website": "Sitio web"
+    },
+    "menu": {
+      "organizations": "Organizaciones gestionadas",
+      "overview": "Resumen",
+      "section": "Integrador"
+    },
+    "organizations": {
+      "active": "Activa",
+      "address": "Dirección",
+      "country": "País",
+      "created_at": "Creada",
+      "empty": "Aún no hay organizaciones gestionadas",
+      "empty_description": "Crea una organización para empezar a gestionarla.",
+      "inactive": "Inactiva",
+      "load_error": "No se pudieron cargar las organizaciones",
+      "load_error_description": "Inténtalo de nuevo.",
+      "status": "Estado",
+      "subtitle": "Organizaciones que gestionas en nombre de tus clientes.",
+      "title": "Organizaciones gestionadas",
+      "type": "Tipo"
+    },
+    "overview": {
+      "limit_reached": "Límite alcanzado",
+      "load_error": "No se pudo cargar la cuota de integrador",
+      "managed_census": "Tamaño del censo",
+      "managed_orgs": "Organizaciones gestionadas",
+      "managed_processes": "Procesos de votación",
+      "subtitle": "Tu cuota de integrador y uso actual.",
+      "title": "Resumen"
+    }
+  },
   "internal_server_error": "Error interno del servidor",
   "invalid_promo_code": "Código promocional no válido",
   "invite": {

--- a/src/i18n/locales/eu/common.json
+++ b/src/i18n/locales/eu/common.json
@@ -747,6 +747,55 @@
     "view_errors_one": "Ikusi {{count}} errorea",
     "view_errors_other": "Ikusi {{count}} errore"
   },
+  "integrator": {
+    "create": {
+      "action": "",
+      "color": "",
+      "communications": "",
+      "country": "",
+      "country_placeholder": "",
+      "error": "",
+      "limit_reached": "",
+      "owner_email": "",
+      "owner_email_placeholder": "",
+      "quota_exceeded": "",
+      "subdomain": "",
+      "subtitle": "",
+      "success": "",
+      "timezone": "",
+      "title": "",
+      "website": ""
+    },
+    "menu": {
+      "organizations": "",
+      "overview": "",
+      "section": ""
+    },
+    "organizations": {
+      "active": "",
+      "address": "",
+      "country": "",
+      "created_at": "",
+      "empty": "",
+      "empty_description": "",
+      "inactive": "",
+      "load_error": "",
+      "load_error_description": "",
+      "status": "",
+      "subtitle": "",
+      "title": "",
+      "type": ""
+    },
+    "overview": {
+      "limit_reached": "",
+      "load_error": "",
+      "managed_census": "",
+      "managed_orgs": "",
+      "managed_processes": "",
+      "subtitle": "",
+      "title": ""
+    }
+  },
   "internal_server_error": "Zerbitzariaren barne-errorea",
   "invalid_promo_code": "Sustapen-kodea ez da baliozkoa",
   "invite": {

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -755,6 +755,55 @@
     "view_errors_many": "",
     "view_errors_other": "Voir {{count}} erreurs"
   },
+  "integrator": {
+    "create": {
+      "action": "",
+      "color": "",
+      "communications": "",
+      "country": "",
+      "country_placeholder": "",
+      "error": "",
+      "limit_reached": "",
+      "owner_email": "",
+      "owner_email_placeholder": "",
+      "quota_exceeded": "",
+      "subdomain": "",
+      "subtitle": "",
+      "success": "",
+      "timezone": "",
+      "title": "",
+      "website": ""
+    },
+    "menu": {
+      "organizations": "",
+      "overview": "",
+      "section": ""
+    },
+    "organizations": {
+      "active": "",
+      "address": "",
+      "country": "",
+      "created_at": "",
+      "empty": "",
+      "empty_description": "",
+      "inactive": "",
+      "load_error": "",
+      "load_error_description": "",
+      "status": "",
+      "subtitle": "",
+      "title": "",
+      "type": ""
+    },
+    "overview": {
+      "limit_reached": "",
+      "load_error": "",
+      "managed_census": "",
+      "managed_orgs": "",
+      "managed_processes": "",
+      "subtitle": "",
+      "title": ""
+    }
+  },
   "internal_server_error": "Erreur interne du serveur",
   "invalid_promo_code": "Code promotionnel invalide",
   "invite": {

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -755,6 +755,55 @@
     "view_errors_many": "View {{count}} errors",
     "view_errors_other": "Visualizza {{count}} errori"
   },
+  "integrator": {
+    "create": {
+      "action": "Crea organizzazione",
+      "color": "Colore del marchio",
+      "communications": "Abilita le comunicazioni",
+      "country": "Paese",
+      "country_placeholder": "es. ES",
+      "error": "Impossibile creare l'organizzazione",
+      "limit_reached": "Hai raggiunto il limite di organizzazioni gestite.",
+      "owner_email": "Email del proprietario",
+      "owner_email_placeholder": "Utente esistente che sarà proprietario (facoltativo)",
+      "quota_exceeded": "Hai raggiunto la tua quota di integratore.",
+      "subdomain": "Sottodominio",
+      "subtitle": "Crea una nuova organizzazione sotto il tuo account integratore.",
+      "success": "Organizzazione creata con successo",
+      "timezone": "Fuso orario",
+      "title": "Crea organizzazione gestita",
+      "website": "Sito web"
+    },
+    "menu": {
+      "organizations": "Organizzazioni gestite",
+      "overview": "Panoramica",
+      "section": "Integratore"
+    },
+    "organizations": {
+      "active": "Attiva",
+      "address": "Indirizzo",
+      "country": "Paese",
+      "created_at": "Creata",
+      "empty": "Nessuna organizzazione gestita",
+      "empty_description": "Crea un'organizzazione per iniziare a gestirla.",
+      "inactive": "Inattiva",
+      "load_error": "Impossibile caricare le organizzazioni",
+      "load_error_description": "Riprova.",
+      "status": "Stato",
+      "subtitle": "Organizzazioni che gestisci per conto dei tuoi clienti.",
+      "title": "Organizzazioni gestite",
+      "type": "Tipo"
+    },
+    "overview": {
+      "limit_reached": "Limite raggiunto",
+      "load_error": "Impossibile caricare la quota di integratore",
+      "managed_census": "Dimensione del censimento",
+      "managed_orgs": "Organizzazioni gestite",
+      "managed_processes": "Processi di voto",
+      "subtitle": "La tua quota di integratore e l'utilizzo attuale.",
+      "title": "Panoramica"
+    }
+  },
   "internal_server_error": "Errore interno del server",
   "invalid_promo_code": "Codice promozione non valido",
   "invite": {

--- a/src/i18n/locales/pt-br/common.json
+++ b/src/i18n/locales/pt-br/common.json
@@ -755,6 +755,55 @@
     "view_errors_many": "",
     "view_errors_other": "Ver {{count}} erros"
   },
+  "integrator": {
+    "create": {
+      "action": "",
+      "color": "",
+      "communications": "",
+      "country": "",
+      "country_placeholder": "",
+      "error": "",
+      "limit_reached": "",
+      "owner_email": "",
+      "owner_email_placeholder": "",
+      "quota_exceeded": "",
+      "subdomain": "",
+      "subtitle": "",
+      "success": "",
+      "timezone": "",
+      "title": "",
+      "website": ""
+    },
+    "menu": {
+      "organizations": "",
+      "overview": "",
+      "section": ""
+    },
+    "organizations": {
+      "active": "",
+      "address": "",
+      "country": "",
+      "created_at": "",
+      "empty": "",
+      "empty_description": "",
+      "inactive": "",
+      "load_error": "",
+      "load_error_description": "",
+      "status": "",
+      "subtitle": "",
+      "title": "",
+      "type": ""
+    },
+    "overview": {
+      "limit_reached": "",
+      "load_error": "",
+      "managed_census": "",
+      "managed_orgs": "",
+      "managed_processes": "",
+      "subtitle": "",
+      "title": ""
+    }
+  },
   "internal_server_error": "Erro interno do servidor",
   "invalid_promo_code": "Código promocional inválido",
   "invite": {

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -755,6 +755,55 @@
     "view_errors_many": "",
     "view_errors_other": "Ver {{count}} erros"
   },
+  "integrator": {
+    "create": {
+      "action": "",
+      "color": "",
+      "communications": "",
+      "country": "",
+      "country_placeholder": "",
+      "error": "",
+      "limit_reached": "",
+      "owner_email": "",
+      "owner_email_placeholder": "",
+      "quota_exceeded": "",
+      "subdomain": "",
+      "subtitle": "",
+      "success": "",
+      "timezone": "",
+      "title": "",
+      "website": ""
+    },
+    "menu": {
+      "organizations": "",
+      "overview": "",
+      "section": ""
+    },
+    "organizations": {
+      "active": "",
+      "address": "",
+      "country": "",
+      "created_at": "",
+      "empty": "",
+      "empty_description": "",
+      "inactive": "",
+      "load_error": "",
+      "load_error_description": "",
+      "status": "",
+      "subtitle": "",
+      "title": "",
+      "type": ""
+    },
+    "overview": {
+      "limit_reached": "",
+      "load_error": "",
+      "managed_census": "",
+      "managed_orgs": "",
+      "managed_processes": "",
+      "subtitle": "",
+      "title": ""
+    }
+  },
   "internal_server_error": "Erro interno do servidor",
   "invalid_promo_code": "Código promocional inválido",
   "invite": {

--- a/src/queries/integrator.ts
+++ b/src/queries/integrator.ts
@@ -1,0 +1,150 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { enforceHexPrefix, useOrganization } from '@vocdoni/react-components'
+import { ApiEndpoints } from '~components/Auth/api'
+import { useAuth } from '~components/Auth/useAuth'
+import { useProfile } from '~queries/account'
+import { useUrlPagination } from '~queries/members'
+import { QueryKeys } from './keys'
+
+// Mirrors the backend OrganizationInfo fields we display (saas-backend#525).
+export type ManagedOrganization = {
+  address: string
+  website: string
+  createdAt: string
+  type: string
+  size: string
+  color: string
+  subdomain: string
+  country: string
+  timezone: string
+  active: boolean
+  communications: boolean
+}
+
+export type IntegratorLimits = {
+  maxManagedOrgs: number
+  maxManagedProcesses: number
+  maxManagedCensusSize: number
+}
+
+export type IntegratorUsage = {
+  managedOrgs: number
+  managedProcesses: number
+  managedCensusSize: number
+}
+
+// GET /organizations/{address}/integrator. `limits` is present only when enabled.
+export type IntegratorInfo = {
+  enabled: boolean
+  limits?: IntegratorLimits
+  usage: IntegratorUsage
+}
+
+export type ManagedOrganizationsResponse = {
+  pagination: {
+    totalItems: number
+    currentPage: number
+    lastPage: number
+    previousPage: number | null
+    nextPage: number | null
+  }
+  organizations: ManagedOrganization[]
+}
+
+// Body of POST /organizations/{address}/managed. Only `type` is required.
+export type CreateManagedOrganizationBody = {
+  type: string
+  website?: string
+  size?: string
+  color?: string
+  subdomain?: string
+  country?: string
+  timezone?: string
+  communications?: boolean
+  ownerEmail?: string
+}
+
+/**
+ * Fetches the integrator quota/usage for the current organization. A non-integrator org returns
+ * `{ enabled: false }`; a 403/404 (e.g. the caller lacks the role) is also treated as "not an
+ * integrator" so detection never throws the dashboard into an error state.
+ */
+export const useIntegratorInfo = () => {
+  const { bearedFetch } = useAuth()
+  const { organization } = useOrganization()
+  const address = organization?.address
+
+  return useQuery<IntegratorInfo>({
+    queryKey: QueryKeys.integrator.info(address),
+    enabled: !!address,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+    queryFn: () =>
+      bearedFetch<IntegratorInfo>(ApiEndpoints.Integrator.replace('{address}', enforceHexPrefix(address))).catch(
+        () => ({ enabled: false, usage: { managedOrgs: 0, managedProcesses: 0, managedCensusSize: 0 } })
+      ),
+  })
+}
+
+/**
+ * Paginated list of organizations managed by the current integrator. Mirrors the drafts pagination
+ * pattern: page comes from the route, limit from the `limit` query param (see `useUrlPagination`).
+ */
+export const usePaginatedManagedOrganizations = () => {
+  const { bearedFetch } = useAuth()
+  const { organization } = useOrganization()
+  const { page, limit } = useUrlPagination()
+  const address = organization?.address
+
+  const baseUrl = ApiEndpoints.ManagedOrganizations.replace('{address}', enforceHexPrefix(address))
+  const fetchUrl = `${baseUrl}?page=${page}&limit=${limit}`
+
+  return useQuery<ManagedOrganizationsResponse>({
+    queryKey: [...QueryKeys.integrator.managed(address), page, limit],
+    enabled: !!address,
+    queryFn: () => bearedFetch<ManagedOrganizationsResponse>(fetchUrl),
+  })
+}
+
+/**
+ * Creates a new managed organization under the current integrator. Refreshes both the managed-org
+ * list and the integrator quota on success.
+ */
+export const useCreateManagedOrganization = () => {
+  const { bearedFetch } = useAuth()
+  const { organization } = useOrganization()
+  const queryClient = useQueryClient()
+  const address = organization?.address
+
+  return useMutation<ManagedOrganization, Error, CreateManagedOrganizationBody>({
+    mutationFn: (body: CreateManagedOrganizationBody) =>
+      bearedFetch<ManagedOrganization>(
+        ApiEndpoints.ManagedOrganizations.replace('{address}', enforceHexPrefix(address)),
+        {
+          method: 'POST',
+          body,
+        }
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QueryKeys.integrator.managed(address) })
+      queryClient.invalidateQueries({ queryKey: QueryKeys.integrator.info(address) })
+    },
+  })
+}
+
+const normalizeAddress = (address?: string) => (address ? address.toLowerCase().replace(/^0x/, '') : '')
+
+/**
+ * Returns the logged-in user's role string ('admin' | 'manager' | 'viewer') for the current
+ * organization, or undefined if not a member.
+ */
+export const useCurrentOrgRole = (): string | undefined => {
+  const { data: profile } = useProfile()
+  const { organization } = useOrganization()
+  const address = normalizeAddress(organization?.address)
+  if (!profile || !address) return undefined
+  return profile.organizations.find((o) => normalizeAddress(o.organization?.address) === address)?.role
+}
+
+// Creating a managed org is admin-only (the backend enforces this; the UI mirrors it).
+export const useIsIntegratorAdmin = (): boolean => useCurrentOrgRole() === 'admin'

--- a/src/queries/keys.ts
+++ b/src/queries/keys.ts
@@ -16,6 +16,10 @@ export const QueryKeys = {
     drafts: (address?: string) => ['organizations', 'drafts', address].filter(Boolean),
     groups: (address?: string) => ['organizations', 'groups', address].filter(Boolean),
   },
+  integrator: {
+    info: (address?: string) => ['integrator', 'info', address].filter(Boolean),
+    managed: (address?: string) => ['integrator', 'managed', address].filter(Boolean),
+  },
   census: {
     bundle: (censusURI?: string) => ['census', 'bundle', censusURI].filter(Boolean),
   },

--- a/src/router/routes/dashboard.tsx
+++ b/src/router/routes/dashboard.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useClient } from '@vocdoni/react-components'
 import { Fragment, lazy } from 'react'
 import { generatePath, LoaderFunctionArgs, Navigate, Params, ShouldRevalidateFunctionArgs } from 'react-router-dom'
+import IntegratorProtectedRoute from '~components/Integrator/IntegratorProtectedRoute'
 import Error from '~elements/Error'
 import LayoutDashboard from '~elements/LayoutDashboard'
 import { paginatedElectionsQuery } from '~queries/organization'
@@ -30,6 +31,8 @@ const Settings = lazy(() => import('~elements/dashboard/settings'))
 const Memberbase = lazy(() => import('~elements/dashboard/memberbase'))
 const Members = lazy(() => import('~elements/dashboard/memberbase/members'))
 const Groups = lazy(() => import('~elements/dashboard/memberbase/groups'))
+const IntegratorDashboard = lazy(() => import('~elements/dashboard/integrator'))
+const ManagedOrganizations = lazy(() => import('~elements/dashboard/integrator/organizations'))
 
 // others
 const Dashboard = lazy(() => import('~elements/dashboard'))
@@ -90,6 +93,34 @@ export const useDashboardRoutes = () => {
               </SuspenseLoader>
             ),
             children: [
+              // Integrator app: a separate experience gated to integrator-enabled organizations.
+              {
+                element: (
+                  <SuspenseLoader>
+                    <IntegratorProtectedRoute />
+                  </SuspenseLoader>
+                ),
+                children: [
+                  {
+                    path: Routes.dashboard.integrator.base,
+                    element: (
+                      <SuspenseLoader>
+                        <IntegratorDashboard />
+                      </SuspenseLoader>
+                    ),
+                    errorElement: <Error />,
+                  },
+                  {
+                    path: Routes.dashboard.integrator.organizations,
+                    element: (
+                      <SuspenseLoader>
+                        <ManagedOrganizations />
+                      </SuspenseLoader>
+                    ),
+                    errorElement: <Error />,
+                  },
+                ],
+              },
               {
                 path: Routes.dashboard.process,
                 element: (

--- a/src/router/routes/index.ts
+++ b/src/router/routes/index.ts
@@ -23,6 +23,10 @@ export const Routes = {
       drafts: '/admin/processes/drafts/:page?',
     },
     profile: '/admin/profile',
+    integrator: {
+      base: '/admin/integrator',
+      organizations: '/admin/integrator/organizations/:page?',
+    },
     memberbase: {
       base: '/admin/memberbase',
       members: '/admin/memberbase/members/:page?',


### PR DESCRIPTION
## What

Adds an **Integrator Dashboard** to the SaaS app. An "integrator" is an organization enabled to provision and manage other organizations on behalf of its customers, subject to a quota.

Integrators and regular orgs **share the login portal but land in different apps**: an integrator gets no elections and no memberbase — only a quota overview and the organizations it manages. After login the current org's integrator status is auto-detected via `GET /organizations/{address}/integrator`, and enabled orgs are redirected to `/admin/integrator` with a dedicated sidebar.

Backend counterpart: **vocdoni/saas-backend#525** (`feat(organizations): integrator layer with managed orgs and quotas`). This PR consumes exactly the three endpoints it exposes — no others are assumed.

## Screens

1. **Overview** (`/admin/integrator`) — three quota cards (managed orgs, processes, census size), each showing usage / limit with a progress bar; metrics at/over their limit are flagged.
2. **Managed organizations** (`/admin/integrator/organizations`) — paginated table (address, type, country, created, status); rows link to the public org detail page.
3. **Create managed organization** — admin-only modal (managers can view but not create), disabled when the managed-orgs quota is reached, with a tailored message when the backend reports the quota error.

## Endpoints used (saas-backend#525)

- `GET /organizations/{address}/integrator` — quota + usage (admin or manager)
- `GET /organizations/{address}/managed?page=&limit=` — paginated managed orgs (admin or manager)
- `POST /organizations/{address}/managed` — create managed org (admin only)

## Role gating (mirrors backend enforcement)

- View dashboard: **admin or manager** of the integrator org.
- Create managed org: **admin only** — the action is hidden for managers.

## How it works / notable choices

- New `src/queries/integrator.ts` with `useIntegratorInfo`, `usePaginatedManagedOrganizations`, `useCreateManagedOrganization` (all over the shared `bearedFetch` + react-query), plus `useCurrentOrgRole` / `useIsIntegratorAdmin` derived from `useProfile()`.
- Reuses existing patterns: the drafts pagination idiom (`RoutedPaginationProvider` + `RoutedPaginatedTableFooter`), `ModalForm`, and the org selectors (`OrganizationTypeSelector`, `MembershipSizeSelector`).
- The menu and the `/admin` landing fork on `integrator.enabled`; integrators keep only the Overview + Managed Organizations nav plus Support and Profile.
- Integrator routes are guarded so a non-integrator org hitting `/admin/integrator/*` is bounced back to `/admin`.
- i18n: new keys added; en/es/ca/it translated.

### Assumption / correction
The brief described the create quota error as HTTP 403. In saas-backend#525 the managed-orgs quota error is actually **HTTP 400, code `40154` (`ErrMaxManagedOrgsReached`)**; `403/40153` means "not an integrator". The error handling special-cases `40154` and `40155` accordingly.

## Out of scope (no API support — follow-ups)

Editing/disabling an integrator, editing quota, and editing/deleting a managed org are intentionally absent — the backend exposes no such endpoints.

## Verification

- `pnpm lint` (tsc + prettier) ✅
- `pnpm test` ✅ (463 passed)
- `pnpm translations` produces a clean locale diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)