### PR TITLE
feat(platform): add votes/SMS/email usage cards to integrator dashboard

### DIFF
--- a/src/platform/components/Integrator/Overview.tsx
+++ b/src/platform/components/Integrator/Overview.tsx
@@ -37,6 +37,11 @@ export const IntegratorOverview = () => {
         <QuotaCard label='Voting processes' usage={usage.managedProcesses} limit={limits.maxManagedProcesses} />
         <QuotaCard label='Census size' usage={usage.managedCensusSize} limit={limits.maxManagedCensusSize} />
       </SimpleGrid>
+      <SimpleGrid columns={{ base: 1, md: 3 }} gap={4}>
+        <QuotaCard label='Votes emitted' usage={usage.sentVotes} limit={limits.maxVotes} />
+        <QuotaCard label='SMS used' usage={usage.sentSMS} limit={limits.maxSMS} />
+        <QuotaCard label='Emails used' usage={usage.sentEmails} limit={limits.maxEmails} />
+      </SimpleGrid>
     </Stack>
   )
 }

--- a/src/platform/queries/integrator.ts
+++ b/src/platform/queries/integrator.ts
@@ -36,12 +36,20 @@ export type IntegratorLimits = {
   maxManagedOrgs: number
   maxManagedProcesses: number
   maxManagedCensusSize: number
+  // Shared-pool caps from the integrator's plan; 0 means unlimited.
+  maxVotes: number
+  maxSMS: number
+  maxEmails: number
 }
 
 export type IntegratorUsage = {
   managedOrgs: number
   managedProcesses: number
   managedCensusSize: number
+  // Usage summed across the integrator's managed organizations.
+  sentVotes: number
+  sentSMS: number
+  sentEmails: number
 }
 
 // GET /integrator. `limits` is present only when enabled.
@@ -79,7 +87,14 @@ export const useIntegratorInfo = () => {
     queryFn: () =>
       bearedFetch<IntegratorInfo>(ApiEndpoints.Integrator).catch(() => ({
         enabled: false,
-        usage: { managedOrgs: 0, managedProcesses: 0, managedCensusSize: 0 },
+        usage: {
+          managedOrgs: 0,
+          managedProcesses: 0,
+          managedCensusSize: 0,
+          sentVotes: 0,
+          sentSMS: 0,
+          sentEmails: 0,
+        },
       })),
   })
 }


### PR DESCRIPTION
## What
Adds three usage/capacity cards to the integrator **Overview** dashboard, in the same `QuotaCard` style as the existing managed-orgs/processes/census cards:

- **Votes emitted** — `sentVotes` / `maxVotes`
- **SMS used** — `sentSMS` / `maxSMS`
- **Emails used** — `sentEmails` / `maxEmails`

Each value is the shared-pool total summed across the integrator's managed organizations, over the integrator plan's cap.

## How
- `src/platform/queries/integrator.ts`: extend `IntegratorUsage` / `IntegratorLimits` (and the offline fallback) with the new fields.
- `src/platform/components/Integrator/Overview.tsx`: a second `SimpleGrid` row with the three new `QuotaCard`s.

Data comes from the extended `GET /integrator` response in **vocdoni/saas-backend#563** — merge that first.

## Notes
- Matches the `src/platform/` convention of hardcoded English labels (the subtree has no i18n yet) rather than introducing i18next for three strings; easy follow-up if desired.
- A `0` limit reuses the existing `QuotaCard` behavior (no full bar) — consistent with the three cards already on the dashboard. Say the word if you'd prefer an explicit "Unlimited" treatment.

## Verified
- `pnpm lint` (tsc + prettier) — clean
- `pnpm test` — the only failures are pre-existing full-suite timeouts in unrelated `Process`/wallet integration tests (they pass in isolation); nothing under `src/platform/` is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)