### PR TITLE
feat(dashboard): responsive card layout for tables

### DIFF
--- a/src/components/Memberbase/Members/MemberCard.tsx
+++ b/src/components/Memberbase/Members/MemberCard.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Member } from '~src/queries/members'
 import { useTable } from '../TableProvider'
-import { maskIfNeeded } from './index'
+import { maskIfNeeded } from './maskIfNeeded'
 
 type MemberCardProps = {
   member: Member

--- a/src/components/Memberbase/Members/MemberCard.tsx
+++ b/src/components/Memberbase/Members/MemberCard.tsx
@@ -23,10 +23,10 @@ const MemberCard = ({ member, actions, selectable = true }: MemberCardProps) => 
     <Card.Root variant='data-list-item'>
       <Card.Header>
         <Flex gap={3} alignItems='center' minW={0}>
-          {selectable && (
+          {selectable && member.id && (
             <Checkbox.Root
               checked={isSelected(member.id)}
-              onCheckedChange={({ checked }) => toggleOne(member.id, checked === true)}
+              onCheckedChange={({ checked }) => toggleOne(member.id!, checked === true)}
               aria-label={t('members.table.select_member', { defaultValue: 'Select {{name}}', name: alias })}
             >
               <Checkbox.HiddenInput />

--- a/src/components/Memberbase/Members/MemberCard.tsx
+++ b/src/components/Memberbase/Members/MemberCard.tsx
@@ -1,5 +1,6 @@
 import { Card, Checkbox, Flex, Text } from '@chakra-ui/react'
 import { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Member } from '~src/queries/members'
 import { useTable } from '../TableProvider'
 import { maskIfNeeded } from './index'
@@ -14,7 +15,9 @@ const memberAlias = (member: Member) =>
   [member.name, member.surname].filter(Boolean).join(' ') || member.email || member.memberNumber
 
 const MemberCard = ({ member, actions, selectable = true }: MemberCardProps) => {
+  const { t } = useTranslation()
   const { columns, isSelected, toggleOne } = useTable()
+  const alias = memberAlias(member)
 
   return (
     <Card.Root variant='data-list-item'>
@@ -24,13 +27,14 @@ const MemberCard = ({ member, actions, selectable = true }: MemberCardProps) => 
             <Checkbox.Root
               checked={isSelected(member.id)}
               onCheckedChange={({ checked }) => toggleOne(member.id, checked === true)}
+              aria-label={t('members.table.select_member', { defaultValue: 'Select {{name}}', name: alias })}
             >
               <Checkbox.HiddenInput />
               <Checkbox.Control />
             </Checkbox.Root>
           )}
           <Text fontWeight='medium' lineClamp={2}>
-            {memberAlias(member)}
+            {alias}
           </Text>
         </Flex>
         {actions}

--- a/src/components/Memberbase/Members/MemberCard.tsx
+++ b/src/components/Memberbase/Members/MemberCard.tsx
@@ -1,0 +1,55 @@
+import { Card, Checkbox, Flex, Text } from '@chakra-ui/react'
+import { ReactNode } from 'react'
+import { Member } from '~src/queries/members'
+import { useTable } from '../TableProvider'
+import { maskIfNeeded } from './index'
+
+type MemberCardProps = {
+  member: Member
+  actions?: ReactNode
+  selectable?: boolean
+}
+
+const memberAlias = (member: Member) =>
+  [member.name, member.surname].filter(Boolean).join(' ') || member.email || member.memberNumber
+
+const MemberCard = ({ member, actions, selectable = true }: MemberCardProps) => {
+  const { columns, isSelected, toggleOne } = useTable()
+
+  return (
+    <Card.Root variant='data-list-item'>
+      <Card.Header>
+        <Flex gap={3} alignItems='center' minW={0}>
+          {selectable && (
+            <Checkbox.Root
+              checked={isSelected(member.id)}
+              onCheckedChange={({ checked }) => toggleOne(member.id, checked === true)}
+            >
+              <Checkbox.HiddenInput />
+              <Checkbox.Control />
+            </Checkbox.Root>
+          )}
+          <Text fontWeight='medium' lineClamp={2}>
+            {memberAlias(member)}
+          </Text>
+        </Flex>
+        {actions}
+      </Card.Header>
+      <Card.Body>
+        {columns
+          .filter((column) => column.visible && !['name', 'surname'].includes(column.id))
+          .map((column) => {
+            const value = maskIfNeeded(column.id, member[column.id])
+            if (!value) return null
+            return (
+              <Text key={column.id}>
+                {column.label}: {value}
+              </Text>
+            )
+          })}
+      </Card.Body>
+    </Card.Root>
+  )
+}
+
+export default MemberCard

--- a/src/components/Memberbase/Members/index.test.tsx
+++ b/src/components/Memberbase/Members/index.test.tsx
@@ -1,0 +1,118 @@
+import type { ReactNode } from 'react'
+import { render, screen } from '~src/test-utils'
+import { TableProvider } from '../TableProvider'
+import MembersTable from './index'
+
+// MembersTable mounts filters, drawers and the delete modal that hit member/group
+// queries on render; stub them so the test stays focused on the breakpoint swap.
+vi.mock('~components/Auth/useAuth', () => ({
+  useAuth: () => ({ bearedFetch: vi.fn().mockResolvedValue(undefined) }),
+}))
+
+vi.mock('~src/queries/members', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~src/queries/members')>()
+  return {
+    ...actual,
+    usePaginatedMembers: () => ({ data: { members: [], pagination: {} }, isLoading: false, isFetching: false }),
+    useDeleteMembers: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+  }
+})
+
+vi.mock('~src/queries/groups', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~src/queries/groups')>()
+  return {
+    ...actual,
+    useGroups: () => ({ data: [], isLoading: false, isFetched: true, error: null }),
+    useCreateGroup: () => ({ mutate: vi.fn(), isPending: false }),
+    useUpdateGroup: () => ({ mutate: vi.fn(), isPending: false }),
+  }
+})
+
+// The import UI and add-member manager are orthogonal to the list layout.
+vi.mock('./Import', () => ({
+  ImportMembers: () => null,
+  ImportProgress: () => null,
+}))
+vi.mock('./Manager', () => ({
+  MemberManager: () => null,
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+    useOutletContext: () => ({
+      search: '',
+      setSearch: vi.fn(),
+      submitSearch: vi.fn(),
+      debouncedSearch: '',
+      jobId: null,
+      setJobId: vi.fn(),
+    }),
+  }
+})
+
+const members = [
+  { id: '1', name: 'Ada', surname: 'Lovelace', email: 'ada@example.test', phone: '600000000' },
+  { id: '2', name: 'Alan', surname: 'Turing', email: 'alan@example.test', phone: '600000001' },
+] as any
+
+const columns = [
+  { id: 'name', label: 'First Name', visible: true },
+  { id: 'surname', label: 'Last Name', visible: true },
+  { id: 'email', label: 'Email', visible: true },
+]
+
+const renderMembers = () =>
+  render(
+    <TableProvider data={members} initialColumns={columns}>
+      <MembersTable />
+    </TableProvider>
+  )
+
+describe('MembersTable layout', () => {
+  // The global matchMedia stub matches nothing, so useBreakpointValue resolves the `base`
+  // value and the list renders stacked member cards instead of the desktop table.
+  it('renders stacked member cards without a table on mobile', () => {
+    renderMembers()
+
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    // The mobile header exposes a labelled select-all checkbox (the desktop header does not).
+    expect(screen.getByText('Select all')).toBeInTheDocument()
+    // Cards show the member alias (name + surname combined).
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument()
+    expect(screen.getByText('Alan Turing')).toBeInTheDocument()
+  })
+
+  it('renders the table with column headers on desktop widths', () => {
+    // Pretend every media query matches (jsdom has no layout), so useBreakpointValue resolves
+    // the `md` value and the table branch renders instead of the mobile cards.
+    const original = window.matchMedia
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+
+    try {
+      renderMembers()
+
+      expect(screen.getByRole('table')).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: 'First Name' })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: 'Email' })).toBeInTheDocument()
+      // The labelled "Select all" checkbox is specific to the mobile header.
+      expect(screen.queryByText('Select all')).not.toBeInTheDocument()
+    } finally {
+      Object.defineProperty(window, 'matchMedia', { writable: true, value: original })
+    }
+  })
+})

--- a/src/components/Memberbase/Members/index.test.tsx
+++ b/src/components/Memberbase/Members/index.test.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react'
 import { render, screen } from '~src/test-utils'
 import { TableProvider } from '../TableProvider'
 import MembersTable from './index'

--- a/src/components/Memberbase/Members/index.tsx
+++ b/src/components/Memberbase/Members/index.tsx
@@ -12,10 +12,12 @@ import {
   InputGroup,
   Menu,
   Progress,
+  Stack,
   Switch,
   Table,
   Tag,
   Text,
+  useBreakpointValue,
   useDisclosure,
   Wrap,
   WrapItem,
@@ -53,6 +55,7 @@ import { MemberbaseTabsContext } from '..'
 import { useTable } from '../TableProvider'
 import { ImportMembers, ImportProgress } from './Import'
 import { MemberManager } from './Manager'
+import MemberCard from './MemberCard'
 
 enum DeleteModes {
   SELECTED = 'selected',
@@ -726,27 +729,62 @@ const MembersList = ({ openDeleteSelected, onAddToGroup, onAddToCensus }: Member
   )
 }
 
-const EmptyMembers = () => {
+const MembersCardList = ({ openDeleteSelected, onAddToGroup, onAddToCensus }: MembersListProps) => {
+  const { data = [], isLoading, isFetching } = useTable()
+  const isLoadingOrImporting = isLoading || isFetching
+  const isEmpty = data.length === 0 && !isLoadingOrImporting
+
+  if (isEmpty) return <EmptyMembersMessage />
+
+  return (
+    <Stack gap={3}>
+      {data.map((member) => (
+        <MemberCard
+          key={member.id}
+          member={member}
+          actions={
+            <MemberActions
+              member={member}
+              onDelete={() => openDeleteSelected(member)}
+              onAddToGroup={() => onAddToGroup(member)}
+              onAddToCensus={() => onAddToCensus(member)}
+            />
+          }
+        />
+      ))}
+    </Stack>
+  )
+}
+
+const EmptyMembersMessage = () => {
   const { t } = useTranslation()
-  const { columns, error } = useTable()
+  const { error } = useTable()
   const { debouncedSearch } = useOutletContext<MemberbaseTabsContext>()
+
+  return (
+    <Flex justify='center' align='center' height='150px'>
+      <Text color='texts.subtle' fontSize='sm'>
+        {debouncedSearch
+          ? t('members.table.no_filter_results', {
+              defaultValue: 'No members matching these attributes',
+            })
+          : error
+            ? error.message.toString()
+            : t('members.table.no_results', {
+                defaultValue: 'No members found',
+              })}
+      </Text>
+    </Flex>
+  )
+}
+
+const EmptyMembers = () => {
+  const { columns } = useTable()
 
   return (
     <Table.Row>
       <Table.Cell colSpan={columns.filter((c) => c.visible).length + 2}>
-        <Flex justify='center' align='center' height='150px'>
-          <Text color='texts.subtle' fontSize='sm'>
-            {debouncedSearch
-              ? t('members.table.no_filter_results', {
-                  defaultValue: 'No members matching these attributes',
-                })
-              : error
-                ? error.message.toString()
-                : t('members.table.no_results', {
-                    defaultValue: 'No members found',
-                  })}
-          </Text>
-        </Flex>
+        <EmptyMembersMessage />
       </Table.Cell>
     </Table.Row>
   )
@@ -876,6 +914,7 @@ const MembersTable = () => {
   const { isLoading, isFetching, allVisibleSelected, someSelected, resetSelectedRows, toggleAll, toggleOne, columns } =
     useTable()
   const isLoadingOrImporting = isLoading || isFetching
+  const isMobile = useBreakpointValue({ base: true, md: false })
 
   const openDeleteSelected = (member?: Member) => {
     setDeleteMode(DeleteModes.SELECTED)
@@ -939,39 +978,65 @@ const MembersTable = () => {
             </Progress.Track>
           </Progress.Root>
         )}
-        <Table.ScrollArea>
-          <Table.Root variant='outline'>
-            <Table.Header>
-              <Table.Row>
-                <Table.ColumnHeader width='50px'>
-                  <Checkbox.Root
-                    checked={allVisibleSelected ? true : someSelected ? 'indeterminate' : false}
-                    onCheckedChange={({ checked }) => toggleAll(checked === true)}
-                  >
-                    <Checkbox.HiddenInput />
-                    <Checkbox.Control />
-                  </Checkbox.Root>
-                </Table.ColumnHeader>
-                {columns
-                  .filter((col) => col.visible)
-                  .map((col) => (
-                    <Table.ColumnHeader key={col.id}>{col.label}</Table.ColumnHeader>
-                  ))}
-                <Table.ColumnHeader width='50px'>
-                  <ColumnManager />
-                </Table.ColumnHeader>
-              </Table.Row>
-            </Table.Header>
-            <MembersList
+        {isMobile ? (
+          <Box p={4}>
+            <Flex justify='space-between' align='center' mb={3}>
+              <Checkbox.Root
+                checked={allVisibleSelected ? true : someSelected ? 'indeterminate' : false}
+                onCheckedChange={({ checked }) => toggleAll(checked === true)}
+              >
+                <Checkbox.HiddenInput />
+                <Checkbox.Control />
+                <Checkbox.Label fontWeight='normal'>
+                  {t('members.table.select_all', { defaultValue: 'Select all' })}
+                </Checkbox.Label>
+              </Checkbox.Root>
+              <ColumnManager />
+            </Flex>
+            <MembersCardList
               openDeleteSelected={openDeleteSelected}
               onAddToGroup={openAddToGroup}
               onAddToCensus={openAddToCensus}
             />
-            <Table.Caption p={4}>
+            <Box pt={4}>
               <RoutedPaginatedTableFooter />
-            </Table.Caption>
-          </Table.Root>
-        </Table.ScrollArea>
+            </Box>
+          </Box>
+        ) : (
+          <Table.ScrollArea>
+            <Table.Root variant='outline'>
+              <Table.Header>
+                <Table.Row>
+                  <Table.ColumnHeader width='50px'>
+                    <Checkbox.Root
+                      checked={allVisibleSelected ? true : someSelected ? 'indeterminate' : false}
+                      onCheckedChange={({ checked }) => toggleAll(checked === true)}
+                    >
+                      <Checkbox.HiddenInput />
+                      <Checkbox.Control />
+                    </Checkbox.Root>
+                  </Table.ColumnHeader>
+                  {columns
+                    .filter((col) => col.visible)
+                    .map((col) => (
+                      <Table.ColumnHeader key={col.id}>{col.label}</Table.ColumnHeader>
+                    ))}
+                  <Table.ColumnHeader width='50px'>
+                    <ColumnManager />
+                  </Table.ColumnHeader>
+                </Table.Row>
+              </Table.Header>
+              <MembersList
+                openDeleteSelected={openDeleteSelected}
+                onAddToGroup={openAddToGroup}
+                onAddToCensus={openAddToCensus}
+              />
+              <Table.Caption p={4}>
+                <RoutedPaginatedTableFooter />
+              </Table.Caption>
+            </Table.Root>
+          </Table.ScrollArea>
+        )}
       </Box>
       <DeleteMemberModal isOpen={isDeleteModalOpen} onClose={() => setDeleteModalOpen(false)} mode={deleteMode} />
       <AddMembersToGroupDrawer isOpen={isAddToGroupOpen} onClose={onAddToGroupClose} />

--- a/src/components/Memberbase/Members/index.tsx
+++ b/src/components/Memberbase/Members/index.tsx
@@ -55,6 +55,7 @@ import { MemberbaseTabsContext } from '..'
 import { useTable } from '../TableProvider'
 import { ImportMembers, ImportProgress } from './Import'
 import { MemberManager } from './Manager'
+import { maskIfNeeded } from './maskIfNeeded'
 import MemberCard from './MemberCard'
 
 enum DeleteModes {
@@ -111,14 +112,6 @@ type MemberTableItemProps = {
   openDeleteSelected: () => void
   onAddToGroup: () => void
   onAddToCensus: () => void
-}
-
-const maskedFields = new Set<string>(['phone'])
-
-export const maskIfNeeded = (fieldId: string, value: string): string => {
-  if (!maskedFields.has(fieldId)) return value
-  if (!value) return ''
-  return '*********'
 }
 
 const AddMembersToGroupDrawer = ({ isOpen, onClose }: AddMembersToGroupDrawerProps) => {

--- a/src/components/Memberbase/Members/maskIfNeeded.ts
+++ b/src/components/Memberbase/Members/maskIfNeeded.ts
@@ -1,7 +1,9 @@
 const maskedFields = new Set<string>(['phone'])
 
-export const maskIfNeeded = (fieldId: string, value: string): string => {
-  if (!maskedFields.has(fieldId)) return value
+// value may be undefined for optional/empty member fields, so guard it before
+// returning so the function always resolves to a string.
+export const maskIfNeeded = (fieldId: string, value?: string): string => {
   if (!value) return ''
+  if (!maskedFields.has(fieldId)) return value
   return '*********'
 }

--- a/src/components/Memberbase/Members/maskIfNeeded.ts
+++ b/src/components/Memberbase/Members/maskIfNeeded.ts
@@ -1,0 +1,7 @@
+const maskedFields = new Set<string>(['phone'])
+
+export const maskIfNeeded = (fieldId: string, value: string): string => {
+  if (!maskedFields.has(fieldId)) return value
+  if (!value) return ''
+  return '*********'
+}

--- a/src/components/Process/Dashboard/ProcessesTable.test.tsx
+++ b/src/components/Process/Dashboard/ProcessesTable.test.tsx
@@ -99,6 +99,57 @@ describe('ProcessesTable', () => {
     })
   })
 
+  // The global matchMedia stub matches nothing, so useBreakpointValue resolves the `base` value
+  // and the list renders stacked cards instead of the desktop table.
+  it('renders stacked cards without a table on mobile', () => {
+    render(
+      <TestMemoryRouter>
+        <ProcessesTable processes={[election as any]} />
+      </TestMemoryRouter>
+    )
+
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader')).not.toBeInTheDocument()
+    // Card view renders the dates as inline labelled lines ("Start date: …").
+    expect(screen.getByText(/start date:/i)).toBeInTheDocument()
+    expect(screen.getByText(/end date:/i)).toBeInTheDocument()
+  })
+
+  it('renders the table with column headers on desktop widths', () => {
+    // Pretend every media query matches (jsdom has no layout), so useBreakpointValue resolves
+    // the `md` value and the table branch renders instead of the mobile cards.
+    const original = window.matchMedia
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+
+    try {
+      render(
+        <TestMemoryRouter>
+          <ProcessesTable processes={[election as any]} />
+        </TestMemoryRouter>
+      )
+
+      expect(screen.getByRole('table')).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: 'Start date' })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: 'End date' })).toBeInTheDocument()
+      // The inline "Start date:" card lines are specific to the mobile view.
+      expect(screen.queryByText(/start date:/i)).not.toBeInTheDocument()
+    } finally {
+      Object.defineProperty(window, 'matchMedia', { writable: true, value: original })
+    }
+  })
+
   it('opens the public voting page with a single localized prefix from the dashboard', async () => {
     render(
       <TestMemoryRouter basename='/ca' initialEntries={['/ca/admin/processes']}>

--- a/src/components/Process/Dashboard/ProcessesTable.test.tsx
+++ b/src/components/Process/Dashboard/ProcessesTable.test.tsx
@@ -2,7 +2,7 @@ import userEvent from '@testing-library/user-event'
 import { ElectionStatus, PublishedElection } from '@vocdoni/sdk'
 import type { ReactNode } from 'react'
 import { fireEvent, mockUseElection, render, screen, TestMemoryRouter, waitFor } from '~src/test-utils'
-import { setReactProvidersMock } from '~src/test-utils-react-providers-mock'
+import { resetReactProvidersMock, setReactProvidersMock } from '~src/test-utils-react-providers-mock'
 import ProcessesTable from './ProcessesTable'
 
 vi.mock('@vocdoni/sdk', async (importOriginal) => {
@@ -60,6 +60,12 @@ describe('ProcessesTable', () => {
         }),
       useRoutedPagination: () => ({ pagination: null, initialPage: 1 }),
     })
+  })
+
+  // setReactProvidersMock mutates a module-level singleton; reset it so provider
+  // overrides never leak into other suites (the global setup also resets, belt-and-suspenders).
+  afterEach(() => {
+    resetReactProvidersMock()
   })
 
   it('renders election title', () => {

--- a/src/components/Process/Dashboard/ProcessesTable.tsx
+++ b/src/components/Process/Dashboard/ProcessesTable.tsx
@@ -1,4 +1,19 @@
-import { Box, Icon, IconButton, Link, Menu, MenuPositioner, Portal, Table, Tag, Text } from '@chakra-ui/react'
+import {
+  Box,
+  Card,
+  HStack,
+  Icon,
+  IconButton,
+  Link,
+  Menu,
+  MenuPositioner,
+  Portal,
+  Stack,
+  Table,
+  Tag,
+  Text,
+  useBreakpointValue,
+} from '@chakra-ui/react'
 import { ElectionProvider, ElectionStatusBadge, QuestionsTypeBadge, useElection } from '@vocdoni/react-components'
 import { ElectionStatus, ensure0x, InvalidElection, PublishedElection } from '@vocdoni/sdk'
 import { Trans, useTranslation } from 'react-i18next'
@@ -20,6 +35,25 @@ type ProcessesListProps = {
 
 const ProcessesTable = ({ processes }: ProcessesListProps) => {
   const { t } = useTranslation()
+  const isMobile = useBreakpointValue({ base: true, md: false })
+
+  const rows =
+    processes &&
+    !!processes.length &&
+    processes?.map((election) => (
+      <ElectionProvider election={election} id={election.id} key={election.id}>
+        {isMobile ? <ProcessCard /> : <ProcessRow />}
+      </ElectionProvider>
+    ))
+
+  if (isMobile) {
+    return (
+      <Stack gap={3} w='full'>
+        {rows}
+        <RoutedPaginatedTableFooter />
+      </Stack>
+    )
+  }
 
   return (
     <Box border='1px solid' borderColor='table.border' borderRadius='sm' w='full'>
@@ -39,21 +73,76 @@ const ProcessesTable = ({ processes }: ProcessesListProps) => {
               <Table.ColumnHeader>&nbsp;</Table.ColumnHeader>
             </Table.Row>
           </Table.Header>
-          <Table.Body>
-            {processes &&
-              !!processes.length &&
-              processes?.map((election) => (
-                <ElectionProvider election={election} id={election.id} key={election.id}>
-                  <ProcessRow />
-                </ElectionProvider>
-              ))}
-          </Table.Body>
+          <Table.Body>{rows}</Table.Body>
           <Table.Caption>
             <RoutedPaginatedTableFooter />
           </Table.Caption>
         </Table.Root>
       </Table.ScrollArea>
     </Box>
+  )
+}
+
+const ProcessResultsTag = () => {
+  const { election } = useElection()
+
+  if (!election || election instanceof InvalidElection) return null
+
+  return ElectionStatus.RESULTS === election.status ||
+    ([ElectionStatus.ENDED, ElectionStatus.ONGOING].includes(election.status) &&
+      !election.electionType.secretUntilTheEnd) ? (
+    <Tag.Root colorPalette='gray' variant='solid' size='sm'>
+      <Tag.Label>
+        <Trans i18nKey='process_list.results_live'>Live</Trans>
+      </Tag.Label>
+    </Tag.Root>
+  ) : (
+    <Tag.Root colorPalette='gray' variant='surface' size='sm'>
+      <Tag.Label>
+        <Trans i18nKey='process_list.not_yet'>Not yet</Trans>
+      </Tag.Label>
+    </Tag.Root>
+  )
+}
+
+const ProcessCard = () => {
+  const { election } = useElection()
+  const { format } = useDateFns()
+  const { t } = useTranslation()
+
+  if (!election || election instanceof InvalidElection) return null
+
+  return (
+    <Card.Root variant='data-list-item'>
+      <Card.Header>
+        <Link asChild title={election.title.default}>
+          <RouterLink to={generatePath(Routes.dashboard.process, { id: ensure0x(election.id) })}>
+            <Text fontWeight='medium' lineClamp={2}>
+              {election.title.default}
+            </Text>
+          </RouterLink>
+        </Link>
+        <ProcessContextMenu />
+      </Card.Header>
+      <Card.Body>
+        <HStack flexWrap='wrap' gap={2}>
+          <QuestionsTypeBadge css={{ '& label': { fontWeight: 'normal' } }} />
+          <ElectionStatusBadge size='sm' />
+          <ProcessResultsTag />
+        </HStack>
+        <Text>
+          {t('process_list.start_date', { defaultValue: 'Start date' })}:{' '}
+          {format(election.startDate, t('organization.date_format'))}
+        </Text>
+        <Text>
+          {t('process_list.end_date', { defaultValue: 'End date' })}:{' '}
+          {format(election.endDate, t('organization.date_format'))}
+        </Text>
+        <Text>
+          {t('process_list.recount', { defaultValue: 'Recount' })}: {election.voteCount}
+        </Text>
+      </Card.Body>
+    </Card.Root>
   )
 }
 
@@ -85,21 +174,7 @@ const ProcessRow = () => {
       </Table.Cell>
       <Table.Cell textAlign='end'>{election.voteCount}</Table.Cell>
       <Table.Cell>
-        {ElectionStatus.RESULTS === election.status ||
-        ([ElectionStatus.ENDED, ElectionStatus.ONGOING].includes(election.status) &&
-          !election.electionType.secretUntilTheEnd) ? (
-          <Tag.Root colorPalette='gray' variant='solid' size='sm'>
-            <Tag.Label>
-              <Trans i18nKey='process_list.results_live'>Live</Trans>
-            </Tag.Label>
-          </Tag.Root>
-        ) : (
-          <Tag.Root colorPalette='gray' variant='surface' size='sm'>
-            <Tag.Label>
-              <Trans i18nKey='process_list.not_yet'>Not yet</Trans>
-            </Tag.Label>
-          </Tag.Root>
-        )}
+        <ProcessResultsTag />
       </Table.Cell>
       <Table.Cell textAlign='end'>
         <ProcessContextMenu />

--- a/src/elements/dashboard/processes/drafts.test.tsx
+++ b/src/elements/dashboard/processes/drafts.test.tsx
@@ -3,7 +3,7 @@ import { act, renderHook } from '@testing-library/react'
 import React from 'react'
 import { ApiEndpoints } from '~components/Auth/api'
 import { mockUseOrganization, render, screen, TestMemoryRouter } from '~src/test-utils'
-import { setReactProvidersMock } from '~src/test-utils-react-providers-mock'
+import { resetReactProvidersMock, setReactProvidersMock } from '~src/test-utils-react-providers-mock'
 import { DraftsTable, useDeleteDraft } from './drafts'
 
 const toastSpy = vi.fn()
@@ -31,6 +31,12 @@ const createWrapper = (queryClient: QueryClient) => {
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   )
 }
+
+// setReactProvidersMock mutates a module-level singleton; reset it so provider
+// overrides never leak into other suites (the global setup also resets, belt-and-suspenders).
+afterEach(() => {
+  resetReactProvidersMock()
+})
 
 describe('useDeleteDraft', () => {
   beforeEach(() => {

--- a/src/elements/dashboard/processes/drafts.test.tsx
+++ b/src/elements/dashboard/processes/drafts.test.tsx
@@ -2,9 +2,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, renderHook } from '@testing-library/react'
 import React from 'react'
 import { ApiEndpoints } from '~components/Auth/api'
-import { mockUseOrganization } from '~src/test-utils'
+import { mockUseOrganization, render, screen, TestMemoryRouter } from '~src/test-utils'
 import { setReactProvidersMock } from '~src/test-utils-react-providers-mock'
-import { useDeleteDraft } from './drafts'
+import { DraftsTable, useDeleteDraft } from './drafts'
 
 const toastSpy = vi.fn()
 const bearedFetchMock = vi.fn().mockResolvedValue(undefined)
@@ -15,16 +15,15 @@ vi.mock('~components/Auth/useAuth', () => ({
   }),
 }))
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (_key: string, opts?: Record<string, string>) => opts?.defaultValue ?? _key,
-  }),
-  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  initReactI18next: { type: '3rdParty', init: vi.fn() },
+// DraftsContextMenu (rendered by both the card and the row) pulls in the create-process
+// wizard; stub it so the list layout tests stay focused on the mobile/desktop branch.
+vi.mock('~components/Process/Create', () => ({
+  useCreateProcess: () => ({ mutateAsync: vi.fn() }),
 }))
 
 vi.mock('~components/Toast', () => ({
   useToast: () => toastSpy,
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
 const createWrapper = (queryClient: QueryClient) => {
@@ -79,5 +78,68 @@ describe('useDeleteDraft', () => {
 
     await expect(result.current.mutateAsync({ draftId: 'draft-3' })).rejects.toThrow(error)
     expect(toastSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('DraftsTable layout', () => {
+  const draft = {
+    id: 'draft-1',
+    metadata: {
+      title: 'My draft',
+      startDate: '2026-01-01',
+      endDate: '2026-01-02',
+      questionType: 'single',
+    },
+  } as any
+
+  // The global matchMedia stub matches nothing, so useBreakpointValue resolves the `base` value
+  // and the list renders stacked cards instead of the desktop table.
+  it('renders stacked cards without a table on mobile', () => {
+    render(
+      <TestMemoryRouter>
+        <DraftsTable drafts={[draft]} />
+      </TestMemoryRouter>
+    )
+
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader')).not.toBeInTheDocument()
+    // Card view renders the dates as inline labelled lines ("Start date: …").
+    expect(screen.getByText(/start date:/i)).toBeInTheDocument()
+    expect(screen.getByText(/end date:/i)).toBeInTheDocument()
+  })
+
+  it('renders the table with column headers on desktop widths', () => {
+    // Pretend every media query matches (jsdom has no layout), so useBreakpointValue resolves
+    // the `md` value and the table branch renders instead of the mobile cards.
+    const original = window.matchMedia
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+
+    try {
+      render(
+        <TestMemoryRouter>
+          <DraftsTable drafts={[draft]} />
+        </TestMemoryRouter>
+      )
+
+      expect(screen.getByRole('table')).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: 'Start date' })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: 'End date' })).toBeInTheDocument()
+      // The inline "Start date:" card lines are specific to the mobile view.
+      expect(screen.queryByText(/start date:/i)).not.toBeInTheDocument()
+    } finally {
+      Object.defineProperty(window, 'matchMedia', { writable: true, value: original })
+    }
   })
 })

--- a/src/elements/dashboard/processes/drafts.tsx
+++ b/src/elements/dashboard/processes/drafts.tsx
@@ -100,7 +100,7 @@ export const useDeleteDraft = () => {
   })
 }
 
-const DraftsTable = ({ drafts }: { drafts: Draft[] }) => {
+export const DraftsTable = ({ drafts }: { drafts: Draft[] }) => {
   const { t } = useTranslation()
   const isMobile = useBreakpointValue({ base: true, md: false })
 

--- a/src/elements/dashboard/processes/drafts.tsx
+++ b/src/elements/dashboard/processes/drafts.tsx
@@ -1,4 +1,5 @@
 import {
+  Card,
   HStack,
   Icon,
   IconButton,
@@ -11,7 +12,10 @@ import {
   MenuTrigger,
   Portal,
   Progress,
+  Stack,
   Table,
+  Text,
+  useBreakpointValue,
 } from '@chakra-ui/react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useClient, useOrganization } from '@vocdoni/react-components'
@@ -98,6 +102,18 @@ export const useDeleteDraft = () => {
 
 const DraftsTable = ({ drafts }: { drafts: Draft[] }) => {
   const { t } = useTranslation()
+  const isMobile = useBreakpointValue({ base: true, md: false })
+
+  if (isMobile) {
+    return (
+      <Stack gap={3} w='full'>
+        {drafts.map((draft) => (
+          <DraftCard key={draft.id} draft={draft} />
+        ))}
+        <RoutedPaginatedTableFooter />
+      </Stack>
+    )
+  }
 
   return (
     <Table.ScrollArea border='1px solid' borderColor='table.border' borderRadius='sm'>
@@ -150,6 +166,40 @@ const DraftsRow = ({ draft }: { draft: Draft }) => {
         <DraftsContextMenu draft={draft} />
       </Table.Cell>
     </Table.Row>
+  )
+}
+
+const DraftCard = ({ draft }: { draft: Draft }) => {
+  const { t } = useTranslation()
+  const notDefined = t('drafts.not_defined', { defaultValue: 'Not defined yet' })
+
+  return (
+    <Card.Root variant='data-list-item'>
+      <Card.Header>
+        <Link asChild _hover={{ textDecoration: 'underline' }} fontWeight='medium'>
+          <RouterLink
+            to={{
+              pathname: generatePath(Routes.processes.create),
+              search: createSearchParams({ draftId: draft.id }).toString(),
+            }}
+          >
+            <Text lineClamp={2}>{draft.metadata?.title || notDefined}</Text>
+          </RouterLink>
+        </Link>
+        <DraftsContextMenu draft={draft} />
+      </Card.Header>
+      <Card.Body>
+        <Text>
+          {t('process_list.start_date', { defaultValue: 'Start date' })}: {draft.metadata?.startDate || notDefined}
+        </Text>
+        <Text>
+          {t('process_list.end_date', { defaultValue: 'End date' })}: {draft.metadata?.endDate || notDefined}
+        </Text>
+        <Text>
+          {t('process_list.type', { defaultValue: 'Type' })}: {draft.metadata?.questionType || notDefined}
+        </Text>
+      </Card.Body>
+    </Card.Root>
   )
 }
 

--- a/src/i18n/locales/ca/common.json
+++ b/src/i18n/locales/ca/common.json
@@ -1057,6 +1057,7 @@
       "remaining_members_many": "",
       "remaining_members_other": "+{{count}} més",
       "search": "Cerca membres...",
+      "select_all": "Selecciona-ho tot",
       "select_group": "Selecciona un grup",
       "select_hint": "Selecciona membres per realitzar accions massives",
       "select_process": "Selecciona un procés",

--- a/src/i18n/locales/ca/common.json
+++ b/src/i18n/locales/ca/common.json
@@ -1060,6 +1060,7 @@
       "select_all": "Selecciona-ho tot",
       "select_group": "Selecciona un grup",
       "select_hint": "Selecciona membres per realitzar accions massives",
+      "select_member": "Selecciona {{name}}",
       "select_process": "Selecciona un procés",
       "selected_one": "Seleccionat: <strong>{{count}} membre</strong>",
       "selected_many": "",

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -1039,6 +1039,7 @@
       "remaining_members_one": "+{{count}} weitere",
       "remaining_members_other": "+{{count}} weitere",
       "search": "Mitglieder suchen...",
+      "select_all": "Alle auswählen",
       "select_group": "Gruppe auswählen",
       "select_hint": "Mitglieder auswählen, um Sammelaktionen durchzuführen",
       "select_process": "Prozess auswählen",

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -1042,6 +1042,7 @@
       "select_all": "Alle auswählen",
       "select_group": "Gruppe auswählen",
       "select_hint": "Mitglieder auswählen, um Sammelaktionen durchzuführen",
+      "select_member": "{{name}} auswählen",
       "select_process": "Prozess auswählen",
       "selected_one": "Ausgewählt: <strong>{{count}} Mitglied</strong>",
       "selected_other": "Ausgewählt: <strong>{{count}} Mitglieder</strong>",

--- a/src/i18n/locales/el/common.json
+++ b/src/i18n/locales/el/common.json
@@ -1039,6 +1039,7 @@
       "remaining_members_one": "+{{count}} ακόμη",
       "remaining_members_other": "+{{count}} ακόμη",
       "search": "Αναζήτηση μελών...",
+      "select_all": "Επιλογή όλων",
       "select_group": "Επιλογή ομάδας",
       "select_hint": "Επιλέξτε μέλη για μαζικές ενέργειες",
       "select_process": "Επιλέξτε διαδικασία",

--- a/src/i18n/locales/el/common.json
+++ b/src/i18n/locales/el/common.json
@@ -1042,6 +1042,7 @@
       "select_all": "Επιλογή όλων",
       "select_group": "Επιλογή ομάδας",
       "select_hint": "Επιλέξτε μέλη για μαζικές ενέργειες",
+      "select_member": "Επιλογή {{name}}",
       "select_process": "Επιλέξτε διαδικασία",
       "selected_one": "Επιλεγμένα: <strong>{{count}} μέλος</strong>",
       "selected_other": "Επιλεγμένα: <strong>{{count}} μέλη</strong>",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1039,6 +1039,7 @@
       "remaining_members_one": "+{{count}} more",
       "remaining_members_other": "+{{count}} more",
       "search": "Search members...",
+      "select_all": "Select all",
       "select_group": "Select group",
       "select_hint": "Select members to perform bulk actions",
       "select_process": "Select process",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1042,6 +1042,7 @@
       "select_all": "Select all",
       "select_group": "Select group",
       "select_hint": "Select members to perform bulk actions",
+      "select_member": "Select {{name}}",
       "select_process": "Select process",
       "selected_one": "Selected: <strong>{{count}} member</strong>",
       "selected_other": "Selected: <strong>{{count}} members</strong>",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1060,6 +1060,7 @@
       "select_all": "Seleccionar todos",
       "select_group": "Seleccionar grupo",
       "select_hint": "Selecciona miembros para realizar acciones masivas",
+      "select_member": "Seleccionar a {{name}}",
       "select_process": "Seleccionar proceso",
       "selected_one": "Seleccionado: <strong>Un miembro</strong>",
       "selected_many": "",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1057,6 +1057,7 @@
       "remaining_members_many": "",
       "remaining_members_other": "+{{count}} más",
       "search": "Buscar miembros...",
+      "select_all": "Seleccionar todos",
       "select_group": "Seleccionar grupo",
       "select_hint": "Selecciona miembros para realizar acciones masivas",
       "select_process": "Seleccionar proceso",

--- a/src/i18n/locales/eu/common.json
+++ b/src/i18n/locales/eu/common.json
@@ -1039,6 +1039,7 @@
       "remaining_members_one": "+{{count}} gehiago",
       "remaining_members_other": "+{{count}} gehiago",
       "search": "Bilatu kideak...",
+      "select_all": "Hautatu denak",
       "select_group": "Hautatu taldea",
       "select_hint": "Hautatu kideak ekintza masiboak egiteko",
       "select_process": "Hautatu prozesua",

--- a/src/i18n/locales/eu/common.json
+++ b/src/i18n/locales/eu/common.json
@@ -1042,6 +1042,7 @@
       "select_all": "Hautatu denak",
       "select_group": "Hautatu taldea",
       "select_hint": "Hautatu kideak ekintza masiboak egiteko",
+      "select_member": "Hautatu {{name}}",
       "select_process": "Hautatu prozesua",
       "selected_one": "Hautatuta: <strong>Kide bat</strong>",
       "selected_other": "Hautatuta: <strong>{{count}} kide</strong>",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1060,6 +1060,7 @@
       "select_all": "Tout sélectionner",
       "select_group": "Sélectionner un groupe",
       "select_hint": "Sélectionnez des membres pour effectuer des actions groupées",
+      "select_member": "Sélectionner {{name}}",
       "select_process": "Sélectionner un processus",
       "selected_one": "Sélectionné : <strong>{{count}} membre</strong>",
       "selected_many": "",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1057,6 +1057,7 @@
       "remaining_members_many": "",
       "remaining_members_other": "+{{count}} de plus",
       "search": "Rechercher des membres…",
+      "select_all": "Tout sélectionner",
       "select_group": "Sélectionner un groupe",
       "select_hint": "Sélectionnez des membres pour effectuer des actions groupées",
       "select_process": "Sélectionner un processus",

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -1060,6 +1060,7 @@
       "select_all": "Seleziona tutti",
       "select_group": "Seleziona gruppo",
       "select_hint": "Seleziona membri per eseguire azioni di massa",
+      "select_member": "Seleziona {{name}}",
       "select_process": "Seleziona processo",
       "selected_one": "Selezionato: <strong>{{count}} membro</strong>",
       "selected_many": "",

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -1057,6 +1057,7 @@
       "remaining_members_many": "",
       "remaining_members_other": "+{{count}} altri",
       "search": "Cerca membri...",
+      "select_all": "Seleziona tutti",
       "select_group": "Seleziona gruppo",
       "select_hint": "Seleziona membri per eseguire azioni di massa",
       "select_process": "Seleziona processo",

--- a/src/i18n/locales/pt-br/common.json
+++ b/src/i18n/locales/pt-br/common.json
@@ -1060,6 +1060,7 @@
       "select_all": "Selecionar todos",
       "select_group": "Selecionar grupo",
       "select_hint": "Selecione membros para realizar ações em massa",
+      "select_member": "Selecionar {{name}}",
       "select_process": "Selecionar processo",
       "selected_one": "Selecionado: <strong>{{count}} membro</strong>",
       "selected_many": "",

--- a/src/i18n/locales/pt-br/common.json
+++ b/src/i18n/locales/pt-br/common.json
@@ -1057,6 +1057,7 @@
       "remaining_members_many": "",
       "remaining_members_other": "+{{count}} a mais",
       "search": "Pesquisar membros...",
+      "select_all": "Selecionar todos",
       "select_group": "Selecionar grupo",
       "select_hint": "Selecione membros para realizar ações em massa",
       "select_process": "Selecionar processo",

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1060,6 +1060,7 @@
       "select_all": "Selecionar todos",
       "select_group": "Selecionar grupo",
       "select_hint": "Seleciona membros para realizar ações em massa",
+      "select_member": "Selecionar {{name}}",
       "select_process": "Selecionar processo",
       "selected_one": "Selecionado: <strong>{{count}} membro</strong>",
       "selected_many": "",

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1057,6 +1057,7 @@
       "remaining_members_many": "",
       "remaining_members_other": "+{{count}} adicionais",
       "search": "Pesquisar membros…",
+      "select_all": "Selecionar todos",
       "select_group": "Selecionar grupo",
       "select_hint": "Seleciona membros para realizar ações em massa",
       "select_process": "Selecionar processo",

--- a/src/theme/recipes/card.ts
+++ b/src/theme/recipes/card.ts
@@ -148,6 +148,30 @@ export const Card = defineSlotRecipe({
           bgColor: 'bg.panel',
         },
       },
+      'data-list-item': {
+        root: {
+          w: 'full',
+          bgColor: 'transparent',
+          border: '1px solid',
+          borderColor: 'border.dashboard',
+          borderRadius: 'sm',
+          p: 4,
+          gap: 2,
+        },
+        header: {
+          p: 0,
+          flexDirection: 'row',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: 2,
+        },
+        body: {
+          p: 0,
+          gap: 1,
+          fontSize: 'sm',
+          color: 'texts.subtle',
+        },
+      },
     },
   },
 })


### PR DESCRIPTION
> [!IMPORTANT]
> **Disclaimer: this is a future fix, not intended for the current iteration.** Parked here for a later cycle — do not merge as part of the ongoing release work.

## What

On mobile (below `md`), the dashboard tables for **voting processes** (All/Ended/Drafts) and **memberbase members** currently render the full desktop table with horizontal scrolling only, which is hard to explore on a phone. This PR replaces them below the `md` breakpoint with stacked card lists; desktop rendering is untouched.

- **Theme**: new `data-list-item` variant on the existing `card` slot recipe, built entirely from semantic tokens (`border.dashboard`, `texts.subtle`) and the spacing/radii scale — no hardcoded styles in components.
- **Processes (All/Ended)**: each election renders as a card — linked title (2-line clamp), type/status/results badges, labeled start/end/recount lines, and the same actions kebab. The Live/Not-yet tag was extracted into a shared `ProcessResultsTag` so row and card share identical logic.
- **Drafts**: same card pattern, reusing `DraftsContextMenu` and the "Not defined yet" fallbacks.
- **Members**: a select-all row (tri-state checkbox + ColumnManager) above stacked member cards, each with a selection checkbox, name title, one line per *visible* column (phone masking preserved), and the actions kebab. Bulk actions, search, drawers and pagination work unchanged through the same `useTable()` context.
- **i18n**: two new keys — `members.table.select_all` and `members.table.select_member` (the per-member selection checkbox aria-label) — translated across all locales.

## Why

Vocdoni org administrators frequently manage votes from their phones; collapsing table rows into cards with a clear hierarchy (title → badges → labeled metadata → kebab) is the standard mobile pattern for data tables. Card/table views are swapped inside the same data loop via `useBreakpointValue` (existing codebase idiom), so business logic is never duplicated.

Deferred to a follow-up: the group-members drawer table (`GroupsBoard.tsx`) — `MemberCard`'s optional `actions`/`selectable` props are already designed for it.

## Review follow-ups

Addressing the automated review:
- Extracted `maskIfNeeded`/`maskedFields` into a dedicated `maskIfNeeded.ts` leaf module, breaking the circular import between `Members/index.tsx` and `MemberCard.tsx`.
- Loosened `maskIfNeeded`'s signature to accept an optional `value` and guard it first, so it always returns a `string` even for optional/empty member fields (previously the `string` contract could hand back `undefined`).
- Added the per-member checkbox aria-label (`members.table.select_member`).
- Added breakpoint tests for `ProcessesTable`, `DraftsTable` and the members list (`MembersTable`) asserting the mobile card branch (no `<table>`/column headers; labelled cards) and the desktop table branch (table + column headers) render as expected.
- Added explicit `afterEach(resetReactProvidersMock())` to the `ProcessesTable`/`DraftsTable` suites so `setReactProvidersMock` overrides can't leak between test files.

## How it was verified

- `pnpm lint` passes; `pnpm test` passes the full suite (574 passed / 3 skipped), including the new mobile/desktop breakpoint tests for `ProcessesTable`, `DraftsTable` and `MembersTable`.
- Verified live at 375px (processes, drafts, members: cards, badges, kebabs, selection, masking, pagination, dark mode) and at 1280px (desktop tables pixel-identical to before).

