### PR TITLE
fix(responsive): auth pages mobile layout and input zoom

### DIFF
--- a/src/components/Dashboard/Menu/index.tsx
+++ b/src/components/Dashboard/Menu/index.tsx
@@ -52,7 +52,7 @@ const DashboardMenu = ({
         position='sticky'
         top={0}
         w={reduced ? rWidth : width}
-        h='100vh'
+        h='100dvh'
         zIndex={100}
         transition='width .3s ease'
       >

--- a/src/elements/LayoutAuth.tsx
+++ b/src/elements/LayoutAuth.tsx
@@ -60,8 +60,8 @@ const LayoutAuth = () => {
   const isSignin = pathname === Routes.auth.signIn
 
   return (
-    <Flex justifyContent='center' alignItems='center' minH='100vh' p={{ base: 6, md: 10 }}>
-      <Flex w='full' maxW={{ base: 'sm', md: '3xl' }} flexDir='column' gap={2}>
+    <Flex justifyContent='center' minH='100dvh' p={{ base: 6, md: 10 }}>
+      <Flex w='full' maxW={{ base: 'sm', md: '3xl' }} flexDir='column' gap={2} my='auto'>
         <Link asChild display='flex' alignItems='center' alignSelf='start'>
           <RouterLink to={isSignin ? Routes.vocdoni : Routes.auth.signIn}>
             <Icon as={LuArrowLeft} />

--- a/src/elements/LayoutIntegratorsAuth.tsx
+++ b/src/elements/LayoutIntegratorsAuth.tsx
@@ -15,8 +15,8 @@ const LayoutIntegratorsAuth = () => {
   const isSignin = pathname === Routes.integrators.signIn
 
   return (
-    <Flex justifyContent='center' alignItems='center' minH='100vh' p={{ base: 6, md: 10 }}>
-      <Flex w='full' maxW='md' flexDir='column' gap={2}>
+    <Flex justifyContent='center' minH='100dvh' p={{ base: 6, md: 10 }}>
+      <Flex w='full' maxW='md' flexDir='column' gap={2} my='auto'>
         <Link asChild display='flex' alignItems='center' alignSelf='start'>
           <RouterLink to={isSignin ? Routes.vocdoni : Routes.integrators.signIn}>
             <Icon as={LuArrowLeft} />

--- a/src/elements/PublicLayout.tsx
+++ b/src/elements/PublicLayout.tsx
@@ -27,7 +27,7 @@ const PublicLayout = ({
   const showLimitedAnnouncementBanner = [Routes.root, Routes.plans].includes(normalizedPathname)
 
   return (
-    <Flex position='relative' flexDirection='column' minH='100vh' mx='auto'>
+    <Flex position='relative' flexDirection='column' minH='100dvh' mx='auto'>
       <HStack
         as='header'
         position='sticky'

--- a/src/elements/SimpleLayout.tsx
+++ b/src/elements/SimpleLayout.tsx
@@ -15,7 +15,7 @@ const Layout = () => {
   const [logo, setLogo] = useState<React.ReactNode>()
 
   return (
-    <Flex position='relative' flexDirection='column' minH='100vh' mx='auto'>
+    <Flex position='relative' flexDirection='column' minH='100dvh' mx='auto'>
       <HStack
         as='header'
         position='sticky'

--- a/src/theme/recipes/form.ts
+++ b/src/theme/recipes/form.ts
@@ -23,12 +23,24 @@ const xxl = {
   },
 }
 
+// iOS Safari auto-zooms focused inputs with a font-size below 16px; keep base at
+// `md` (16px) on mobile and restore the compact `sm` (14px) look from `md` up.
+// Set at variant level so it overrides Chakra's default size variants (textStyle `sm`).
+const mobileSafeFontSize = {
+  fontSize: { base: 'md', md: 'sm' },
+  _placeholder: {
+    fontSize: { base: 'md', md: 'sm' },
+  },
+}
+
 const sm = {
   borderRadius: 'sm',
+  ...mobileSafeFontSize,
 }
 
 const md = {
   borderRadius: 'sm',
+  ...mobileSafeFontSize,
 }
 
 export const input = defineRecipe({
@@ -58,6 +70,10 @@ export const textarea = defineRecipe({
     },
   },
   variants: {
+    size: {
+      sm: mobileSafeFontSize,
+      md: mobileSafeFontSize,
+    },
     variant: {
       borderless: {
         border: 'none',


### PR DESCRIPTION
## Summary

Fixes two mobile (iOS Safari, ~390px) usability issues on auth pages:

1. **Large top gap + card hidden below the fold**: The auth layouts used `minH='100vh'` + `alignItems='center'`, which on iOS Safari (where 100vh includes the collapsible browser chrome) creates a visible gap and can clip tall form content at the top when overflowing.

2. **Page zoom-on-input-focus**: iOS Safari auto-zooms any focused input with a rendered font-size below 16px. The form recipe set 16px in base styles, but Chakra v3's default size variants (textStyle: `sm` = 14px) override base styles, causing inputs to render at 14px and trigger the zoom.

## Changes

### Layout (auth pages + consistency sweep)
- Replace `minH='100vh'` with `minH='100dvh'` — measure the visible mobile viewport correctly instead of the large viewport behind browser chrome
- Replace `alignItems='center'` with `my='auto'` on the card column — auto margins center when space allows and collapse on overflow, preventing content from clipping above the scroll line
- Apply to all full-height layout components for consistency: `LayoutAuth`, `LayoutIntegratorsAuth`, `PublicLayout`, `SimpleLayout`, and the dashboard sidebar

### Input sizing (prevent iOS focus-zoom)
- Override Chakra's default size variants in `form.ts` input and textarea recipes to set font-size at the variant level
- `fontSize: { base: 'md', md: 'sm' }` → **16px at mobile, 14px at desktop+**, preventing iOS auto-zoom while keeping the compact visual style on larger screens

## Testing

✅ `pnpm lint` (TypeScript + Prettier)
✅ `pnpm test` (511 passed; 2 flaky Providers.test.tsx timeouts that pass in isolation)
✅ `pnpm chakra:typegen` (system types regenerated)

### Browser verification
- **Mobile (390×844)**: Card safe-centered with no oversized top gap; input font-size 16px; whole card reachable by scroll
- **Mobile overflow (390×480)**: Card margins collapse to 0; top of card at padding; page scrolls from the very top (no clipping)
- **Desktop**: Card centered with testimonial panel (unchanged); inputs 14px

## Files changed
- `src/elements/LayoutAuth.tsx`
- `src/elements/LayoutIntegratorsAuth.tsx`
- `src/elements/PublicLayout.tsx`
- `src/elements/SimpleLayout.tsx`
- `src/components/Dashboard/Menu/index.tsx`
- `src/theme/recipes/form.ts`