### PR TITLE
fix(integrators): lock create-org modal while provisioning

### DIFF
--- a/src/components/Integrator/NotIntegratorNotice.test.tsx
+++ b/src/components/Integrator/NotIntegratorNotice.test.tsx
@@ -12,6 +12,23 @@ vi.mock('~src/queries/integrators', () => ({
   useProvisionIntegratorOrganization: vi.fn(() => ({ mutateAsync: provisionMutateAsync, isPending: false })),
 }))
 
+// Capture the props DeleteModal is rendered with so we can assert the dialog is locked while
+// provisioning (ESC + outside interaction disabled) without simulating Chakra's dismiss internals.
+let deleteModalProps: Record<string, any> = {}
+vi.mock('~components/Modal/DeleteModal', () => ({
+  default: (props: any) => {
+    deleteModalProps = props
+    if (!props.open) return null
+    return (
+      <div>
+        <div>{props.title}</div>
+        <div>{props.subtitle}</div>
+        {props.children}
+      </div>
+    )
+  },
+}))
+
 vi.mock('~components/Auth/useAuth', () => ({
   useAuth: vi.fn(() => ({ signerRefresh })),
 }))
@@ -29,6 +46,7 @@ vi.mock('~components/Dashboard/Menu/useOrganizationNames', () => ({
 }))
 
 import { useProfile } from '~src/queries/account'
+import { useProvisionIntegratorOrganization } from '~src/queries/integrators'
 import NotIntegratorNotice from './NotIntegratorNotice'
 
 const mockProfile = (addresses: string[]) =>
@@ -42,6 +60,12 @@ describe('NotIntegratorNotice', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
+    // clearAllMocks resets call data but not implementations, so re-establish the default here to keep
+    // the locking test's mockReturnValue(isPending: true) from leaking into any later test.
+    vi.mocked(useProvisionIntegratorOrganization).mockReturnValue({
+      mutateAsync: provisionMutateAsync,
+      isPending: false,
+    } as any)
   })
 
   it('asks for confirmation before creating and only provisions on confirm', async () => {
@@ -90,5 +114,28 @@ describe('NotIntegratorNotice', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Create a free integrator organization' }))
 
     expect(await screen.findByText('Or switch to an existing organization')).toBeInTheDocument()
+  })
+
+  it('locks the dialog and disables Cancel/switch actions while provisioning', async () => {
+    mockProfile(['0xa', '0xb'])
+    vi.mocked(useProvisionIntegratorOrganization).mockReturnValue({
+      mutateAsync: provisionMutateAsync,
+      isPending: true,
+    } as any)
+
+    render(<NotIntegratorNotice />)
+    fireEvent.click(screen.getByRole('button', { name: 'Create a free integrator organization' }))
+
+    await screen.findByText('Create a free integrator organization?')
+
+    // Dialog can't be dismissed via ESC or outside interaction while the request is in-flight.
+    expect(deleteModalProps.closeOnEscape).toBe(false)
+    expect(deleteModalProps.closeOnInteractOutside).toBe(false)
+
+    // Cancel and the switch-org buttons are disabled so the user can't bail mid-provision.
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+    // Org names are mocked empty, so each switch button falls back to rendering its address as its label.
+    expect(screen.getByRole('button', { name: '0xa' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: '0xb' })).toBeDisabled()
   })
 })

--- a/src/components/Integrator/NotIntegratorNotice.tsx
+++ b/src/components/Integrator/NotIntegratorNotice.tsx
@@ -78,6 +78,10 @@ const NotIntegratorNotice = () => {
             'A new organization on the free integrator plan will be created on your account and set as your active organization.',
         })}
         open={open}
+        // While the org is being created, keep the modal locked: block ESC and outside clicks so the
+        // request can't be dismissed mid-flight (it still completes, but closing it is confusing).
+        closeOnEscape={!provision.isPending}
+        closeOnInteractOutside={!provision.isPending}
         onOpenChange={({ open }) => setOpen(open)}
       >
         {hasMultipleOrgs && (
@@ -92,6 +96,7 @@ const NotIntegratorNotice = () => {
                   variant='outline'
                   justifyContent='flex-start'
                   gap={2}
+                  disabled={provision.isPending}
                   onClick={() => selectOrganization(organization, isIntegrator)}
                 >
                   <Icon as={LuSquareStack} />
@@ -111,7 +116,7 @@ const NotIntegratorNotice = () => {
         )}
 
         <Flex justifyContent='flex-end' mt={4} gap={2}>
-          <Button variant='outline' onClick={() => setOpen(false)}>
+          <Button variant='outline' disabled={provision.isPending} onClick={() => setOpen(false)}>
             {t('integrators.create_org.cancel', { defaultValue: 'Cancel' })}
           </Button>
           <Button loading={provision.isPending} onClick={onCreate}>


### PR DESCRIPTION
## What

The integrators "create a free integrator organization" confirmation modal could be dismissed while the creation request was in flight — via the ESC key, clicking outside, the Cancel button, or the "switch to an existing organization" buttons.

## Why

The provisioning still completed in the background, but letting the user close (or navigate away from) the modal mid-request was confusing.

## How

In `NotIntegratorNotice.tsx`, disable every closing path while `provision.isPending`:

- `closeOnEscape={!provision.isPending}` — blocks the ESC key
- `closeOnInteractOutside={!provision.isPending}` — blocks outside/backdrop clicks
- `disabled` on the Cancel button
- `disabled` on the switch-org buttons (switching the active org mid-creation is equally disruptive)

The confirm button already used `loading={provision.isPending}`, and `DeleteModal` renders no `X` close trigger, so those paths were already covered.

## Verification

- `tsc` passes (new `closeOnEscape`/`closeOnInteractOutside` props are valid `DialogRootProps`)
- `prettier --check src` passes
- `NotIntegratorNotice.test.tsx` passes