### PR TITLE
fix(platform): move API-key endpoints under /integrator (saas-backend#582)

### DIFF
--- a/src/platform/api/endpoints.ts
+++ b/src/platform/api/endpoints.ts
@@ -29,9 +29,9 @@ export enum ApiEndpoints {
   // the session (or an API key), so no organization address is passed in the URL.
   Integrator = 'integrator',
   ManagedOrganizations = 'integrator/organizations',
-  // API keys (saas-backend#535)
-  APIKeys = 'organizations/{address}/apikeys',
-  APIKey = 'organizations/{address}/apikeys/{keyID}',
+  // API keys (saas-backend#535, moved under /integrator by saas-backend#582)
+  APIKeys = 'integrator/organizations/{orgAddress}/apikeys',
+  APIKey = 'integrator/organizations/{orgAddress}/apikeys/{keyId}',
 }
 
 export enum ErrorCode {

--- a/src/platform/queries/apikeys.ts
+++ b/src/platform/queries/apikeys.ts
@@ -44,7 +44,7 @@ export const useApiKeys = () => {
     queryKey: QueryKeys.organization.apikeys(address),
     enabled: !!address,
     queryFn: () =>
-      bearedFetch<{ apiKeys: ApiKey[] }>(ApiEndpoints.APIKeys.replace('{address}', ensure0x(address!))).then(
+      bearedFetch<{ apiKeys: ApiKey[] }>(ApiEndpoints.APIKeys.replace('{orgAddress}', ensure0x(address!))).then(
         (d) => d.apiKeys ?? []
       ),
   })
@@ -58,7 +58,7 @@ export const useCreateApiKey = () => {
 
   return useMutation<CreatedApiKey, Error, CreateApiKeyBody>({
     mutationFn: (body) =>
-      bearedFetch<CreatedApiKey>(ApiEndpoints.APIKeys.replace('{address}', ensure0x(address!)), {
+      bearedFetch<CreatedApiKey>(ApiEndpoints.APIKeys.replace('{orgAddress}', ensure0x(address!)), {
         method: 'POST',
         body,
       }),
@@ -76,7 +76,7 @@ export const useRevokeApiKey = () => {
 
   return useMutation<void, Error, { id: string }>({
     mutationFn: ({ id }) =>
-      bearedFetch<void>(ApiEndpoints.APIKey.replace('{address}', ensure0x(address!)).replace('{keyID}', id), {
+      bearedFetch<void>(ApiEndpoints.APIKey.replace('{orgAddress}', ensure0x(address!)).replace('{keyId}', id), {
         method: 'DELETE',
       }),
     onSuccess: () => {


### PR DESCRIPTION
## Summary
- saas-backend#582 relocated the API-key routes as a hard cutover (no legacy alias): `organizations/{address}/apikeys[/{keyID}]` → `integrator/organizations/{orgAddress}/apikeys[/{keyId}]`. Response shape (`APIKeyInfo`) is unchanged.
- Updates `ApiEndpoints.APIKeys`/`APIKey` and the `.replace(...)` calls in `queries/apikeys.ts` (`useApiKeys`, `useCreateApiKey`, `useRevokeApiKey`) to the new path.
- Confirmed this is the only integrator-UI-relevant breaking change in #582: the rest (path-param renames, `/jobs` consolidation, `/processes` reshapes) doesn't touch any endpoint this UI calls.

Closes #1730

## Test plan
- [ ] `npx tsc --noEmit` clean on touched files (checked locally)
- [ ] Manual: create/list/revoke an API key against a saas-backend build that includes #582