### PR TITLE
fix(integrators): move API-key endpoints under /integrator (saas-backend#582)

### DIFF
--- a/src/components/Auth/api.ts
+++ b/src/components/Auth/api.ts
@@ -17,8 +17,8 @@ export enum ApiEndpoints {
   // Path-less: the integrator organization is resolved server-side from the authenticated session.
   Integrator = 'integrator',
   ManagedOrganizations = 'integrator/organizations',
-  OrganizationApiKeys = 'organizations/{address}/apikeys',
-  OrganizationApiKey = 'organizations/{address}/apikeys/{keyID}',
+  OrganizationApiKeys = 'integrator/organizations/{orgAddress}/apikeys',
+  OrganizationApiKey = 'integrator/organizations/{orgAddress}/apikeys/{keyId}',
   Login = 'auth/login',
   Me = 'users/me',
   Organization = 'organizations/{address}',

--- a/src/queries/integrators.ts
+++ b/src/queries/integrators.ts
@@ -121,7 +121,7 @@ export type CreateApiKeyBody = {
 
 export type CreatedApiKey = ApiKey & { secret: string }
 
-/** API keys owned by the selected organization (GET /organizations/{address}/apikeys, admin only). */
+/** API keys owned by the selected organization (GET /integrator/organizations/{orgAddress}/apikeys, admin only). */
 export const useApiKeys = () => {
   const { bearedFetch } = useAuth()
   const { account } = useClient()
@@ -132,7 +132,7 @@ export const useApiKeys = () => {
     enabled: !!address,
     queryFn: () =>
       bearedFetch<{ apiKeys: ApiKey[] }>(
-        ApiEndpoints.OrganizationApiKeys.replace('{address}', ensure0x(address as string))
+        ApiEndpoints.OrganizationApiKeys.replace('{orgAddress}', ensure0x(address as string))
       ).then((d) => d.apiKeys ?? []),
   })
 }
@@ -146,10 +146,13 @@ export const useCreateApiKey = () => {
 
   return useMutation<CreatedApiKey, Error, CreateApiKeyBody>({
     mutationFn: (body) =>
-      bearedFetch<CreatedApiKey>(ApiEndpoints.OrganizationApiKeys.replace('{address}', ensure0x(address as string)), {
-        method: 'POST',
-        body,
-      }),
+      bearedFetch<CreatedApiKey>(
+        ApiEndpoints.OrganizationApiKeys.replace('{orgAddress}', ensure0x(address as string)),
+        {
+          method: 'POST',
+          body,
+        }
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QueryKeys.organization.apikeys(address) })
     },
@@ -166,7 +169,7 @@ export const useRevokeApiKey = () => {
   return useMutation<void, Error, { id: string }>({
     mutationFn: ({ id }) =>
       bearedFetch<void>(
-        ApiEndpoints.OrganizationApiKey.replace('{address}', ensure0x(address as string)).replace('{keyID}', id),
+        ApiEndpoints.OrganizationApiKey.replace('{orgAddress}', ensure0x(address as string)).replace('{keyId}', id),
         { method: 'DELETE' }
       ),
     onSuccess: () => {


### PR DESCRIPTION
## Summary
- saas-backend#582 relocated the API-key routes as a hard cutover (no legacy alias): `organizations/{address}/apikeys[/{keyID}]` → `integrator/organizations/{orgAddress}/apikeys[/{keyId}]`. Response shape (`APIKeyInfo`) is unchanged.
- Updates `ApiEndpoints.OrganizationApiKeys`/`OrganizationApiKey` (`src/components/Auth/api.ts`) and the `.replace(...)` calls in `src/queries/integrators.ts` (`useApiKeys`, `useCreateApiKey`, `useRevokeApiKey`) to the new path.

## Context
Reapplies #1731 (originally merged into `feat/platform-integrator-build`, a separate standalone SPA build under `src/platform/*`). That branch turned out not to be the base the integrator feature actually shipped on — `develop` has its own, independently-built integrator implementation (`src/components/Integrator/*`, `src/queries/integrators.ts`, `src/router/routes/integrators.tsx`), which is the one users are actually running. Same underlying bug, different codebase, so it needed to be reapplied here rather than merged forward.

Re-audited the rest of #582's breaking changes against this implementation: path-param renames and `/jobs`/`/processes`/`/census` reshapes don't touch anything this integrator code calls — API keys is the only fix needed. (Note: `ApiEndpoints.OrganizationMembersImport` in the same `api.ts` file also points at a route #582 removed, but that's used by the main, non-integrator member-import UI — out of scope here, flagging separately.)

Closes #1730

## Test plan
- [ ] `npx tsc --noEmit` clean on touched files (checked locally; 4 pre-existing unrelated theme-typing errors on `develop` baseline are untouched by this change)
- [ ] Manual: create/list/revoke an API key from the integrator dashboard against a saas-backend build that includes #582