### PR TITLE
refactor(sdk): rely on SDK dev defaults

### DIFF
--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -1,6 +1,6 @@
 import { Signer } from '@ethersproject/abstract-signer'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { ComponentsProvider, useClient } from '@vocdoni/react-components'
+import { ComponentsProvider } from '@vocdoni/react-components'
 import { setDefaultOptions } from 'date-fns'
 import { PropsWithChildren, useCallback, useEffect, useMemo, useState } from 'react'
 import { I18nextProvider, useTranslation } from 'react-i18next'
@@ -188,31 +188,12 @@ const SaasProviders = ({ children }: PropsWithChildren<{}>) => (
   </AuthProvider>
 )
 
-// ClientOptions has no explorerUrl field, so the dev explorer override resolved
-// in getVocdoniClientConfig can't be passed to ClientProvider. Apply it onto the
-// provider's client instance (the one the "Open in explorer" links read via
-// useClient) after creation, mirroring createVocdoniSdkClient.
-const ExplorerUrlSync = ({ explorerUrl }: { explorerUrl?: string }) => {
-  const { client } = useClient()
-
-  useEffect(() => {
-    if (explorerUrl && client) {
-      client.explorerUrl = explorerUrl
-    }
-  }, [client, explorerUrl])
-
-  return null
-}
-
 const AppRuntimeProviders = ({ children }: PropsWithChildren) => {
   const { data } = useWalletClient()
   const { i18n } = useTranslation()
   const { VOCDONI_ENVIRONMENT } = useAppEnv()
   const locale = datesLocale(i18n.language)
-  const { clientEnv, options, explorerUrl } = useMemo(
-    () => getVocdoniClientConfig(VOCDONI_ENVIRONMENT),
-    [VOCDONI_ENVIRONMENT]
-  )
+  const { clientEnv } = useMemo(() => getVocdoniClientConfig(VOCDONI_ENVIRONMENT), [VOCDONI_ENVIRONMENT])
 
   const signer = data ? walletClientToSigner(data) : null
 
@@ -223,8 +204,7 @@ const AppRuntimeProviders = ({ children }: PropsWithChildren) => {
   return (
     <RainbowKitTheme>
       <ComponentsProvider components={uiScaffoldComponents}>
-        <ClientProvider env={clientEnv} signer={signer as Signer} options={options}>
-          <ExplorerUrlSync explorerUrl={explorerUrl} />
+        <ClientProvider env={clientEnv} signer={signer as Signer}>
           <ConnectionToastProvider>
             <SaasProviders>
               <AnalyticsProvider>

--- a/src/pages/@lang/processes/@id/+data.ts
+++ b/src/pages/@lang/processes/@id/+data.ts
@@ -5,7 +5,7 @@ import { getVocdoniClientConfig } from '~src/providers/vocdoni-client-config'
 import { serializePublicPageErrorDetails } from '~src/ssr/public-pages'
 
 export default async function data(pageContext: PageContextServer) {
-  const { clientEnv, options } = getVocdoniClientConfig(getServerAppEnv().VOCDONI_ENVIRONMENT)
+  const { clientEnv } = getVocdoniClientConfig(getServerAppEnv().VOCDONI_ENVIRONMENT)
 
   try {
     return await loadProcessPublicPageData(pageContext)
@@ -14,7 +14,6 @@ export default async function data(pageContext: PageContextServer) {
       routeParams: pageContext.routeParams,
       urlPathname: pageContext.urlPathname,
       clientEnv,
-      clientOptions: options,
       error: serializePublicPageErrorDetails(error),
     })
 

--- a/src/pages/@lang/processes/@id/summary/+data.ts
+++ b/src/pages/@lang/processes/@id/summary/+data.ts
@@ -5,7 +5,7 @@ import { getVocdoniClientConfig } from '~src/providers/vocdoni-client-config'
 import { serializePublicPageErrorDetails } from '~src/ssr/public-pages'
 
 export default async function data(pageContext: PageContextServer) {
-  const { clientEnv, options } = getVocdoniClientConfig(getServerAppEnv().VOCDONI_ENVIRONMENT)
+  const { clientEnv } = getVocdoniClientConfig(getServerAppEnv().VOCDONI_ENVIRONMENT)
 
   try {
     return await loadProcessSummaryPublicPageData(pageContext)
@@ -14,7 +14,6 @@ export default async function data(pageContext: PageContextServer) {
       routeParams: pageContext.routeParams,
       urlPathname: pageContext.urlPathname,
       clientEnv,
-      clientOptions: options,
       error: serializePublicPageErrorDetails(error),
     })
 

--- a/src/providers/vocdoni-client-config.test.ts
+++ b/src/providers/vocdoni-client-config.test.ts
@@ -1,17 +1,22 @@
 import { EnvOptions } from '@vocdoni/sdk'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
+
+import { getVocdoniClientConfig } from './vocdoni-client-config'
 
 describe('getVocdoniClientConfig', () => {
-  afterEach(() => {
-    delete process.env.VOCDONI_ENVIRONMENT
-    vi.resetModules()
+  it('resolves the dev environment to the SDK dev defaults', () => {
+    expect(getVocdoniClientConfig('dev')).toEqual({
+      clientEnv: EnvOptions.DEV,
+    })
   })
 
-  it('resolves the dev environment to the SDK dev defaults', async () => {
-    process.env.VOCDONI_ENVIRONMENT = 'dev'
+  it('resolves the prod environment to the SDK prod defaults', () => {
+    expect(getVocdoniClientConfig('prod')).toEqual({
+      clientEnv: EnvOptions.PROD,
+    })
+  })
 
-    const { getVocdoniClientConfig } = await import('./vocdoni-client-config')
-
+  it('defaults to the SDK dev environment', () => {
     expect(getVocdoniClientConfig()).toEqual({
       clientEnv: EnvOptions.DEV,
     })

--- a/src/providers/vocdoni-client-config.test.ts
+++ b/src/providers/vocdoni-client-config.test.ts
@@ -7,17 +7,13 @@ describe('getVocdoniClientConfig', () => {
     vi.resetModules()
   })
 
-  it('rewrites the dev environment to the one-dev api endpoint', async () => {
+  it('resolves the dev environment to the SDK dev defaults', async () => {
     process.env.VOCDONI_ENVIRONMENT = 'dev'
 
     const { getVocdoniClientConfig } = await import('./vocdoni-client-config')
 
     expect(getVocdoniClientConfig()).toEqual({
       clientEnv: EnvOptions.DEV,
-      options: {
-        api_url: 'https://one-dev.vocdoni.net/v2',
-      },
-      explorerUrl: 'https://one-dev.explorer.vote',
     })
   })
 })

--- a/src/providers/vocdoni-client-config.ts
+++ b/src/providers/vocdoni-client-config.ts
@@ -6,32 +6,14 @@ import { EnvOptions, VocdoniSDKClient } from '@vocdoni/sdk'
 export const getVocdoniClientConfig = (environment: string = 'dev') => {
   const normalizedEnvironment = environment.toLowerCase()
   const clientEnv: EnvOptions = normalizedEnvironment === 'prod' ? EnvOptions.PROD : EnvOptions.DEV
-  const options: { api_url?: string } = {}
-  let explorerUrl: string | undefined
 
-  if (clientEnv === EnvOptions.DEV) {
-    options.api_url = 'https://one-dev.vocdoni.net/v2'
-    // The SDK defaults the dev explorer to https://dev.explorer.vote, which does
-    // not know about the one-dev (vocone) network we point the api_url to. Pin it
-    // to the matching one-dev explorer so links resolve instead of returning
-    // "election not found".
-    explorerUrl = 'https://one-dev.explorer.vote'
-  }
-
-  return { clientEnv, options, explorerUrl }
+  return { clientEnv }
 }
 
 export const createVocdoniSdkClient = (environment?: string) => {
-  const { clientEnv, options, explorerUrl } = getVocdoniClientConfig(environment)
+  const { clientEnv } = getVocdoniClientConfig(environment)
 
-  const client = new VocdoniSDKClient({
+  return new VocdoniSDKClient({
     env: clientEnv,
-    ...options,
   })
-
-  if (explorerUrl) {
-    client.explorerUrl = explorerUrl
-  }
-
-  return client
 }


### PR DESCRIPTION
The DEV environment already defaults to api-dev.vocdoni.net and dev.explorer.vote, so the manual api_url/explorerUrl overrides in getVocdoniClientConfig were redundant. Drop them along with the ExplorerUrlSync provider and the option plumbing in the callers.