### PR TITLE
refactor(subscriptions): match plans by stable name

### DIFF
--- a/src/components/Auth/Subscription.tsx
+++ b/src/components/Auth/Subscription.tsx
@@ -16,7 +16,7 @@ type PermissionsContextType = {
 
 export type SubscriptionType = {
   subscriptionDetails: {
-    planId: number
+    planId: string
     startDate: string
     endDate: string
     lastPaymentDate: string

--- a/src/components/Organization/Dashboard/index.tsx
+++ b/src/components/Organization/Dashboard/index.tsx
@@ -35,7 +35,7 @@ import { DashboardBox, Heading, SubHeading } from '~components/Dashboard/Content
 import { ListStateAlert } from '~components/Feedback/ListStateAlert'
 import InvertedAccordionIcon from '~components/Layout/InvertedAccordionIcon'
 import { WhatsAppButton } from '~components/Layout/WhatsappButton'
-import { PlanId } from '~constants'
+import { isPlanNamed, PlanName } from '~constants'
 import { usePublicLanguage } from '~i18n/usePublicLanguage'
 import { Routes } from '~routes'
 import { useAppEnv } from '~src/app-env'
@@ -101,7 +101,7 @@ const Tutorial = () => {
           </Text>
         ) : (
           subscription &&
-          subscription.plan.id === PlanId.Free && (
+          isPlanNamed(subscription.plan, PlanName.Free) && (
             <Text color='gray.500' mb={4}>
               <Trans i18nKey='plan.free'>
                 <strong>You're on the Free Plan</strong>, which already lets you launch votes. If you need more

--- a/src/components/Pricing/Card.test.tsx
+++ b/src/components/Pricing/Card.test.tsx
@@ -1,11 +1,10 @@
 import { FormProvider, useForm } from 'react-hook-form'
-import { PlanId } from '~constants'
 import { createTestI18n, render, screen, TestMemoryRouter } from '~src/test-utils'
 import PricingCard from './Card'
 
 vi.mock('~components/Auth/Subscription', () => ({
   useSubscription: () => ({
-    subscription: { plan: { id: 3 }, subscriptionDetails: { active: false } },
+    subscription: { plan: { name: 'Free' }, subscriptionDetails: { active: false } },
   }),
 }))
 
@@ -35,6 +34,7 @@ vi.mock('./Plans', async (importOriginal) => {
   return {
     ...actual,
     usePlanTranslations: () => ({}),
+    usePlans: () => ({ data: [] }),
   }
 })
 
@@ -69,13 +69,15 @@ describe('PricingCard', () => {
             popular={false}
             isDisabled={false}
             isCurrentPlan={false}
+            isCustom={false}
             plan={
               {
-                id: PlanId.Essential,
+                id: 'prod_starter',
+                name: 'Starter',
                 monthlyPrice: 10,
                 yearlyPrice: 100,
                 freeTrialDays: 0,
-                organization: { customPlan: false },
+                organization: {},
               } as any
             }
             features={[{ icon: () => null, text: 'Feature A' }]}
@@ -105,13 +107,15 @@ describe('PricingCard', () => {
             popular={false}
             isDisabled={false}
             isCurrentPlan={false}
+            isCustom={false}
             plan={
               {
-                id: PlanId.Essential,
+                id: 'prod_starter',
+                name: 'Starter',
                 monthlyPrice: 10,
                 yearlyPrice: 100,
                 freeTrialDays: 0,
-                organization: { customPlan: false },
+                organization: {},
               } as any
             }
             features={[{ icon: () => null, text: 'Feature A' }]}

--- a/src/components/Pricing/Card.tsx
+++ b/src/components/Pricing/Card.tsx
@@ -9,12 +9,12 @@ import { Link as RouterLink, useLocation } from 'react-router-dom'
 import { useSubscription } from '~components/Auth/Subscription'
 import ContactButton from '~components/ContactLink'
 import { BookerModalButton } from '~components/Dashboard/Booker'
-import { PlanId } from '~constants'
+import { getPlanKey, isPlanNamed, PlanName } from '~constants'
 import { useProfile } from '~queries/account'
 import { usePortalSession } from '~queries/stripe'
 import { Routes } from '~routes'
 import { currency } from '~utils/numbers'
-import { usePlanTranslations, type Plan } from './Plans'
+import { usePlans, usePlanTranslations, type Plan } from './Plans'
 
 gsap.registerPlugin(useGSAP)
 
@@ -26,6 +26,7 @@ type PricingCardProps = {
   features: { icon: React.ElementType; text: string }[]
   isDisabled?: boolean
   isCurrentPlan: boolean
+  isCustom: boolean
   width?: string
   plan: Plan
 }
@@ -38,11 +39,13 @@ const PricingCard = ({
   features,
   isDisabled,
   isCurrentPlan,
+  isCustom,
   plan,
 }: PricingCardProps) => {
   const { t } = useTranslation()
   const translations = usePlanTranslations()
   const { subscription } = useSubscription()
+  const { data: plans } = usePlans()
   const { mutateAsync, isPending } = usePortalSession()
   const { setValue, watch } = useFormContext()
   const { data: me } = useProfile()
@@ -56,13 +59,19 @@ const PricingCard = ({
     w: 'full',
   }
 
-  const isCustomPlan = plan?.organization?.customPlan || plan.id === PlanId.Custom
+  const isCustomPlan = isCustom
   const period = watch('billingPeriod', 'year')
   const isDashboard = pathname.startsWith(Routes.dashboard.base)
+  // The lightweight org subscription only exposes the plan's product key, so we
+  // resolve the Free plan's id from the plans list to detect prior paid subscriptions.
+  const freePlanId = plans?.find((p) => isPlanNamed(p, PlanName.Free))?.id
   const hadSubscribed =
-    typeof me?.organizations.find(({ organization }) => organization.subscription?.planId !== PlanId.Free) !==
-    'undefined'
-  const hasActiveSubscription = subscription?.plan.id !== PlanId.Free && !!subscription?.subscriptionDetails.active
+    !!freePlanId &&
+    !!me?.organizations.some(
+      ({ organization }) => organization.subscription && organization.subscription.planId !== freePlanId
+    )
+  const hasActiveSubscription =
+    !isPlanNamed(subscription?.plan, PlanName.Free) && !!subscription?.subscriptionDetails.active
   const ContactLink = ({ children }: { children?: ReactNode }) => (
     <Link asChild>
       <RouterLink to={Routes.dashboard.settings.support}>{children}</RouterLink>
@@ -169,7 +178,7 @@ const PricingCard = ({
           )}
         </Flex>
       </Card.Body>
-      {(plan.id === PlanId.Premium || plan.id === PlanId.Essential) && (
+      {(isPlanNamed(plan, PlanName.Professional) || isPlanNamed(plan, PlanName.Starter)) && (
         <Text fontSize='xs' fontStyle='italic' textAlign='center'>
           <Trans i18nKey='pricing_card.need_more_members' components={{ 2: <ContactLink /> }} />
         </Text>
@@ -222,7 +231,7 @@ const PricingCard = ({
                   ? t('current_plan', { defaultValue: 'Current Plan' })
                   : t('upgrade_plan', {
                       defaultValue: 'Upgrade to {{plan}}',
-                      plan: translations[plan.id]?.title || plan.name,
+                      plan: translations[getPlanKey(plan) as PlanName]?.title || plan.name,
                     })}
               </Button>
             )

--- a/src/components/Pricing/Card.tsx
+++ b/src/components/Pricing/Card.tsx
@@ -60,6 +60,7 @@ const PricingCard = ({
   }
 
   const isCustomPlan = isCustom
+  const planKey = getPlanKey(plan)
   const period = watch('billingPeriod', 'year')
   const isDashboard = pathname.startsWith(Routes.dashboard.base)
   // The lightweight org subscription only exposes the plan's product key, so we
@@ -231,7 +232,7 @@ const PricingCard = ({
                   ? t('current_plan', { defaultValue: 'Current Plan' })
                   : t('upgrade_plan', {
                       defaultValue: 'Upgrade to {{plan}}',
-                      plan: translations[getPlanKey(plan) as PlanName]?.title || plan.name,
+                      plan: (planKey ? translations[planKey]?.title : undefined) || plan.name,
                     })}
               </Button>
             )

--- a/src/components/Pricing/ComparisonTable.test.tsx
+++ b/src/components/Pricing/ComparisonTable.test.tsx
@@ -5,15 +5,16 @@ vi.mock('./Plans', () => ({
   usePlans: () => ({
     data: [
       {
-        id: 'basic',
+        id: 'prod_starter',
+        name: 'Starter',
         limits: { maxMembers: 10 },
-        organization: { customPlan: false },
+        organization: {},
       },
     ],
     isLoading: false,
   }),
   usePlanTranslations: () => ({
-    basic: { title: 'Basic' },
+    Starter: { title: 'Basic' },
   }),
 }))
 

--- a/src/components/Pricing/ComparisonTable.tsx
+++ b/src/components/Pricing/ComparisonTable.tsx
@@ -14,7 +14,7 @@ import {
   LuZap,
 } from 'react-icons/lu'
 import { BooleanIcon } from '~components/Layout/BooleanIcon'
-import { PlanId } from '~constants'
+import { getPlanKey, PlanName } from '~constants'
 import { CategorizedSpecs, CategoryTitleKeys, FeatureSpec } from './Features'
 import { Plan, usePlans, usePlanTranslations } from './Plans'
 
@@ -130,7 +130,8 @@ export const ComparisonTable = forwardRef<HTMLDivElement, ComparisonTableProps>(
     )
   }
 
-  const filteredPlans = plans.filter((plan) => !(plan?.organization?.customPlan || plan.id === PlanId.Custom))
+  // The custom plan is no longer returned by the API, so all returned plans are shown.
+  const filteredPlans = plans ?? []
 
   return (
     <Flex ref={ref} justifyContent='center' w='full' display='block'>
@@ -149,7 +150,7 @@ export const ComparisonTable = forwardRef<HTMLDivElement, ComparisonTableProps>(
                   <Table.ColumnHeader key={plan.id} textAlign='center'>
                     <Flex flexDirection={'column'} justifyContent={'center'}>
                       <Text as={'span'} textAlign={'center'}>
-                        {translations[plan.id].title}
+                        {translations[getPlanKey(plan) as PlanName]?.title ?? plan.name}
                       </Text>
                     </Flex>
                   </Table.ColumnHeader>

--- a/src/components/Pricing/ComparisonTable.tsx
+++ b/src/components/Pricing/ComparisonTable.tsx
@@ -146,11 +146,12 @@ export const ComparisonTable = forwardRef<HTMLDivElement, ComparisonTableProps>(
               </Table.ColumnHeader>
 
               {filteredPlans.map((plan) => {
+                const planKey = getPlanKey(plan)
                 return (
                   <Table.ColumnHeader key={plan.id} textAlign='center'>
                     <Flex flexDirection={'column'} justifyContent={'center'}>
                       <Text as={'span'} textAlign={'center'}>
-                        {translations[getPlanKey(plan) as PlanName]?.title ?? plan.name}
+                        {(planKey ? translations[planKey]?.title : undefined) ?? plan.name}
                       </Text>
                     </Flex>
                   </Table.ColumnHeader>

--- a/src/components/Pricing/Features.tsx
+++ b/src/components/Pricing/Features.tsx
@@ -2,7 +2,7 @@ import { Flex, TagLabel, TagRoot, Text } from '@chakra-ui/react'
 import { dotobject } from '@vocdoni/sdk'
 import { Trans, useTranslation } from 'react-i18next'
 import { BooleanIcon } from '~components/Layout/BooleanIcon'
-import { PlanId, SubscriptionPermission } from '~constants'
+import { isPlanNamed, PlanName, SubscriptionPermission } from '~constants'
 import type { Plan } from './Plans'
 
 export type PlanFeatureSpec = {
@@ -131,7 +131,7 @@ export const CategorizedSpecs: Record<string, FeatureSpec[]> = {
   ],
   customization: [
     staticFeature('basicBranding', 'features.basic_branding', {
-      render: (plan) => (plan.id === PlanId.Premium ? <OnDemandTag /> : false),
+      render: (plan) => (isPlanNamed(plan, PlanName.Professional) ? <OnDemandTag /> : false),
     }),
     planFeature(SubscriptionPermission.WhiteLabel, 'features.white_label'),
     planFeature(SubscriptionPermission.Personalization, 'features.personalization'),
@@ -140,10 +140,10 @@ export const CategorizedSpecs: Record<string, FeatureSpec[]> = {
   extraFeatures: [
     planFeature(SubscriptionPermission.LiveResults, 'features.live_results', 'features.tooltips.live_results'),
     staticFeature('emailNotifications', 'features.email_notifications', {
-      render: (plan) => (plan.id === PlanId.Premium ? <OnDemandTag /> : false),
+      render: (plan) => (isPlanNamed(plan, PlanName.Professional) ? <OnDemandTag /> : false),
     }),
     staticFeature('smsNotifications', 'features.sms_notifications', {
-      render: (plan) => (plan.id === PlanId.Premium ? <OnDemandTag /> : false),
+      render: (plan) => (isPlanNamed(plan, PlanName.Professional) ? <OnDemandTag /> : false),
     }),
     planFeature(SubscriptionPermission.LiveStreaming, 'features.live_streaming'),
   ],
@@ -157,7 +157,7 @@ export const CategorizedSpecs: Record<string, FeatureSpec[]> = {
   ],
   support: [
     staticFeature('prioritySupport', 'features.priority_support', {
-      available: (plan) => (plan.id === PlanId.Premium ? true : false),
+      available: (plan) => (isPlanNamed(plan, PlanName.Professional) ? true : false),
     }),
     staticFeature('emailSupport', 'features.email_support', {
       available: () => true,
@@ -167,9 +167,9 @@ export const CategorizedSpecs: Record<string, FeatureSpec[]> = {
           <Flex flexDirection='column' alignItems='center' gap={1}>
             <BooleanIcon value={true} />
             <Text fontSize='xs'>
-              {plan.id === PlanId.Premium
+              {isPlanNamed(plan, PlanName.Professional)
                 ? t('features.email_support_premium', { defaultValue: '(24h resp.)' })
-                : plan.id === PlanId.Essential
+                : isPlanNamed(plan, PlanName.Starter)
                   ? t('features.email_support_essential', { defaultValue: '(48h resp.)' })
                   : t('features.email_support_basic', { defaultValue: '(72h resp.)' })}
             </Text>
@@ -205,10 +205,9 @@ export const CategorizedSpecs: Record<string, FeatureSpec[]> = {
               <BooleanIcon value={true} />
               <Text fontSize='xs'>
                 {t('features.uptime_guaranteed', {
-                  suffix:
-                    plan.id === PlanId.Premium
-                      ? t('features.generic_sla', { defaultValue: 'Generic SLA' })
-                      : t('features.basic_sla', { defaultValue: 'Best-effort' }),
+                  suffix: isPlanNamed(plan, PlanName.Professional)
+                    ? t('features.generic_sla', { defaultValue: 'Generic SLA' })
+                    : t('features.basic_sla', { defaultValue: 'Best-effort' }),
                   defaultValue: 'Guaranteed ({{suffix}})',
                 })}
               </Text>

--- a/src/components/Pricing/Plans.tsx
+++ b/src/components/Pricing/Plans.tsx
@@ -246,7 +246,8 @@ export const usePlanNameTranslator = () => {
     return plans.reduce<Record<string, string>>((acc, plan) => {
       const normalizedPlanName = normalizeName(plan.name)
       if (normalizedPlanName) {
-        acc[normalizedPlanName] = planTranslations[getPlanKey(plan) as PlanName]?.title || plan.name
+        const planKey = getPlanKey(plan)
+        acc[normalizedPlanName] = (planKey ? planTranslations[planKey]?.title : undefined) || plan.name
       }
       return acc
     }, {})
@@ -296,15 +297,15 @@ export const SubscriptionPlans = () => {
     if (!plans) return []
 
     const planCards = plans.map((plan) => {
-      const key = getPlanKey(plan) as PlanName
+      const key = getPlanKey(plan)
       return {
         plan,
         isCustom: false,
         popular: isPlanNamed(plan, PlanName.Professional),
-        title: translations[key]?.title || plan.name,
-        subtitle: translations[key]?.subtitle || '',
+        title: (key ? translations[key]?.title : undefined) || plan.name,
+        subtitle: (key ? translations[key]?.subtitle : undefined) || '',
         price: period === 'year' ? plan.yearlyPrice / 12 : plan.monthlyPrice,
-        features: translations[key]?.features || [],
+        features: (key ? translations[key]?.features : undefined) || [],
         isCurrentPlan: !!subscription && isPlanNamed(plan, subscription.plan?.name),
       }
     })
@@ -376,8 +377,8 @@ export const SubscriptionPlans = () => {
             </Tabs.List>
           </Tabs.Root>
           <SimpleGrid columns={{ base: 1, md: 2, xl: 4 }} gap={6}>
-            {cards.map((card, idx) => (
-              <PricingCard key={idx} {...card} />
+            {cards.map((card) => (
+              <PricingCard key={card.plan.id} {...card} />
             ))}
           </SimpleGrid>
         </Flex>

--- a/src/components/Pricing/Plans.tsx
+++ b/src/components/Pricing/Plans.tsx
@@ -17,13 +17,13 @@ import { ApiEndpoints } from '~components/Auth/api'
 import { useSubscription } from '~components/Auth/Subscription'
 import { useAuth } from '~components/Auth/useAuth'
 import { ListStateAlert } from '~components/Feedback/ListStateAlert'
-import { PlanId } from '~constants'
+import { getPlanKey, isPlanNamed, PlanName } from '~constants'
 import { QueryKeys } from '~src/queries/keys'
 import PricingCard from './Card'
 import { useSubscriptionCheckout } from './use-subscription-checkout'
 
 export type Plan = {
-  id: number
+  id: string
   name: string
   stripeID: string
   yearlyPrice: number
@@ -39,7 +39,6 @@ export type Plan = {
     maxDuration: string
     customURL: boolean
     drafts: boolean
-    customPlan: boolean
   }
   votingTypes: {
     single: boolean
@@ -65,7 +64,7 @@ export type Plan = {
 
 export type SubscriptionCheckoutFormValues = {
   billingPeriod: 'month' | 'year'
-  planId: number | null
+  planId: string | null
 }
 
 export const usePlans = () => {
@@ -83,21 +82,25 @@ export const usePlans = () => {
 export const usePlanTranslations = (plans?: Plan[]) => {
   const { t } = useTranslation()
 
-  const byId = useMemo(() => {
-    const m = new Map<PlanId, Plan>()
-    plans?.forEach((p) => m.set(p.id, p))
+  const byName = useMemo(() => {
+    const m = new Map<string, Plan>()
+    plans?.forEach((p) => {
+      const key = normalizeName(p.name)
+      if (key) m.set(key, p)
+    })
     return m
   }, [plans])
 
-  const getMembers = (id: PlanId, fallback = 100) => byId.get(id)?.organization?.maxCensus ?? fallback
-  const getProcesses = (id: PlanId, fallback = 10) => byId.get(id)?.organization?.maxProcesses ?? fallback
-  const getTeamMembers = (id: PlanId, fallback = 1) => byId.get(id)?.organization?.teamMembers ?? fallback
-  const get2FAsms = (id: PlanId, fallback = 0) => byId.get(id)?.features?.['2FAsms'] ?? fallback
-  const get2FAemail = (id: PlanId, fallback = 0) => byId.get(id)?.features?.['2FAemail'] ?? fallback
+  const get = (name: PlanName) => byName.get(name.toLowerCase())
+  const getMembers = (name: PlanName, fallback = 100) => get(name)?.organization?.maxCensus ?? fallback
+  const getProcesses = (name: PlanName, fallback = 10) => get(name)?.organization?.maxProcesses ?? fallback
+  const getTeamMembers = (name: PlanName, fallback = 1) => get(name)?.organization?.teamMembers ?? fallback
+  const get2FAsms = (name: PlanName, fallback = 0) => get(name)?.features?.['2FAsms'] ?? fallback
+  const get2FAemail = (name: PlanName, fallback = 0) => get(name)?.features?.['2FAemail'] ?? fallback
 
-  const get2FA = (id: PlanId) => {
-    const hasEmail = Number(get2FAemail(id)) > 0
-    const hasSms = Number(get2FAsms(id)) > 0
+  const get2FA = (name: PlanName) => {
+    const hasEmail = Number(get2FAemail(name)) > 0
+    const hasSms = Number(get2FAsms(name)) > 0
 
     const suffix =
       hasSms && hasEmail
@@ -110,7 +113,7 @@ export const usePlanTranslations = (plans?: Plan[]) => {
   }
 
   const translations = {
-    [PlanId.Free]: {
+    [PlanName.Free]: {
       title: t('pricing.free_title', { defaultValue: 'Free' }),
       subtitle: t('pricing.free_subtitle', {
         defaultValue: 'Perfect for getting started',
@@ -120,21 +123,21 @@ export const usePlanTranslations = (plans?: Plan[]) => {
           icon: LuUsers,
           text: t('pricing.core_voting', {
             defaultValue: 'Up to {{ count }} members',
-            count: getMembers(PlanId.Free, 100),
+            count: getMembers(PlanName.Free, 100),
           }),
         },
         {
           icon: LuVote,
           text: t('pricing.yearly_processes', {
             defaultValue: '{{ count }} votes per year¹',
-            count: getProcesses(PlanId.Free, 10),
+            count: getProcesses(PlanName.Free, 10),
           }),
         },
         {
           icon: LuUserCheck,
           text: t('pricing.up_to_admins', {
             defaultValue: '{{ count }} admins',
-            count: getTeamMembers(PlanId.Free, 1),
+            count: getTeamMembers(PlanName.Free, 1),
           }),
         },
         {
@@ -144,7 +147,7 @@ export const usePlanTranslations = (plans?: Plan[]) => {
         {
           icon: LuShield,
           text: t('pricing.2fa', {
-            suffix: get2FA(PlanId.Free),
+            suffix: get2FA(PlanName.Free),
             defaultValue: '2FA authentication² ({{suffix}})',
           }),
         },
@@ -152,7 +155,7 @@ export const usePlanTranslations = (plans?: Plan[]) => {
         { icon: LuMail, text: t('pricing.ticket_support_72', { defaultValue: 'Email support (72h)' }) },
       ],
     },
-    [PlanId.Essential]: {
+    [PlanName.Starter]: {
       title: t('pricing.essential_title', { defaultValue: 'Essential' }),
       subtitle: t('pricing.essential_subtitle', {
         defaultValue: 'For growing organizations',
@@ -161,33 +164,33 @@ export const usePlanTranslations = (plans?: Plan[]) => {
         {
           icon: LuUsers,
           text: t('pricing.core_voting', {
-            count: getMembers(PlanId.Essential, 500),
+            count: getMembers(PlanName.Starter, 500),
           }),
         },
         {
           icon: LuVote,
           text: t('pricing.yearly_processes', {
-            count: getProcesses(PlanId.Essential, 20),
+            count: getProcesses(PlanName.Starter, 20),
           }),
         },
         {
           icon: LuUserCheck,
           text: t('pricing.up_to_admins', {
-            count: getTeamMembers(PlanId.Essential, 1),
+            count: getTeamMembers(PlanName.Starter, 1),
           }),
         },
         { icon: LuCircleCheckBig, text: t('pricing.different_voting_methods') },
         {
           icon: LuShield,
           text: t('pricing.2fa', {
-            suffix: get2FA(PlanId.Essential),
+            suffix: get2FA(PlanName.Starter),
           }),
         },
         { icon: LuChartColumn, text: t('pricing.basic_analytics', { defaultValue: 'Basic analytics' }) },
         { icon: LuMail, text: t('pricing.ticket_support_48', { defaultValue: 'Email support (48h)' }) },
       ],
     },
-    [PlanId.Premium]: {
+    [PlanName.Professional]: {
       title: t('pricing.premium_title', { defaultValue: 'Premium' }),
       subtitle: t('pricing.premium_subtitle', {
         defaultValue: 'For established organizations',
@@ -196,37 +199,31 @@ export const usePlanTranslations = (plans?: Plan[]) => {
         {
           icon: LuUsers,
           text: t('pricing.core_voting', {
-            count: getMembers(PlanId.Premium, 2000),
+            count: getMembers(PlanName.Professional, 2000),
           }),
         },
         {
           icon: LuVote,
           text: t('pricing.yearly_processes', {
-            count: getProcesses(PlanId.Premium, 50),
+            count: getProcesses(PlanName.Professional, 50),
           }),
         },
         {
           icon: LuUserCheck,
           text: t('pricing.up_to_admins', {
-            count: getTeamMembers(PlanId.Premium, 5),
+            count: getTeamMembers(PlanName.Professional, 5),
           }),
         },
         { icon: LuCircleCheckBig, text: t('pricing.different_voting_methods') },
         {
           icon: LuShield,
           text: t('pricing.2fa', {
-            suffix: get2FA(PlanId.Premium),
+            suffix: get2FA(PlanName.Professional),
           }),
         },
         { icon: LuPalette, text: t('pricing.custom_branding', { defaultValue: 'Custom branding*' }) },
         { icon: LuMail, text: t('pricing.priority_support', { defaultValue: 'Priority email support (24h)' }) },
       ],
-    },
-    [PlanId.Custom]: {
-      title: t('pricing.custom_title', { defaultValue: 'Custom' }),
-      subtitle: t('pricing.custom_subtitle', {
-        defaultValue: 'Tailored for your needs',
-      }),
     },
   }
 
@@ -249,7 +246,7 @@ export const usePlanNameTranslator = () => {
     return plans.reduce<Record<string, string>>((acc, plan) => {
       const normalizedPlanName = normalizeName(plan.name)
       if (normalizedPlanName) {
-        acc[normalizedPlanName] = planTranslations[plan.id]?.title || plan.name
+        acc[normalizedPlanName] = planTranslations[getPlanKey(plan) as PlanName]?.title || plan.name
       }
       return acc
     }, {})
@@ -269,6 +266,10 @@ export const usePlanNameTranslator = () => {
 
   return translatePlanName
 }
+
+// Synthetic plan backing the hardcoded custom card. PricingCard short-circuits all
+// plan-data usage when `isCustom` is set, so a minimal shape is enough.
+const CUSTOM_PLAN = { id: 'custom', name: 'Custom', organization: {} } as unknown as Plan
 
 export const SubscriptionPlans = () => {
   const { subscription, error: subscriptionError } = useSubscription()
@@ -294,17 +295,34 @@ export const SubscriptionPlans = () => {
   const cards = useMemo(() => {
     if (!plans) return []
 
-    return plans.map((plan) => {
+    const planCards = plans.map((plan) => {
+      const key = getPlanKey(plan) as PlanName
       return {
-        popular: plan.id === PlanId.Premium,
-        title: translations[plan.id]?.title || plan.name,
-        subtitle: translations[plan.id]?.subtitle || '',
+        plan,
+        isCustom: false,
+        popular: isPlanNamed(plan, PlanName.Professional),
+        title: translations[key]?.title || plan.name,
+        subtitle: translations[key]?.subtitle || '',
         price: period === 'year' ? plan.yearlyPrice / 12 : plan.monthlyPrice,
-        features: translations[plan.id]?.features || [],
-        isCurrentPlan: subscription && plan.id === subscription?.plan.id,
+        features: translations[key]?.features || [],
+        isCurrentPlan: !!subscription && isPlanNamed(plan, subscription.plan?.name),
       }
     })
-  }, [plans, subscription, translations, period])
+
+    // The "custom" plan no longer exists in the API; it's hardcoded and appended last.
+    planCards.push({
+      plan: CUSTOM_PLAN,
+      isCustom: true,
+      popular: false,
+      title: t('pricing.custom_title', { defaultValue: 'Custom' }),
+      subtitle: t('pricing.custom_subtitle', { defaultValue: 'Tailored for your needs' }),
+      price: 0,
+      features: [],
+      isCurrentPlan: false,
+    })
+
+    return planCards
+  }, [plans, subscription, translations, period, t])
 
   const error = plansError ?? subscriptionError
   const hasError = !!error && !isLoading
@@ -359,7 +377,7 @@ export const SubscriptionPlans = () => {
           </Tabs.Root>
           <SimpleGrid columns={{ base: 1, md: 2, xl: 4 }} gap={6}>
             {cards.map((card, idx) => (
-              <PricingCard key={idx} plan={plans[idx]} {...card} />
+              <PricingCard key={idx} {...card} />
             ))}
           </SimpleGrid>
         </Flex>

--- a/src/components/Pricing/SubscriptionPayment.tsx
+++ b/src/components/Pricing/SubscriptionPayment.tsx
@@ -28,7 +28,7 @@ import { useSubscriptionCheckout } from './use-subscription-checkout'
 
 export type SubscriptionPaymentData = {
   billingPeriod: 'month' | 'year'
-  lookupKey: number
+  lookupKey: string
 }
 
 type CheckoutResponse = {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -60,8 +60,10 @@ export const normalizePlanName = (value?: string | null) => value?.trim().toLowe
 /**
  * Whether a plan matches a given name (case-insensitively).
  */
-export const isPlanNamed = (plan: { name?: string } | null | undefined, name?: string | null) =>
-  !!normalizePlanName(plan?.name) && normalizePlanName(plan?.name) === normalizePlanName(name)
+export const isPlanNamed = (plan: { name?: string } | null | undefined, name?: string | null) => {
+  const a = normalizePlanName(plan?.name)
+  return !!a && a === normalizePlanName(name)
+}
 
 /**
  * Resolves a plan to its canonical PlanName key (or undefined if it doesn't match

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -38,12 +38,39 @@ export enum SubscriptionPermission {
   LiveStreaming = 'features.liveStreaming',
 }
 
-export enum PlanId {
-  Essential = 1,
-  Premium = 2,
-  Free = 3,
-  Custom = 4,
-}
+/**
+ * Canonical Stripe product names returned by the `/plans` endpoint. These are
+ * the stable identifiers used to match plans, since the plan `id` is now the
+ * Stripe product key (which may change).
+ */
+export const PlanName = {
+  Free: 'Free',
+  Starter: 'Starter',
+  Professional: 'Professional',
+} as const
+
+export type PlanName = (typeof PlanName)[keyof typeof PlanName]
+
+/**
+ * Normalizes a plan name for case-insensitive comparison. The API returns names
+ * in TitleCase, but matching defensively avoids breakage on casing drift.
+ */
+export const normalizePlanName = (value?: string | null) => value?.trim().toLowerCase() || undefined
+
+/**
+ * Whether a plan matches a given name (case-insensitively).
+ */
+export const isPlanNamed = (plan: { name?: string } | null | undefined, name?: string | null) =>
+  !!normalizePlanName(plan?.name) && normalizePlanName(plan?.name) === normalizePlanName(name)
+
+/**
+ * Resolves a plan to its canonical PlanName key (or undefined if it doesn't match
+ * any known plan). Useful to look up plan-specific translations by name.
+ */
+export const getPlanKey = (plan: { name?: string } | null | undefined): PlanName | undefined =>
+  (Object.values(PlanName) as string[]).find((n) => normalizePlanName(n) === normalizePlanName(plan?.name)) as
+    | PlanName
+    | undefined
 
 export const LocalStorageKeys = {
   DashboardMenuReduced: 'dashboard.menu.reduced',

--- a/src/queries/account.ts
+++ b/src/queries/account.ts
@@ -21,7 +21,7 @@ export interface Organization {
 }
 
 export interface Subscription {
-  planId: number
+  planId: string
   startDate: string
   renewalDate: string
   lastPaymentDate: string


### PR DESCRIPTION
The SAAS API no longer identifies plans by numeric ids; plan `id` is now the Stripe product key (a string that may change). Match plans by their stable `name` ('Free'/'Starter'/'Professional', case-insensitive) instead.

- Replace the numeric `PlanId` enum with `PlanName` plus `normalizePlanName`, `isPlanNamed` and `getPlanKey` helpers in `~constants`.
- Type plan/subscription ids as strings; checkout `lookupKey` now carries the product-key `plan.id`.
- Key plan translations by name (Starter/Professional reuse the existing essential/premium copy, so displayed titles are unchanged).
- Drop the API "custom" plan and hardcode the custom card, appended last.
- Fix current-plan computation (portal-vs-checkout routing, free-plan UI) that silently broke when string ids were compared against the numeric enum.
- Update Card/ComparisonTable tests to name-based mocks.