### PR TITLE
feat(platform): use path-less integrator endpoints (saas-backend#549)

### DIFF
--- a/src/platform/api/endpoints.ts
+++ b/src/platform/api/endpoints.ts
@@ -25,9 +25,10 @@ export enum ApiEndpoints {
   SubscriptionCheckout = 'subscriptions/checkout',
   OrganizationSubscription = 'organizations/{address}/subscription',
   SubscriptionPortal = 'subscriptions/{address}/portal',
-  // Integrator (saas-backend#525)
-  Integrator = 'organizations/{address}/integrator',
-  ManagedOrganizations = 'organizations/{address}/managed',
+  // Integrator (saas-backend#549) — path-less; the integrator org is resolved server-side from
+  // the session (or an API key), so no organization address is passed in the URL.
+  Integrator = 'integrator',
+  ManagedOrganizations = 'integrator/organizations',
   // API keys (saas-backend#535)
   APIKeys = 'organizations/{address}/apikeys',
   APIKey = 'organizations/{address}/apikeys/{keyID}',

--- a/src/platform/queries/integrator.ts
+++ b/src/platform/queries/integrator.ts
@@ -4,8 +4,6 @@ import { useAuth } from '~platform/auth/AuthContext'
 import { useOrg } from '~platform/auth/OrgContext'
 import { QueryKeys } from './keys'
 
-const ensure0x = (address: string) => (address.startsWith('0x') ? address : `0x${address}`)
-
 // Mirrors the backend OrganizationInfo fields we display (saas-backend#525).
 export type ManagedOrganization = {
   address: string
@@ -33,7 +31,7 @@ export type IntegratorUsage = {
   managedCensusSize: number
 }
 
-// GET /organizations/{address}/integrator. `limits` is present only when enabled.
+// GET /integrator. `limits` is present only when enabled.
 export type IntegratorInfo = {
   enabled: boolean
   limits?: IntegratorLimits
@@ -66,9 +64,10 @@ export const useIntegratorInfo = () => {
     staleTime: 5 * 60 * 1000,
     retry: false,
     queryFn: () =>
-      bearedFetch<IntegratorInfo>(ApiEndpoints.Integrator.replace('{address}', ensure0x(selectedAddress!))).catch(
-        () => ({ enabled: false, usage: { managedOrgs: 0, managedProcesses: 0, managedCensusSize: 0 } })
-      ),
+      bearedFetch<IntegratorInfo>(ApiEndpoints.Integrator).catch(() => ({
+        enabled: false,
+        usage: { managedOrgs: 0, managedProcesses: 0, managedCensusSize: 0 },
+      })),
   })
 }
 
@@ -80,9 +79,7 @@ export const usePaginatedManagedOrganizations = (page: number, limit: number) =>
   return useQuery<ManagedOrganizationsResponse>({
     queryKey: [...QueryKeys.integrator.managed(selectedAddress), page, limit],
     enabled: !!selectedAddress,
-    queryFn: () => {
-      const base = ApiEndpoints.ManagedOrganizations.replace('{address}', ensure0x(selectedAddress!))
-      return bearedFetch<ManagedOrganizationsResponse>(`${base}?page=${page}&limit=${limit}`)
-    },
+    queryFn: () =>
+      bearedFetch<ManagedOrganizationsResponse>(`${ApiEndpoints.ManagedOrganizations}?page=${page}&limit=${limit}`),
   })
 }


### PR DESCRIPTION
Stacked on #1700. Merge #1700 → develop first, then this.

## What

Adopts the breaking path-less integrator API from **saas-backend#549**: the integrator org is resolved server-side from the session (or an API key), so the URL no longer carries an address.

| before | after |
|---|---|
| `GET organizations/{address}/integrator` | `GET integrator` |
| `GET organizations/{address}/managed` | `GET integrator/managed` |

- `ApiEndpoints.Integrator` / `ManagedOrganizations` updated to the path-less values.
- `useIntegratorInfo` / `usePaginatedManagedOrganizations` drop the `{address}` substitution (and the now-unused `ensure0x`). `selectedAddress` is kept only for cache keying + the `enabled` guard.

The platform reads these two endpoints only; there's no create-managed UI to change. `tsc`, Prettier and `pnpm build:platform` all green.

## Merge order

1. saas-backend#549 (the backend change) → merged + deployed to the environment the platform points at
2. vocdoni-app#1700 → develop
3. this PR → develop

Until #549 is live, these calls 404 against an un-patched backend.