### PR TITLE
feat(analytics): PostHog integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ PRIORITY_SUPPORT_PHONE="+34 900 123 456"
 STRIPE_PUBLIC_KEY=key
 GTM_CONTAINER_ID=GTM-XXXXXXX
 PLAUSIBLE_DOMAIN=app.vocdoni.io
+# PostHog is disabled unless a project API key is set (production only)
+POSTHOG_KEY=
+POSTHOG_HOST=https://eu.i.posthog.com
 ANALYTICS_CLIENT_ID=client-id
 CRISP_WEBSITE_ID=
 ANNOUNCEMENT='{"message": {"en": "Welcome!", "es": "¡Bienvenido!"}, "status": "info", "lsKey": "unique-local-storage-key"}'

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -33,6 +33,18 @@ Env is runtime-injected (see `src/app-env-build.ts`), so a single Docker image w
    `$current_url`/`$referrer`; exception payloads get email addresses redacted.
 4. **Session replay** only for authenticated users who accepted consent, with `maskAllInputs`; ballot
    content carries `.ph-no-capture` as defense in depth.
+5. **Memberbase PII is never recorded.** Every surface that renders a member record carries
+   `.ph-no-capture`, so rrweb skips the subtree entirely (text *and* attributes): member table cells
+   (`Memberbase/Members/index.tsx`), member cards (`MemberCard.tsx` — the checkbox `aria-label`
+   embeds the member name, so the whole card is excluded), group member table cells
+   (`GroupsBoard.tsx`), and the CSV import error list (`Members/Import.tsx`), which quotes offending
+   rows. Member search and the add/edit member form are covered by `maskAllInputs`. Surrounding
+   chrome — tabs, headings, buttons, counts, group names — stays visible, so replays remain usable.
+   **When adding a component that renders member fields, add `className='ph-no-capture'` to it.**
+6. **Opting a field back in.** `maskAllInputs` hides every input value, including ones that are not
+   personal data. `posthogMaskInput` (wired as `maskInputFn`) restores the value for inputs inside a
+   `data-ph-unmask` subtree; passwords are never restored. The only current use is the organization
+   name in Settings → Organization details (`Organization/Form.tsx`).
 
 ## Tracking events
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -55,10 +55,10 @@ keep their historical strings for Plausible/GTM and are renamed to snake_case fo
 contain voter identifiers, ballot content, emails, or tokens.
 
 Current taxonomy (PostHog names): `account_signed_up`, `user_logged_in`, `organization_created`,
-`process_created`, `subscription_completed`, `multiquestion_multichoice_attempted`, `checkout_started`,
+`process_created`, `subscription_completed`, `checkout_started`,
 `billing_portal_opened`, `paywall_viewed`, `feature_blocked`, `process_creation_failed`,
 `process_template_selected`, `process_action`, `process_results_viewed`, `members_import_started`,
-`members_import_completed`, `member_group_created`, `member_group_deleted`, `census_published`,
+`members_import_completed`, `member_group_created`, `member_group_deleted`, `census_configured`,
 `onboarding_step_completed`, `team_member_invited`, `team_member_removed`, `pdf_report_downloaded`.
 
 Organization-level BI: every session registers `org_address`/`org_name`/`org_plan` super properties, and
@@ -116,9 +116,9 @@ What it provisions:
 
 | Dashboard | Insights |
 | --- | --- |
-| **Activation** | signup → org → first election (steps, time-to-convert, weekly trend); memberbase import funnel; onboarding steps completed |
+| **Activation** | signup → org → first election (steps, time-to-convert, weekly trend); memberbase import funnel; onboarding steps completed; organizations created by name |
 | **Monetization** | paywall → checkout → subscription (broken down by `source`); blocked feature → upgrade (by `feature`); paywall exposure per plan |
-| **Elections & engagement** | wizard funnel `process_template_selected` → `census_published` → `process_created` → `process_results_viewed`; created vs failed; weekly active organizations; elections by `census_type` |
+| **Elections & engagement** | wizard funnel `process_template_selected` → `census_configured` → `process_created` → `process_results_viewed`; created vs failed; weekly active organizations; elections by `census_type` |
 
 Two things make these worth more than the PostHog defaults:
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,106 @@
+# Analytics & PostHog
+
+The app fans analytics out to three sinks — Plausible, GTM, and **PostHog** (EU Cloud) — through a single
+abstraction: `src/utils/analytics.ts` (vendor modules, lazy-loaded) and `src/components/AnalyticsProvider.tsx`
+(React wiring: consent, identity, organization group). PostHog is the primary product-analytics/BI tool;
+Plausible/GTM are kept for continuity.
+
+## Configuration (runtime env)
+
+| Variable | Meaning |
+| --- | --- |
+| `POSTHOG_KEY` | PostHog project API key (`phc_…`). **Unset = PostHog fully disabled** (nothing is loaded). Set it in production only. |
+| `POSTHOG_HOST` | Defaults to `https://eu.i.posthog.com` (EU data residency). Point it at a reverse proxy later to mitigate ad-blockers without code changes. |
+
+Env is runtime-injected (see `src/app-env-build.ts`), so a single Docker image works across environments.
+
+## Privacy model
+
+1. **Voters are never tracked — zero events on voting routes.** Two independent layers in
+   `src/utils/analytics.ts`:
+   - `initializePosthog` refuses to load the SDK when `window.location.pathname` matches
+     `isVotingPath` (`/processes/:id`, `/processes/:id/summary`, with or without a language prefix).
+     Voters never download the SDK.
+   - `posthogBeforeSend` returns `null` for **any** event (pageviews, autocapture, replay snapshots,
+     exceptions) whose URL is a voting route — covers admins SPA-navigating into a process view.
+   Consequently there are **no voter-side events** in the taxonomy; election participation BI comes from
+   admin-side events (`process_results_viewed`) and, later, the backend.
+2. **Cookieless until consent.** Before the cookie banner is accepted, PostHog runs with
+   `persistence: 'memory'` (no cookies/localStorage) and anonymous events only
+   (`person_profiles: 'identified_only'`). On accept: persistence upgrades and dashboard users are
+   `identify()`d. On reject: `opt_out_capturing()` — full silence.
+3. **URL scrubbing.** `sanitizeAnalyticsUrl` strips `email`, `token`, `code` query params from
+   `$current_url`/`$referrer`; exception payloads get email addresses redacted.
+4. **Session replay** only for authenticated users who accepted consent, with `maskAllInputs`; ballot
+   content carries `.ph-no-capture` as defense in depth.
+
+## Tracking events
+
+Use `useAnalytics().trackEvent(...)` in components, or `trackAnalyticsEvent(...)` from
+`~utils/analytics` in hooks/query files. Event names live in `AnalyticsEvents`; the six legacy names
+keep their historical strings for Plausible/GTM and are renamed to snake_case for PostHog via
+`posthogEventNames`. New events are snake_case everywhere. Properties must be primitives and must never
+contain voter identifiers, ballot content, emails, or tokens.
+
+Current taxonomy (PostHog names): `account_signed_up`, `user_logged_in`, `organization_created`,
+`process_created`, `subscription_completed`, `multiquestion_multichoice_attempted`, `checkout_started`,
+`billing_portal_opened`, `paywall_viewed`, `feature_blocked`, `process_creation_failed`,
+`process_template_selected`, `process_action`, `process_results_viewed`, `members_import_started`,
+`members_import_completed`, `member_group_created`, `member_group_deleted`, `census_published`,
+`onboarding_step_completed`, `team_member_invited`, `team_member_removed`, `pdf_report_downloaded`.
+
+Organization-level BI: every session registers `org_address`/`org_plan` super properties, and the
+`organization` group profile carries plan, type, country, size, usage counters, and renewal date
+(see `AnalyticsProvider`).
+
+## Feature flags
+
+```tsx
+import { useFeatureFlag } from '~utils/use-feature-flag'
+
+const enabled = useFeatureFlag('new-dashboard') // undefined until flags load → render your default
+```
+
+- `undefined` means "not loaded / PostHog disabled" — defaults must always be safe.
+- Never gate voter-facing functionality on a flag: the SDK does not exist on voting routes.
+- No SSR bootstrapping: SSR HTML is LRU-cached across users (`server/ssr-cache.mjs`).
+
+## PostHog workspace checklist (one-time, in app.posthog.com — EU)
+
+1. Create the project in **PostHog Cloud EU**; copy the key to the production deployment as `POSTHOG_KEY`.
+2. Project settings: leave **IP capture disabled** (EU default); enable **error tracking** and
+   **session replay** products; set replay **sampling** to ~50% initially (free tier: 5K replays/mo).
+3. Surveys: target dashboard routes only (`/admin/*`) — never `/processes/*`.
+4. Add PostHog to the privacy policy / subprocessor list (legal, outside this repo).
+5. Suggested dashboards:
+   - **Org acquisition** — `organization_created` per week, broken down by `org_type` / `org_plan` / `client`.
+   - **Activation funnel** — `account_signed_up` → `organization_created` → `members_import_completed` →
+     `process_created` (+ time-to-value); `onboarding_step_completed` breakdown.
+   - **Engagement** — weekly active organizations (unique `org_address`), `process_created` per org.
+   - **Monetization** — `paywall_viewed` → `checkout_started` → `subscription_completed` conversion;
+     `feature_blocked` by `feature`.
+   - **Election operations** — `process_created` by `census_type`, `process_action`, turnout via
+     `process_results_viewed` (`turnout_pct`).
+6. Free-tier quotas: 1M events, 5K replays, 1M flag requests per month. Voting pages emit nothing, so
+   volume is admin-driven. Set billing limits per product as a guardrail.
+
+## Follow-up: server-side events (saas-backend)
+
+The frontend cannot see renewals, churn, payment failures, or final turnout. A follow-up in the
+saas-backend repo should send server-authoritative events with `posthog-node`, keyed to the same
+`organization` group: `organization_registered`, `subscription_renewed`, `subscription_cancelled`,
+`payment_failed`, election finalization with final turnout, and a periodic usage-counter sync to group
+properties. That makes PostHog the single BI pane without ever touching voters.
+
+## Verifying locally
+
+```bash
+POSTHOG_KEY=phc_yourdevkey pnpm dev
+```
+
+- Open a public process page → **zero** requests to `posthog.com`, SDK not loaded.
+- Elsewhere, before consent: events flow, no `ph_*` cookie/localStorage entries.
+- Accept the banner: `ph_*` storage appears; after login, the person is identified and events carry
+  `$groups.organization`.
+- Reject the banner: network silence. Logout: `posthog.reset()` (new anonymous id).
+- `posthog.debug()` in the console prints every captured event.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -61,9 +61,16 @@ Current taxonomy (PostHog names): `account_signed_up`, `user_logged_in`, `organi
 `members_import_completed`, `member_group_created`, `member_group_deleted`, `census_published`,
 `onboarding_step_completed`, `team_member_invited`, `team_member_removed`, `pdf_report_downloaded`.
 
-Organization-level BI: every session registers `org_address`/`org_plan` super properties, and the
-`organization` group profile carries plan, type, country, size, usage counters, and renewal date
-(see `AnalyticsProvider`).
+Organization-level BI: every session registers `org_address`/`org_name`/`org_plan` super properties, and
+the `organization` group profile carries name, plan, type, country, size, usage counters, and renewal
+date (see `AnalyticsProvider`).
+
+The group's `name` property is what PostHog uses to label a group — without it every organization renders
+as a bare `0x…` address. It is duplicated as the `org_name` super property because group properties are
+only queryable with the group analytics add-on, whereas super properties land on every event.
+`organization_created` also carries `org_name`/`org_address` directly, since it fires before the group
+profile has been registered. Organization names are business data, not personal data; note that a
+one-person organization may still be named after its owner.
 
 ## Feature flags
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -103,4 +103,15 @@ POSTHOG_KEY=phc_yourdevkey pnpm dev
 - Accept the banner: `ph_*` storage appears; after login, the person is identified and events carry
   `$groups.organization`.
 - Reject the banner: network silence. Logout: `posthog.reset()` (new anonymous id).
-- `posthog.debug()` in the console prints every captured event.
+
+Two gotchas when verifying:
+
+- **`window.posthog` is always `undefined`.** The SDK is imported as an ES module, not injected via the
+  `<script>` snippet, so it is never attached to `window`. Do not use it to tell whether PostHog loaded
+  (it looks identical on voting and non-voting pages), and `posthog.debug()` is not available in the
+  console. Use the **Network tab filtered on `posthog`** instead — that is the reliable signal.
+- **Headless browsers capture nothing.** posthog-js drops every event when its internal `_is_bot()` check
+  is true, which includes Playwright/Puppeteer even with a spoofed user agent and `navigator.webdriver`.
+  The SDK still initializes and still calls `/flags/`, so it looks alive while `before_send` is never
+  reached and no `/e/` request is ever made. Automated end-to-end checks need `opt_out_useragent_filter:
+  true` set temporarily, or a headed real browser.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -84,17 +84,47 @@ const enabled = useFeatureFlag('new-dashboard') // undefined until flags load �
    **session replay** products; set replay **sampling** to ~50% initially (free tier: 5K replays/mo).
 3. Surveys: target dashboard routes only (`/admin/*`) — never `/processes/*`.
 4. Add PostHog to the privacy policy / subprocessor list (legal, outside this repo).
-5. Suggested dashboards:
-   - **Org acquisition** — `organization_created` per week, broken down by `org_type` / `org_plan` / `client`.
-   - **Activation funnel** — `account_signed_up` → `organization_created` → `members_import_completed` →
-     `process_created` (+ time-to-value); `onboarding_step_completed` breakdown.
-   - **Engagement** — weekly active organizations (unique `org_address`), `process_created` per org.
-   - **Monetization** — `paywall_viewed` → `checkout_started` → `subscription_completed` conversion;
-     `feature_blocked` by `feature`.
-   - **Election operations** — `process_created` by `census_type`, `process_action`, turnout via
-     `process_results_viewed` (`turnout_pct`).
+5. Dashboards: run `pnpm posthog:insights` (see below) instead of clicking them together.
 6. Free-tier quotas: 1M events, 5K replays, 1M flag requests per month. Voting pages emit nothing, so
    volume is admin-driven. Set billing limits per product as a guardrail.
+
+## Dashboards & funnels (provisioned from code)
+
+`scripts/posthog-insights.mjs` creates the dashboards and insights through the PostHog API, so they are
+reviewable in git and reproducible across projects. It matches objects **by name**, so re-running updates
+them in place rather than duplicating.
+
+```bash
+POSTHOG_PERSONAL_API_KEY=phx_… pnpm posthog:insights --dry-run   # print the plan
+POSTHOG_PERSONAL_API_KEY=phx_… pnpm posthog:insights             # apply
+```
+
+The key is a **personal** API key (<https://eu.posthog.com/settings/user-api-keys>) with `insight:write`,
+`dashboard:write` and `group:read`. The `phc_…` project key the app ships with is write-only for events
+and cannot create insights. `POSTHOG_PROJECT_ID` is optional (first accessible project by default);
+`POSTHOG_API_HOST` defaults to `https://eu.posthog.com` — the app host, not the `eu.i.posthog.com`
+ingestion host.
+
+What it provisions:
+
+| Dashboard | Insights |
+| --- | --- |
+| **Activation** | signup → org → first election (steps, time-to-convert, weekly trend); memberbase import funnel; onboarding steps completed |
+| **Monetization** | paywall → checkout → subscription (broken down by `source`); blocked feature → upgrade (by `feature`); paywall exposure per plan |
+| **Elections & engagement** | wizard funnel `process_template_selected` → `census_published` → `process_created` → `process_results_viewed`; created vs failed; weekly active organizations; elections by `census_type` |
+
+Two things make these worth more than the PostHog defaults:
+
+- **Organization-level aggregation.** Every funnel that starts after an org exists sets
+  `aggregation_group_type_index` to the `organization` group, so conversion counts organizations, not
+  seats — several colleagues sharing one journey no longer inflate the numerator. The script resolves the
+  index from `/api/projects/:id/groups_types/`; if the group does not exist yet (it appears with the first
+  group event), it warns and falls back to person aggregation, so re-run it once real traffic has landed.
+- **Real conversion windows.** Checkout gets 7 days, activation 30, wizard failures 1 hour — an unbounded
+  window makes every funnel look better than it is.
+
+Edit the `buildPlan` function to change a funnel; the query shapes follow PostHog's `FunnelsQuery` /
+`TrendsQuery` schema.
 
 ## Follow-up: server-side events (saas-backend)
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "lexical": "^0.34.0",
     "lru-cache": "^11.2.4",
     "next-themes": "^0.4.6",
+    "posthog-js": "^1.407.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-dropzone": "^14.3.8",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
+    "posthog:insights": "node scripts/posthog-insights.mjs",
     "knip": "knip"
   },
   "eslintConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         version: 0.4.4
       '@rainbow-me/rainbowkit':
         specifier: ^2.2.10
-        version: 2.2.10(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5))
+        version: 2.2.10(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
       '@react-pdf/renderer':
         specifier: 4.4.1
         version: 4.4.1(react@19.2.7)
@@ -115,7 +115,7 @@ importers:
         version: 1.1.0
       '@vocdoni/rainbowkit-wallets':
         specifier: ^1.0.0
-        version: 1.0.0(d469549390ca0dc4315daa225c4ed1a4)
+        version: 1.0.0(1a92cee76e006291b32fcb4965ac0180)
       '@vocdoni/react-components':
         specifier: ^2.1.2
         version: 2.1.2(@tanstack/react-query@5.90.16(react@19.2.7))(@vocdoni/api-types@1.2.0)(@vocdoni/ballot@1.1.0)(@vocdoni/react-providers@2.2.0(@tanstack/react-query@5.90.16(react@19.2.7))(@vocdoni/api-client@1.2.1)(@vocdoni/api-types@1.2.0)(@vocdoni/api-voting@1.0.1)(react@19.2.7))(date-fns@4.1.0)(i18next@25.8.13(typescript@5.9.3))(react-i18next@16.5.4(i18next@25.8.13(typescript@5.9.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3))(react-router-dom@6.30.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -124,7 +124,7 @@ importers:
         version: 2.2.0(@tanstack/react-query@5.90.16(react@19.2.7))(@vocdoni/api-client@1.2.1)(@vocdoni/api-types@1.2.0)(@vocdoni/api-voting@1.0.1)(react@19.2.7)
       '@wagmi/core':
         specifier: ^2.22.1
-        version: 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
+        version: 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       chakra-react-select:
         specifier: ^6.1.1
         version: 6.1.1(@chakra-ui/react@3.31.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(next-themes@0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -158,6 +158,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      posthog-js:
+        specifier: ^1.407.3
+        version: 1.414.0
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -193,7 +196,7 @@ importers:
         version: 4.0.1
       viem:
         specifier: ^2.43.5
-        version: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       vike:
         specifier: ^0.4.258
         version: 0.4.258(react-streaming@0.4.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(srvx@0.11.15)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
@@ -202,7 +205,7 @@ importers:
         version: 0.6.21(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vike@0.4.258(react-streaming@0.4.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(srvx@0.11.15)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)))
       wagmi:
         specifier: ^2.19.5
-        version: 2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5)
+        version: 2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       web-vitals:
         specifier: ^3.5.2
         version: 3.5.2
@@ -1640,6 +1643,15 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@posthog/browser-common@0.4.0':
+    resolution: {integrity: sha512-W9DCGVks15docUMPvJ2nd8NS16Gn74bsGWuaeg31beEKFSjdW8wvnQ1ETY6WSql5pYxZb3GdJmEUZVVstKSrBQ==}
+
+  '@posthog/core@1.46.9':
+    resolution: {integrity: sha512-EXO6y5ih+jBkTCpUCuYgQmajuDZuvy6vMvflkub6pLQyi0GPlCPWVSvZZkOeQw9e2MxoD5GteeGCt9R8+UJ/yQ==}
+
+  '@posthog/types@1.402.2':
+    resolution: {integrity: sha512-ZZTiS4dLwF4/D0YTzS3gGSLFnhuNOY5yu4d9VGS9trGe5GW6FjIXo20p18K5BPW2RZSYSld8sdnSAY3AUXleUQ==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -3602,6 +3614,9 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  core-js@3.50.0:
+    resolution: {integrity: sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -3648,6 +3663,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   css-select@4.3.0:
     resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
@@ -3827,6 +3843,9 @@ packages:
   domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -4087,6 +4106,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
@@ -5327,11 +5349,22 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.414.0:
+    resolution: {integrity: sha512-dtZd4asdskr8lNyltAEX6zyn48uO1pO0EMvx6AXJU65PFhu6yn2LPbKtQcyLysjcN57FJPNT9QYL6St5SBJHqw==}
+
   preact@10.24.2:
     resolution: {integrity: sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==}
 
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
+
+  preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   prettier@3.7.4:
     resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
@@ -5410,6 +5443,9 @@ packages:
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   query-string@7.1.3:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
@@ -6478,6 +6514,12 @@ packages:
   web-vitals@3.5.2:
     resolution: {integrity: sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg==}
 
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
+
+  web-vitals@6.0.0:
+    resolution: {integrity: sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==}
+
   webextension-polyfill@0.10.0:
     resolution: {integrity: sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==}
 
@@ -7026,16 +7068,16 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-org/account@2.4.0(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@base-org/account@2.4.0(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@coinbase/cdp-sdk': 1.40.2(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@4.3.5)
+      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.3(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7))
     transitivePeerDependencies:
       - '@types/react'
@@ -7168,15 +7210,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@4.3.5)
+      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.3(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7))
     transitivePeerDependencies:
       - '@types/react'
@@ -7756,11 +7798,11 @@ snapshots:
 
   '@fontsource/inter@5.2.8': {}
 
-  '@gemini-wallet/core@0.3.2(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))':
+  '@gemini-wallet/core@0.3.2(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       '@metamask/rpc-errors': 7.0.2
       eventemitter3: 5.0.1
-      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -8438,6 +8480,17 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@posthog/browser-common@0.4.0':
+    dependencies:
+      '@posthog/core': 1.46.9
+      '@posthog/types': 1.402.2
+
+  '@posthog/core@1.46.9':
+    dependencies:
+      '@posthog/types': 1.402.2
+
+  '@posthog/types@1.402.2': {}
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -8461,7 +8514,7 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5))':
+  '@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))':
     dependencies:
       '@tanstack/react-query': 5.90.16(react@19.2.7)
       '@vanilla-extract/css': 1.17.3(babel-plugin-macros@3.1.0)
@@ -8473,8 +8526,8 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       react-remove-scroll: 2.6.2(@types/react@19.2.17)(react@19.2.7)
       ua-parser-js: 1.0.41
-      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      wagmi: 2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5)
+      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
     transitivePeerDependencies:
       - '@types/react'
       - babel-plugin-macros
@@ -8596,24 +8649,24 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-common@1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@reown/appkit-common@1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@reown/appkit-controllers@1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@19.2.17)(react@19.2.7)
-      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -8642,12 +8695,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-pay@1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@reown/appkit-pay@1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.17)(react@19.2.7))(zod@4.3.5)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.17)(react@19.2.7))(zod@3.25.76)
       lit: 3.3.0
       valtio: 1.13.2(@types/react@19.2.17)(react@19.2.7)
     transitivePeerDependencies:
@@ -8682,12 +8735,12 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.17)(react@19.2.7))(zod@4.3.5)':
+  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.17)(react@19.2.7))(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.17)(react@19.2.7))(zod@4.3.5)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.17)(react@19.2.7))(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
     transitivePeerDependencies:
@@ -8719,10 +8772,10 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-ui@1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@reown/appkit-ui@1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -8754,16 +8807,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.17)(react@19.2.7))(zod@4.3.5)':
+  '@reown/appkit-utils@1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.17)(react@19.2.7))(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-polyfills': 1.7.8
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@19.2.17)(react@19.2.7)
-      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -8803,21 +8856,21 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@reown/appkit@1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@reown/appkit@1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@reown/appkit-pay': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-pay': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.17)(react@19.2.7))(zod@4.3.5)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.17)(react@19.2.7))(zod@4.3.5)
+      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.17)(react@19.2.7))(zod@3.25.76)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.17)(react@19.2.7))(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/types': 2.21.0
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.17)(react@19.2.7)
-      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -8936,9 +8989,9 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.55.1':
     optional: true
 
-  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - bufferutil
@@ -8946,10 +8999,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -9436,7 +9489,7 @@ snapshots:
       '@solana/buffer-layout': 4.0.1
       '@solana/codecs-numbers': 2.3.0(typescript@5.9.3)
       agentkeepalive: 4.6.0
-      bn.js: 5.2.2
+      bn.js: 5.2.3
       borsh: 0.7.0
       bs58: 4.0.1
       buffer: 6.0.3
@@ -10029,17 +10082,17 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.4
 
-  '@vocdoni/rainbowkit-wallets@1.0.0(d469549390ca0dc4315daa225c4ed1a4)':
+  '@vocdoni/rainbowkit-wallets@1.0.0(1a92cee76e006291b32fcb4965ac0180)':
     dependencies:
-      '@rainbow-me/rainbowkit': 2.2.10(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5))
+      '@rainbow-me/rainbowkit': 2.2.10(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
       '@tanstack/react-query': 5.90.16(react@19.2.7)
       buffer: 6.0.3
       crypto-js: 4.2.0
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-modal: 3.16.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      wagmi: 2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5)
+      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
 
   '@vocdoni/react-components@2.1.2(@tanstack/react-query@5.90.16(react@19.2.7))(@vocdoni/api-types@1.2.0)(@vocdoni/ballot@1.1.0)(@vocdoni/react-providers@2.2.0(@tanstack/react-query@5.90.16(react@19.2.7))(@vocdoni/api-client@1.2.1)(@vocdoni/api-types@1.2.0)(@vocdoni/api-voting@1.0.1)(react@19.2.7))(date-fns@4.1.0)(i18next@25.8.13(typescript@5.9.3))(react-i18next@16.5.4(i18next@25.8.13(typescript@5.9.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3))(react-router-dom@6.30.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -10064,19 +10117,19 @@ snapshots:
       '@vocdoni/api-voting': 1.0.1
       react: 19.2.7
 
-  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5))(zod@4.3.5)':
+  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      '@base-org/account': 2.4.0(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@gemini-wallet/core': 0.3.2(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
+      '@base-org/account': 2.4.0(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@gemini-wallet/core': 0.3.2(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@metamask/sdk': 0.33.1(bufferutil@4.1.0)(encoding@0.1.13)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
-      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5))
-      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      porto: 0.2.35(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
+      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -10117,11 +10170,11 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/core@2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))':
+  '@wagmi/core@2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.0(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7))
     optionalDependencies:
       '@tanstack/query-core': 5.90.16
@@ -10132,7 +10185,7 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@walletconnect/core@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@walletconnect/core@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -10146,7 +10199,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -10176,7 +10229,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@walletconnect/core@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -10190,7 +10243,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -10224,18 +10277,18 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@reown/appkit': 1.7.8(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/jsonrpc-http-connection': 1.0.8(encoding@0.1.13)
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.21.1
-      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -10358,16 +10411,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@walletconnect/sign-client@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@walletconnect/core': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@walletconnect/core': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -10394,16 +10447,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/sign-client@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@walletconnect/sign-client@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@walletconnect/core': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@walletconnect/core': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -10492,7 +10545,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/universal-provider@2.21.0(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@walletconnect/universal-provider@2.21.0(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8(encoding@0.1.13)
@@ -10501,9 +10554,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@walletconnect/sign-client': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -10532,7 +10585,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/universal-provider@2.21.1(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@walletconnect/universal-provider@2.21.1(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8(encoding@0.1.13)
@@ -10541,9 +10594,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -10572,7 +10625,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@walletconnect/utils@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -10590,7 +10643,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -10616,7 +10669,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@walletconnect/utils@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -10634,7 +10687,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11214,10 +11267,10 @@ snapshots:
       typescript: 5.9.3
       zod: 3.25.76
 
-  abitype@1.0.8(typescript@5.9.3)(zod@4.3.5):
+  abitype@1.0.8(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.3
-      zod: 4.3.5
+      zod: 3.25.76
 
   abitype@1.2.3(typescript@5.9.3)(zod@3.22.4):
     optionalDependencies:
@@ -11384,7 +11437,7 @@ snapshots:
 
   borsh@0.7.0:
     dependencies:
-      bn.js: 5.2.2
+      bn.js: 5.2.3
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
 
@@ -11602,6 +11655,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  core-js@3.50.0: {}
 
   core-util-is@1.0.3: {}
 
@@ -11822,6 +11877,10 @@ snapshots:
   domhandler@4.3.1:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.13:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@2.8.0:
     dependencies:
@@ -12176,6 +12235,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  fflate@0.4.9: {}
 
   fflate@0.8.2: {}
 
@@ -13504,43 +13565,28 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.11.1(typescript@5.9.3)(zod@4.3.5):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.5)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - zod
-
-  ox@0.6.7(typescript@5.9.3)(zod@4.3.5):
+  ox@0.6.7(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.5)
+      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.9(typescript@5.9.3)(zod@4.3.5):
+  ox@0.6.9(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.5)
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -13716,21 +13762,21 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.35(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5)):
+  porto@0.2.35(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
     dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hono: 4.11.3
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.17(typescript@5.9.3)(zod@4.3.5)
-      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 4.3.5
       zustand: 5.0.9(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7))
     optionalDependencies:
       '@tanstack/react-query': 5.90.16(react@19.2.7)
       react: 19.2.7
       typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5)
+      wagmi: 2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -13746,9 +13792,26 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.414.0:
+    dependencies:
+      '@posthog/browser-common': 0.4.0
+      '@posthog/core': 1.46.9
+      '@posthog/types': 1.402.2
+      core-js: 3.50.0
+      dompurify: 3.4.13
+      fflate: 0.4.9
+      preact: 10.29.8
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+      web-vitals-soft-navs: web-vitals@6.0.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+
   preact@10.24.2: {}
 
   preact@10.29.2: {}
+
+  preact@10.29.8: {}
 
   prettier@3.7.4: {}
 
@@ -13833,6 +13896,8 @@ snapshots:
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
+
+  query-selector-shadow-dom@1.0.1: {}
 
   query-string@7.1.3:
     dependencies:
@@ -14177,7 +14242,7 @@ snapshots:
       '@types/uuid': 8.3.4
       '@types/ws': 8.18.1
       buffer: 6.0.3
-      eventemitter3: 5.0.1
+      eventemitter3: 5.0.4
       uuid: 8.3.2
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
@@ -14725,15 +14790,15 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5):
+  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.5)
+      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
       isows: 1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      ox: 0.6.7(typescript@5.9.3)(zod@4.3.5)
+      ox: 0.6.7(typescript@5.9.3)(zod@3.25.76)
       ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
@@ -14768,23 +14833,6 @@ snapshots:
       abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
       isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.11.1(typescript@5.9.3)(zod@3.25.76)
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
-  viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.5)
-      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      ox: 0.11.1(typescript@5.9.3)(zod@4.3.5)
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
@@ -14951,14 +14999,14 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5):
+  wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76):
     dependencies:
       '@tanstack/react-query': 5.90.16(react@19.2.7)
-      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5))(zod@4.3.5)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
+      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.7))(@types/react@19.2.17)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.17)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       react: 19.2.7
       use-sync-external-store: 1.4.0(react@19.2.7)
-      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      viem: 2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -15007,6 +15055,10 @@ snapshots:
   web-streams-polyfill@3.3.3: {}
 
   web-vitals@3.5.2: {}
+
+  web-vitals@5.3.0: {}
+
+  web-vitals@6.0.0: {}
 
   webextension-polyfill@0.10.0: {}
 

--- a/scripts/posthog-insights.mjs
+++ b/scripts/posthog-insights.mjs
@@ -175,6 +175,14 @@ const buildPlan = (orgIndex) => {
           breakdown: 'step',
           display: 'ActionsBar',
         }),
+        trend({
+          name: 'Organizations created (by name)',
+          description:
+            'Who signed up, by name. `org_name` rides on the creation event itself, since the group profile is only registered once the organization has been fetched.',
+          series: [event('organization_created')],
+          breakdown: 'org_name',
+          display: 'ActionsTable',
+        }),
       ],
     },
     {
@@ -218,8 +226,8 @@ const buildPlan = (orgIndex) => {
         funnel({
           name: 'Election wizard · template → census → created → results',
           description:
-            'The creation flow in order: a template is picked, the census is published mid-wizard, the process is created, and results are opened later. Organization-level.',
-          steps: ['process_template_selected', 'census_published', 'process_created', 'process_results_viewed'],
+            'The creation flow in order: a template is picked, voter authentication (the census) is configured mid-wizard, the process is created, and results are opened later. Organization-level.',
+          steps: ['process_template_selected', 'census_configured', 'process_created', 'process_results_viewed'],
           groupTypeIndex: byOrg,
         }),
         funnel({
@@ -229,6 +237,14 @@ const buildPlan = (orgIndex) => {
           groupTypeIndex: byOrg,
           windowInterval: 1,
           windowUnit: 'hour',
+        }),
+        trend({
+          name: 'Most active organizations (by name)',
+          description:
+            'Elections created per organization, named. Reads off the `org_name` super property, which is on every event, so it works without the group analytics add-on.',
+          series: [event('process_created')],
+          breakdown: 'org_name',
+          display: 'ActionsTable',
         }),
         trend({
           name: 'Weekly active organizations',

--- a/scripts/posthog-insights.mjs
+++ b/scripts/posthog-insights.mjs
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+/**
+ * Provisions the PostHog funnels/insights and dashboards for the Vocdoni app.
+ *
+ * Idempotent: objects are matched by name, so re-running updates in place instead
+ * of duplicating. Run it again after editing this file to roll changes out.
+ *
+ *   POSTHOG_PERSONAL_API_KEY=phx_… node scripts/posthog-insights.mjs [--dry-run]
+ *
+ * The personal API key (https://eu.posthog.com/settings/user-api-keys) needs the
+ * `insight:write`, `dashboard:write` and `group:read` scopes. The `phc_…` project
+ * key used by the app is write-only for events and cannot create insights.
+ *
+ * Optional env: POSTHOG_API_HOST (default https://eu.posthog.com — note this is
+ * the app host, not the `eu.i.posthog.com` ingestion host), POSTHOG_PROJECT_ID
+ * (auto-resolved to the first accessible project when unset).
+ */
+
+const API_HOST = (process.env.POSTHOG_API_HOST ?? 'https://eu.posthog.com').replace(/\/$/, '')
+const API_KEY = process.env.POSTHOG_PERSONAL_API_KEY
+const DRY_RUN = process.argv.includes('--dry-run')
+
+if (!API_KEY && !DRY_RUN) {
+  console.error('POSTHOG_PERSONAL_API_KEY is required (create one at %s/settings/user-api-keys)', API_HOST)
+  process.exit(1)
+}
+
+const api = async (path, { method = 'GET', body } = {}) => {
+  const res = await fetch(`${API_HOST}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${API_KEY}`,
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  })
+  const text = await res.text()
+  if (!res.ok) throw new Error(`${method} ${path} → ${res.status} ${text.slice(0, 500)}`)
+  return text ? JSON.parse(text) : null
+}
+
+// Paginated GET, following `next` until exhausted.
+const apiList = async (path) => {
+  const results = []
+  let next = path
+  while (next) {
+    const page = await api(next.startsWith('http') ? next.slice(API_HOST.length) : next)
+    results.push(...(page.results ?? []))
+    next = page.next
+  }
+  return results
+}
+
+// ---------------------------------------------------------------------------
+// Query builders
+// ---------------------------------------------------------------------------
+
+const event = (name, extra = {}) => ({ kind: 'EventsNode', event: name, name, ...extra })
+
+/**
+ * `aggregation_group_type_index` makes a funnel count organizations instead of
+ * people — the right unit for a B2B product, where several colleagues share one
+ * account's journey. Left null for funnels that start before an org exists.
+ */
+const funnel = ({
+  name,
+  description,
+  steps,
+  groupTypeIndex = null,
+  windowInterval = 30,
+  windowUnit = 'day',
+  vizType = 'steps',
+  breakdown = null,
+  dateFrom = '-90d',
+  extraFilter = {},
+}) => ({
+  name,
+  description,
+  query: {
+    kind: 'InsightVizNode',
+    source: {
+      kind: 'FunnelsQuery',
+      series: steps.map((step) => (typeof step === 'string' ? event(step) : step)),
+      dateRange: { date_from: dateFrom },
+      filterTestAccounts: true,
+      ...(groupTypeIndex === null ? {} : { aggregation_group_type_index: groupTypeIndex }),
+      ...(breakdown ? { breakdownFilter: { breakdown, breakdown_type: 'event' } } : {}),
+      funnelsFilter: {
+        funnelOrderType: 'ordered',
+        funnelVizType: vizType,
+        funnelWindowInterval: windowInterval,
+        funnelWindowIntervalUnit: windowUnit,
+        ...extraFilter,
+      },
+    },
+  },
+})
+
+const trend = ({
+  name,
+  description,
+  series,
+  breakdown = null,
+  breakdownType = 'event',
+  interval = 'week',
+  dateFrom = '-90d',
+  display = 'ActionsLineGraph',
+}) => ({
+  name,
+  description,
+  query: {
+    kind: 'InsightVizNode',
+    source: {
+      kind: 'TrendsQuery',
+      series,
+      interval,
+      dateRange: { date_from: dateFrom },
+      filterTestAccounts: true,
+      ...(breakdown ? { breakdownFilter: { breakdown, breakdown_type: breakdownType } } : {}),
+      trendsFilter: { display },
+    },
+  },
+})
+
+// ---------------------------------------------------------------------------
+// The plan: dashboards and the insights they hold
+// ---------------------------------------------------------------------------
+
+const buildPlan = (orgIndex) => {
+  // Aggregating by organization needs the group type to exist in the project. It
+  // only appears once the app has sent its first `organization` group, so fall
+  // back to person aggregation rather than emitting an invalid query.
+  const byOrg = orgIndex
+  const orgMath = orgIndex === null ? {} : { math: 'unique_group', math_group_type_index: orgIndex }
+
+  const activationSteps = ['account_signed_up', 'organization_created', 'process_created']
+
+  return [
+    {
+      dashboard: {
+        name: 'Vocdoni · Activation',
+        description: 'From signup to a first published election, and what stalls on the way.',
+      },
+      insights: [
+        funnel({
+          name: 'Activation · signup → org → first election',
+          description:
+            'Person-level: signup happens before an organization exists, so this one cannot be aggregated by org. 30-day conversion window.',
+          steps: activationSteps,
+        }),
+        funnel({
+          name: 'Activation · time to first election',
+          description: 'How long the org creation → first election step takes, distributed across users.',
+          steps: activationSteps,
+          vizType: 'time_to_convert',
+          extraFilter: { funnelFromStep: 1, funnelToStep: 2 },
+        }),
+        funnel({
+          name: 'Activation · conversion over time',
+          description: 'Weekly activation rate — the trend behind the funnel, so cohorts can be compared.',
+          steps: activationSteps,
+          vizType: 'trends',
+        }),
+        funnel({
+          name: 'Memberbase adoption · org → import started → import completed',
+          description:
+            'Where CSV imports are abandoned. A wide gap between started and completed points at the column-mapping step.',
+          steps: ['organization_created', 'members_import_started', 'members_import_completed'],
+          groupTypeIndex: byOrg,
+        }),
+        trend({
+          name: 'Onboarding steps completed',
+          description: 'Which setup checklist steps organizations actually finish. Drop-offs show the weakest step.',
+          series: [event('onboarding_step_completed', orgMath)],
+          breakdown: 'step',
+          display: 'ActionsBar',
+        }),
+      ],
+    },
+    {
+      dashboard: {
+        name: 'Vocdoni · Monetization',
+        description: 'Paywall exposure, checkout conversion, and which blocked features drive upgrades.',
+      },
+      insights: [
+        funnel({
+          name: 'Monetization · paywall → checkout → subscription',
+          description: 'Organization-level, 7-day window. Broken down by where the paywall was opened from.',
+          steps: ['paywall_viewed', 'checkout_started', 'subscription_completed'],
+          groupTypeIndex: byOrg,
+          windowInterval: 7,
+          breakdown: 'source',
+        }),
+        funnel({
+          name: 'Monetization · blocked feature → upgrade',
+          description:
+            'Which locked feature actually converts. Breakdown by feature uses first-touch attribution, i.e. the feature that started the journey.',
+          steps: ['feature_blocked', 'paywall_viewed', 'checkout_started', 'subscription_completed'],
+          groupTypeIndex: byOrg,
+          windowInterval: 14,
+          breakdown: 'feature',
+        }),
+        trend({
+          name: 'Paywall exposure per plan',
+          description: 'How often each plan hits a wall — sustained pressure on one plan is a packaging signal.',
+          series: [event('feature_blocked', orgMath)],
+          breakdown: 'plan',
+          display: 'ActionsBar',
+        }),
+      ],
+    },
+    {
+      dashboard: {
+        name: 'Vocdoni · Elections & engagement',
+        description: 'The election creation wizard, and how many organizations keep coming back.',
+      },
+      insights: [
+        funnel({
+          name: 'Election wizard · template → census → created → results',
+          description:
+            'The creation flow in order: a template is picked, the census is published mid-wizard, the process is created, and results are opened later. Organization-level.',
+          steps: ['process_template_selected', 'census_published', 'process_created', 'process_results_viewed'],
+          groupTypeIndex: byOrg,
+        }),
+        funnel({
+          name: 'Election wizard · created vs failed',
+          description: 'Creation attempts that ended in an error. Anything above a few percent is a bug, not friction.',
+          steps: ['process_template_selected', 'process_creation_failed'],
+          groupTypeIndex: byOrg,
+          windowInterval: 1,
+          windowUnit: 'hour',
+        }),
+        trend({
+          name: 'Weekly active organizations',
+          description: 'Distinct organizations emitting any event in the week. The retention denominator.',
+          series: [event(null, { name: 'All events', ...orgMath })],
+        }),
+        trend({
+          name: 'Elections created by census type',
+          description: 'Volume split by how voters are authenticated — the main product-mix signal.',
+          series: [event('process_created')],
+          breakdown: 'census_type',
+          display: 'ActionsBar',
+        }),
+      ],
+    },
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Apply
+// ---------------------------------------------------------------------------
+
+const resolveProjectId = async () => {
+  if (process.env.POSTHOG_PROJECT_ID) return process.env.POSTHOG_PROJECT_ID
+  const projects = await apiList('/api/projects/?limit=100')
+  if (!projects.length) throw new Error('no projects accessible with this key — check its organization/project scope')
+  if (projects.length > 1) {
+    console.warn(
+      'Multiple projects visible; using "%s" (%s). Set POSTHOG_PROJECT_ID to pick another.',
+      projects[0].name,
+      projects[0].id
+    )
+  }
+  return projects[0].id
+}
+
+const resolveOrgGroupIndex = async (projectId) => {
+  const types = await api(`/api/projects/${projectId}/groups_types/`)
+  const org = (Array.isArray(types) ? types : (types?.results ?? [])).find((t) => t.group_type === 'organization')
+  if (!org) {
+    console.warn(
+      'No "organization" group type in this project yet — it appears after the app sends its first group event.\n' +
+        'Funnels will aggregate by person for now; re-run this script once the group exists.'
+    )
+    return null
+  }
+  return org.group_type_index
+}
+
+const upsert = async (projectId, kind, existingByName, payload) => {
+  const existing = existingByName.get(payload.name)
+  if (DRY_RUN) {
+    console.log('%s %s: %s', existing ? 'would update' : 'would create', kind, payload.name)
+    return existing?.id ?? null
+  }
+  const path = `/api/projects/${projectId}/${kind}s/`
+  const result = existing
+    ? await api(`${path}${existing.id}/`, { method: 'PATCH', body: payload })
+    : await api(path, { method: 'POST', body: payload })
+  console.log('%s %s: %s (id %s)', existing ? 'updated' : 'created', kind, payload.name, result.id)
+  return result.id
+}
+
+const main = async () => {
+  // `--dry-run` without a key stays fully offline, so the plan can be reviewed
+  // (and the query JSON diffed) before anyone provisions credentials.
+  if (!API_KEY) {
+    console.log('No POSTHOG_PERSONAL_API_KEY — printing the plan only, assuming organization group index 0.\n')
+    for (const { dashboard, insights } of buildPlan(0)) {
+      console.log('dashboard: %s', dashboard.name)
+      for (const insight of insights) console.log('  %s\n    %s', insight.name, JSON.stringify(insight.query))
+    }
+    return
+  }
+
+  const projectId = await resolveProjectId()
+  console.log('project %s @ %s%s', projectId, API_HOST, DRY_RUN ? ' (dry run)' : '')
+
+  const orgIndex = await resolveOrgGroupIndex(projectId)
+  const plan = buildPlan(orgIndex)
+
+  const dashboardsByName = new Map(
+    (await apiList(`/api/projects/${projectId}/dashboards/?limit=100`))
+      .filter((d) => !d.deleted)
+      .map((d) => [d.name, d])
+  )
+  const insightsByName = new Map(
+    (await apiList(`/api/projects/${projectId}/insights/?basic=true&limit=500`))
+      .filter((i) => !i.deleted && i.name)
+      .map((i) => [i.name, i])
+  )
+
+  for (const { dashboard, insights } of plan) {
+    const dashboardId = await upsert(projectId, 'dashboard', dashboardsByName, { ...dashboard, pinned: true })
+    for (const insight of insights) {
+      await upsert(projectId, 'insight', insightsByName, {
+        ...insight,
+        ...(dashboardId ? { dashboards: [dashboardId] } : {}),
+      })
+    }
+  }
+
+  console.log('\nDone. Dashboards: %s/project/%s/dashboard', API_HOST, projectId)
+}
+
+main().catch((error) => {
+  console.error(error.message)
+  process.exit(1)
+})

--- a/src/__mocks__/posthog-js.ts
+++ b/src/__mocks__/posthog-js.ts
@@ -11,4 +11,6 @@ export default {
   has_opted_out_capturing: () => false,
   startSessionRecording: () => {},
   stopSessionRecording: () => {},
+  onFeatureFlags: () => () => {},
+  isFeatureEnabled: () => undefined,
 }

--- a/src/__mocks__/posthog-js.ts
+++ b/src/__mocks__/posthog-js.ts
@@ -1,0 +1,14 @@
+export default {
+  init: () => {},
+  capture: () => {},
+  identify: () => {},
+  reset: () => {},
+  group: () => {},
+  register: () => {},
+  set_config: () => {},
+  opt_in_capturing: () => {},
+  opt_out_capturing: () => {},
+  has_opted_out_capturing: () => false,
+  startSessionRecording: () => {},
+  stopSessionRecording: () => {},
+}

--- a/src/app-env-build.ts
+++ b/src/app-env-build.ts
@@ -19,6 +19,8 @@ export type AppEnv = {
   VIDEO_TUTORIAL?: Record<string, string>
   GTM_CONTAINER_ID?: string
   PLAUSIBLE_DOMAIN?: string
+  POSTHOG_KEY?: string
+  POSTHOG_HOST?: string
   VOCDONI_CONTACT_EMAIL?: string
   ANNOUNCEMENT?: string
   APP_URL?: string
@@ -172,6 +174,8 @@ export const buildAppEnv = (env: EnvSource = {}): AppEnvObject => {
     VIDEO_TUTORIAL: resolveVideoTutorials(env.VIDEO_TUTORIAL),
     GTM_CONTAINER_ID: env.GTM_CONTAINER_ID,
     PLAUSIBLE_DOMAIN: env.PLAUSIBLE_DOMAIN,
+    POSTHOG_KEY: env.POSTHOG_KEY,
+    POSTHOG_HOST: trimTrailingSlash(env.POSTHOG_HOST || 'https://eu.i.posthog.com'),
     VOCDONI_CONTACT_EMAIL: env.VOCDONI_CONTACT_EMAIL || 'hello@vocdoni.io',
     ANNOUNCEMENT: env.ANNOUNCEMENT,
     PRIVACY_POLICY_URL: trimTrailingSlash(env.PRIVACY_POLICY_URL || 'https://vocdoni.io/privacy'),

--- a/src/components/Actions/ActionButtons.tsx
+++ b/src/components/Actions/ActionButtons.tsx
@@ -5,8 +5,15 @@ import { forwardRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '~components/Auth/useAuth'
 import { sameAddress } from '~utils/address'
+import { AnalyticsEvents, trackAnalyticsEvent } from '~utils/analytics'
 import { useActions } from './ActionsContext'
 import { ConfirmActionModal } from './ConfirmActionModal'
+
+const trackProcessAction = (action: string, election: { id?: string } | null | undefined) =>
+  trackAnalyticsEvent({
+    name: AnalyticsEvents.ProcessAction,
+    props: { action, election_id: election?.id ?? 'unknown' },
+  })
 
 export const ActionContinue = forwardRef<HTMLButtonElement, ButtonProps>(({ children, ...props }, ref) => {
   const { currentAddress } = useAuth()
@@ -23,7 +30,16 @@ export const ActionContinue = forwardRef<HTMLButtonElement, ButtonProps>(({ chil
   }
 
   return (
-    <Button ref={ref} loading={loading} onClick={resume} disabled={disabled || status !== 'PAUSED'} {...props}>
+    <Button
+      ref={ref}
+      loading={loading}
+      onClick={() => {
+        trackProcessAction('resume', election)
+        return resume()
+      }}
+      disabled={disabled || status !== 'PAUSED'}
+      {...props}
+    >
       {children ?? t('actions.continue')}
     </Button>
   )
@@ -45,7 +61,16 @@ export const ActionPause = forwardRef<HTMLButtonElement, ButtonProps>(({ childre
   }
 
   return (
-    <Button ref={ref} loading={loading} onClick={pause} disabled={disabled || status !== 'ONGOING'} {...props}>
+    <Button
+      ref={ref}
+      loading={loading}
+      onClick={() => {
+        trackProcessAction('pause', election)
+        return pause()
+      }}
+      disabled={disabled || status !== 'ONGOING'}
+      {...props}
+    >
       {children ?? t('actions.pause')}
     </Button>
   )
@@ -74,6 +99,7 @@ export const ActionEnd = forwardRef<HTMLButtonElement, ButtonProps>(({ children,
         />
       )
     ) {
+      trackProcessAction('end', election)
       await end()
     }
   }
@@ -118,6 +144,7 @@ export const ActionCancel = forwardRef<HTMLButtonElement, ButtonProps>(({ childr
         />
       )
     ) {
+      trackProcessAction('cancel', election)
       await cancel()
     }
   }

--- a/src/components/AnalyticsProvider.test.tsx
+++ b/src/components/AnalyticsProvider.test.tsx
@@ -1,0 +1,65 @@
+import { render } from '@testing-library/react'
+import { AnalyticsProvider } from './AnalyticsProvider'
+
+// The provider pulls the whole dashboard context in; stub every source so the
+// test only exercises what it reports to PostHog.
+const setPosthogOrganization = vi.fn()
+const registerPosthogSuperProperties = vi.fn()
+
+vi.mock('~utils/analytics', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~utils/analytics')>()
+  return {
+    ...actual,
+    initializePlausible: vi.fn(),
+    initializeGTM: vi.fn(),
+    initializePosthog: vi.fn(),
+    applyPosthogConsent: vi.fn(),
+    identifyPosthogUser: vi.fn(),
+    resetPosthogUser: vi.fn(),
+    setPosthogSessionRecording: vi.fn(),
+    setPosthogOrganization: (...args: unknown[]) => setPosthogOrganization(...args),
+    registerPosthogSuperProperties: (...args: unknown[]) => registerPosthogSuperProperties(...args),
+  }
+})
+
+vi.mock('~src/app-env', () => ({ useAppEnv: () => ({ POSTHOG_KEY: 'phc_test' }) }))
+vi.mock('~components/Auth/useAuth', () => ({ useAuth: () => ({ isAuthenticated: true }) }))
+vi.mock('~queries/account', () => ({ useProfile: () => ({ data: undefined }) }))
+vi.mock('~components/Auth/Subscription', () => ({ useSubscription: () => ({ subscription: undefined }) }))
+vi.mock('~components/Account/SaasAccountProvider', () => ({
+  useSaasAccount: () => ({
+    organization: {
+      address: '0xabc',
+      type: 'association',
+      country: 'ES',
+      size: '10',
+      createdAt: '2026-01-01',
+      account: { name: { default: 'Acme Coop' } },
+    },
+  }),
+}))
+
+describe('AnalyticsProvider organization reporting', () => {
+  beforeEach(() => {
+    setPosthogOrganization.mockClear()
+    registerPosthogSuperProperties.mockClear()
+  })
+
+  // Without a `name` property PostHog labels the group with its key, so every
+  // organization shows up as a bare address in insights.
+  it('sends the organization name as the group display name', () => {
+    render(<AnalyticsProvider>{null}</AnalyticsProvider>)
+
+    expect(setPosthogOrganization).toHaveBeenCalledWith('0xabc', expect.objectContaining({ name: 'Acme Coop' }))
+  })
+
+  // Group properties need the group analytics add-on to be queryable; the super
+  // property lands on every event regardless.
+  it('registers the organization name as a super property', () => {
+    render(<AnalyticsProvider>{null}</AnalyticsProvider>)
+
+    expect(registerPosthogSuperProperties).toHaveBeenCalledWith(
+      expect.objectContaining({ org_address: '0xabc', org_name: 'Acme Coop' })
+    )
+  })
+})

--- a/src/components/AnalyticsProvider.test.tsx
+++ b/src/components/AnalyticsProvider.test.tsx
@@ -5,6 +5,7 @@ import { AnalyticsProvider } from './AnalyticsProvider'
 // test only exercises what it reports to PostHog.
 const setPosthogOrganization = vi.fn()
 const registerPosthogSuperProperties = vi.fn()
+const initializePosthog = vi.fn()
 
 vi.mock('~utils/analytics', async (importOriginal) => {
   const actual = await importOriginal<typeof import('~utils/analytics')>()
@@ -12,7 +13,7 @@ vi.mock('~utils/analytics', async (importOriginal) => {
     ...actual,
     initializePlausible: vi.fn(),
     initializeGTM: vi.fn(),
-    initializePosthog: vi.fn(),
+    initializePosthog: (...args: unknown[]) => initializePosthog(...args),
     applyPosthogConsent: vi.fn(),
     identifyPosthogUser: vi.fn(),
     resetPosthogUser: vi.fn(),
@@ -43,6 +44,8 @@ describe('AnalyticsProvider organization reporting', () => {
   beforeEach(() => {
     setPosthogOrganization.mockClear()
     registerPosthogSuperProperties.mockClear()
+    initializePosthog.mockClear()
+    localStorage.clear()
   })
 
   // Without a `name` property PostHog labels the group with its key, so every
@@ -61,5 +64,30 @@ describe('AnalyticsProvider organization reporting', () => {
     expect(registerPosthogSuperProperties).toHaveBeenCalledWith(
       expect.objectContaining({ org_address: '0xabc', org_name: 'Acme Coop' })
     )
+  })
+})
+
+describe('AnalyticsProvider consent handling', () => {
+  beforeEach(() => {
+    initializePosthog.mockClear()
+    localStorage.clear()
+  })
+
+  it('passes an explicit acceptance through', () => {
+    localStorage.setItem('vocdoni-cookie-consent', 'accepted')
+
+    render(<AnalyticsProvider>{null}</AnalyticsProvider>)
+
+    expect(initializePosthog).toHaveBeenCalledWith(expect.objectContaining({ consent: 'accepted' }))
+  })
+
+  // The stored value is user-editable; an unrecognised one must not be trusted
+  // as a decision either way.
+  it('treats an unrecognised stored value as no decision', () => {
+    localStorage.setItem('vocdoni-cookie-consent', 'true')
+
+    render(<AnalyticsProvider>{null}</AnalyticsProvider>)
+
+    expect(initializePosthog).toHaveBeenCalledWith(expect.objectContaining({ consent: null }))
   })
 })

--- a/src/components/AnalyticsProvider.tsx
+++ b/src/components/AnalyticsProvider.tsx
@@ -7,7 +7,6 @@ import { COOKIE_CONSENT_CHANGE_EVENT, getCookieConsent } from '~components/Cooki
 import { useProfile } from '~queries/account'
 import { useAppEnv } from '~src/app-env'
 import {
-  AnalyticsEvent,
   applyPosthogConsent,
   identifyPosthogUser,
   initializeGTM,
@@ -17,6 +16,7 @@ import {
   registerPosthogSuperProperties,
   resetPosthogUser,
   setPosthogOrganization,
+  trackAnalyticsEvent,
   trackGTMEvent,
   trackPlausibleEvent,
   trackPosthogEvent,
@@ -129,14 +129,8 @@ const useAnalyticsProvider = () => {
     subscription,
   ])
 
-  const trackEvent = (event: AnalyticsEvent) => {
-    trackPlausibleEvent(event)
-    trackGTMEvent(event)
-    trackPosthogEvent(event)
-  }
-
   return {
-    trackEvent,
+    trackEvent: trackAnalyticsEvent,
     trackPlausibleEvent,
     trackGTMEvent,
     trackPosthogEvent,

--- a/src/components/AnalyticsProvider.tsx
+++ b/src/components/AnalyticsProvider.tsx
@@ -17,6 +17,7 @@ import {
   resetPosthogUser,
   setPosthogOrganization,
   setPosthogSessionRecording,
+  toPosthogConsent,
   trackAnalyticsEvent,
   trackGTMEvent,
   trackPlausibleEvent,
@@ -37,10 +38,10 @@ const useAnalyticsProvider = () => {
   const { organization } = useSaasAccount()
   const { subscription } = useSubscription()
   const { i18n } = useTranslation()
-  const [consent, setConsent] = useState<PosthogConsent>(() => getCookieConsent() as PosthogConsent)
+  const [consent, setConsent] = useState<PosthogConsent>(() => toPosthogConsent(getCookieConsent()))
 
   useEffect(() => {
-    const syncConsent = () => setConsent(getCookieConsent() as PosthogConsent)
+    const syncConsent = () => setConsent(toPosthogConsent(getCookieConsent()))
     window.addEventListener(COOKIE_CONSENT_CHANGE_EVENT, syncConsent)
     return () => window.removeEventListener(COOKIE_CONSENT_CHANGE_EVENT, syncConsent)
   }, [])

--- a/src/components/AnalyticsProvider.tsx
+++ b/src/components/AnalyticsProvider.tsx
@@ -107,6 +107,9 @@ const useAnalyticsProvider = () => {
     if (!organization?.address) return
 
     setPosthogOrganization(organization.address, {
+      // PostHog labels a group by its `name` property; without it every
+      // organization shows up as a bare address in insights and group lists.
+      name: organization.account?.name?.default,
       type: organization.type,
       country: organization.country,
       size: organization.size,
@@ -124,10 +127,15 @@ const useAnalyticsProvider = () => {
     })
     registerPosthogSuperProperties({
       org_address: organization.address,
+      // Duplicated from the group profile on purpose: group properties are only
+      // queryable with the group analytics add-on, whereas a super property
+      // lands on every event and can always be broken down by.
+      org_name: organization.account?.name?.default,
       org_plan: subscription?.plan?.name,
     })
   }, [
     organization?.address,
+    organization?.account?.name?.default,
     organization?.type,
     organization?.country,
     organization?.size,

--- a/src/components/AnalyticsProvider.tsx
+++ b/src/components/AnalyticsProvider.tsx
@@ -16,6 +16,7 @@ import {
   registerPosthogSuperProperties,
   resetPosthogUser,
   setPosthogOrganization,
+  setPosthogSessionRecording,
   trackAnalyticsEvent,
   trackGTMEvent,
   trackPlausibleEvent,
@@ -61,6 +62,11 @@ const useAnalyticsProvider = () => {
   useEffect(() => {
     applyPosthogConsent(consent)
   }, [consent])
+
+  // Session replay only for consented, authenticated dashboard users
+  useEffect(() => {
+    setPosthogSessionRecording(consent === 'accepted' && isAuthenticated)
+  }, [consent, isAuthenticated])
 
   // Keep the interface locale attached to every event
   useEffect(() => {

--- a/src/components/AnalyticsProvider.tsx
+++ b/src/components/AnalyticsProvider.tsx
@@ -1,16 +1,48 @@
-import { createContext, PropsWithChildren, useContext, useEffect } from 'react'
+import { createContext, PropsWithChildren, useContext, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSaasAccount } from '~components/Account/SaasAccountProvider'
+import { useSubscription } from '~components/Auth/Subscription'
+import { useAuth } from '~components/Auth/useAuth'
+import { COOKIE_CONSENT_CHANGE_EVENT, getCookieConsent } from '~components/Cookies/utils'
+import { useProfile } from '~queries/account'
 import { useAppEnv } from '~src/app-env'
 import {
   AnalyticsEvent,
+  applyPosthogConsent,
+  identifyPosthogUser,
   initializeGTM,
   initializePlausible,
+  initializePosthog,
+  PosthogConsent,
+  registerPosthogSuperProperties,
+  resetPosthogUser,
+  setPosthogOrganization,
   trackGTMEvent,
   trackPlausibleEvent,
+  trackPosthogEvent,
 } from '~utils/analytics'
 
 const useAnalyticsProvider = () => {
-  const { GTM_CONTAINER_ID: gtmContainerId, PLAUSIBLE_DOMAIN: plausibleDomain, ANALYTICS_CLIENT_ID } = useAppEnv()
+  const {
+    GTM_CONTAINER_ID: gtmContainerId,
+    PLAUSIBLE_DOMAIN: plausibleDomain,
+    POSTHOG_KEY: posthogKey,
+    POSTHOG_HOST: posthogHost,
+    ANALYTICS_CLIENT_ID,
+  } = useAppEnv()
   const analyticsClientId = ANALYTICS_CLIENT_ID?.trim() || undefined
+  const { isAuthenticated } = useAuth()
+  const { data: profile } = useProfile({ enabled: isAuthenticated })
+  const { organization } = useSaasAccount()
+  const { subscription } = useSubscription()
+  const { i18n } = useTranslation()
+  const [consent, setConsent] = useState<PosthogConsent>(() => getCookieConsent() as PosthogConsent)
+
+  useEffect(() => {
+    const syncConsent = () => setConsent(getCookieConsent() as PosthogConsent)
+    window.addEventListener(COOKIE_CONSENT_CHANGE_EVENT, syncConsent)
+    return () => window.removeEventListener(COOKIE_CONSENT_CHANGE_EVENT, syncConsent)
+  }, [])
 
   useEffect(() => {
     if (plausibleDomain) {
@@ -20,17 +52,94 @@ const useAnalyticsProvider = () => {
     if (gtmContainerId && window.location.pathname === '/') {
       initializeGTM({ gtmId: gtmContainerId }, analyticsClientId)
     }
-  }, [gtmContainerId, plausibleDomain, analyticsClientId])
+
+    if (posthogKey) {
+      initializePosthog({ key: posthogKey, host: posthogHost, analyticsClientId, consent })
+    }
+  }, [gtmContainerId, plausibleDomain, posthogKey, posthogHost, analyticsClientId, consent])
+
+  useEffect(() => {
+    applyPosthogConsent(consent)
+  }, [consent])
+
+  // Keep the interface locale attached to every event
+  useEffect(() => {
+    const locale = i18n.resolvedLanguage || i18n.language
+    if (locale) {
+      registerPosthogSuperProperties({ locale })
+    }
+  }, [i18n.resolvedLanguage, i18n.language])
+
+  // Identify dashboard users only after explicit cookie consent; anonymous
+  // visitors and voters never get a person profile.
+  const identifiedRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (consent !== 'accepted' || !profile?.id || identifiedRef.current === profile.id) return
+
+    identifyPosthogUser(profile.id, {
+      email: profile.email,
+      first_name: profile.firstName,
+      last_name: profile.lastName,
+      organizations_count: profile.organizations?.length,
+    })
+    identifiedRef.current = profile.id
+  }, [consent, profile])
+
+  // Unlink the device from the user on logout
+  const wasAuthenticatedRef = useRef(false)
+  useEffect(() => {
+    if (wasAuthenticatedRef.current && !isAuthenticated) {
+      resetPosthogUser()
+      identifiedRef.current = null
+    }
+    wasAuthenticatedRef.current = isAuthenticated
+  }, [isAuthenticated])
+
+  // Organization-level BI: group profile plus super properties so insights can
+  // break down by organization/plan even without the group analytics add-on.
+  useEffect(() => {
+    if (!organization?.address) return
+
+    setPosthogOrganization(organization.address, {
+      type: organization.type,
+      country: organization.country,
+      size: organization.size,
+      created_at: organization.createdAt,
+      plan_id: subscription?.subscriptionDetails?.planId,
+      plan_name: subscription?.plan?.name,
+      subscription_active: subscription?.subscriptionDetails?.active,
+      renewal_date: subscription?.subscriptionDetails?.renewalDate,
+      max_census_size: subscription?.subscriptionDetails?.maxCensusSize,
+      usage_processes: subscription?.usage?.processes,
+      usage_users: subscription?.usage?.users,
+      usage_sub_orgs: subscription?.usage?.subOrgs,
+      usage_sent_emails: subscription?.usage?.sentEmails,
+      usage_sent_sms: subscription?.usage?.sentSMS,
+    })
+    registerPosthogSuperProperties({
+      org_address: organization.address,
+      org_plan: subscription?.plan?.name,
+    })
+  }, [
+    organization?.address,
+    organization?.type,
+    organization?.country,
+    organization?.size,
+    organization?.createdAt,
+    subscription,
+  ])
 
   const trackEvent = (event: AnalyticsEvent) => {
     trackPlausibleEvent(event)
     trackGTMEvent(event)
+    trackPosthogEvent(event)
   }
 
   return {
     trackEvent,
     trackPlausibleEvent,
     trackGTMEvent,
+    trackPosthogEvent,
   }
 }
 

--- a/src/components/Auth/SignIn.tsx
+++ b/src/components/Auth/SignIn.tsx
@@ -60,7 +60,7 @@ const SignIn = ({
   const toast = useToast()
   const navigate = useNavigate()
   const { setTitle, setSubtitle } = useOutletContext<AuthOutletContextType>()
-  const { trackPlausibleEvent } = useAnalytics()
+  const { trackEvent } = useAnalytics()
   const methods = useForm<FormData>({
     defaultValues: { email: emailProp },
   })
@@ -90,7 +90,7 @@ const SignIn = ({
   const onSubmit = async (data: FormData) => {
     await login(data)
       .then(() => {
-        trackPlausibleEvent({ name: AnalyticsEvents.UserLoggedIn })
+        trackEvent({ name: AnalyticsEvents.UserLoggedIn, props: { method: 'password' } })
         const redirect = localStorage.getItem('redirectTo')
         localStorage.removeItem('redirectTo')
         navigate(redirect || successRoute)

--- a/src/components/Auth/SignUp.tsx
+++ b/src/components/Auth/SignUp.tsx
@@ -63,7 +63,7 @@ const SignUp = ({
   const { register: signup } = useAuth()
   const inviteSignup = useSignupFromInvite(invite?.address)
   const { setTitle, setSubtitle } = useOutletContext<AuthOutletContextType>()
-  const { trackPlausibleEvent } = useAnalytics()
+  const { trackEvent } = useAnalytics()
 
   const methods = useForm<FormData>({
     defaultValues: {
@@ -80,6 +80,9 @@ const SignUp = ({
   const email = watch('email')
   // Holds the email being verified once registration succeeds in inline-verify mode.
   const [verifyingEmail, setVerifyingEmail] = useState<string | null>(null)
+  // Holds the email once registration succeeds in the regular flow, so tracking and the
+  // mutation reset can run in an effect instead of during render (StrictMode double-fires).
+  const [registeredEmail, setRegisteredEmail] = useState<string | null>(null)
 
   // Both mutations surface their own errors via toast (see useAuthProvider's
   // register and useSignupFromInvite), so we only track the pending state here.
@@ -112,26 +115,42 @@ const SignUp = ({
   // registration succeeds so the verify form below can render without leaving the page.
   useEffect(() => {
     if (verifyInline && signup.isSuccess && !verifyingEmail) {
-      trackPlausibleEvent({ name: AnalyticsEvents.AccountSignup })
+      trackEvent({ name: AnalyticsEvents.AccountSignup, props: { method: 'password' } })
       setVerifyingEmail(email)
       signup.reset()
     }
-  }, [verifyInline, signup.isSuccess, verifyingEmail, email, trackPlausibleEvent, signup])
+  }, [verifyInline, signup.isSuccess, verifyingEmail, email, trackEvent, signup])
+
+  useEffect(() => {
+    if (!verifyInline && signup.isSuccess && !registeredEmail) {
+      trackEvent({ name: AnalyticsEvents.AccountSignup, props: { method: 'password' } })
+      setRegisteredEmail(email)
+      signup.reset()
+    }
+  }, [verifyInline, signup.isSuccess, registeredEmail, email, trackEvent, signup])
+
+  useEffect(() => {
+    if (inviteSignup.isSuccess) {
+      trackEvent({ name: AnalyticsEvents.AccountSignup, props: { method: 'invite' } })
+    }
+  }, [inviteSignup.isSuccess, trackEvent])
 
   if (verifyInline && (signup.isSuccess || verifyingEmail)) {
     return <VerificationPending email={verifyingEmail ?? email} nextRoute={verifyNextRoute} />
   }
 
   // normally registered accounts need verification (separate verify page)
+  if (registeredEmail) {
+    return <Navigate to={`${afterRegisterRoute}?email=${encodeURIComponent(registeredEmail)}`} replace />
+  }
+
+  // registration succeeded but the effect above hasn't staged the redirect yet
   if (signup.isSuccess) {
-    trackPlausibleEvent({ name: AnalyticsEvents.AccountSignup })
-    signup.reset()
-    return <Navigate to={`${afterRegisterRoute}?email=${encodeURIComponent(email)}`} replace />
+    return null
   }
 
   // accounts coming from invites don't need verification
   if (inviteSignup.isSuccess) {
-    trackPlausibleEvent({ name: AnalyticsEvents.AccountSignup })
     return <Navigate to={Routes.auth.signIn} replace />
   }
 

--- a/src/components/Form/InputBasic.test.tsx
+++ b/src/components/Form/InputBasic.test.tsx
@@ -18,4 +18,16 @@ describe('InputBasic', () => {
     expect(screen.getByText('Name')).toBeInTheDocument()
     expect(screen.getByRole('textbox')).toBeInTheDocument()
   })
+
+  // The organization name field relies on this to stay readable in session
+  // replays (see posthogMaskInput in ~utils/analytics).
+  it('forwards data attributes to the underlying input', () => {
+    render(
+      <Wrapper>
+        <InputBasic formValue='name' label='Name' data-ph-unmask='' />
+      </Wrapper>
+    )
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('data-ph-unmask')
+  })
 })

--- a/src/components/Layout/SubscriptionLockedContent.tsx
+++ b/src/components/Layout/SubscriptionLockedContent.tsx
@@ -1,13 +1,16 @@
 import { Progress, Box, Button, HStack, Icon, Stack, TagLabel, TagRoot, Text, Wrap } from '@chakra-ui/react'
 import { dotobject } from '~utils/objects'
+import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LuLock, LuSparkles } from 'react-icons/lu'
 import { generatePath, Link as ReactRouterLink } from 'react-router-dom'
+import { useAnalytics } from '~components/AnalyticsProvider'
 import { useSubscription } from '~components/Auth/Subscription'
 import { PlanFeaturesTranslationKeys } from '~components/Pricing/Features'
 import { usePlans, usePlanTranslations } from '~components/Pricing/Plans'
 import { SubscriptionPermission } from '~constants'
 import { Routes } from '~src/router/routes'
+import { AnalyticsEvents } from '~utils/analytics'
 
 type SubscriptionLockedContentProps = {
   children: (args: { isLocked: boolean }) => React.ReactNode
@@ -28,6 +31,15 @@ export const SubscriptionLockedContent = ({ children, permissionType }: Subscrip
   const permissionName = t(PlanFeaturesTranslationKeys[permissionType])
   const hasPermission = permission(permissionType)
   const isLocked = !hasPermission
+  const { trackEvent } = useAnalytics()
+
+  useEffect(() => {
+    if (loading || hasPermission) return
+    trackEvent({
+      name: AnalyticsEvents.FeatureBlocked,
+      props: { feature: permissionType, plan: subscription?.plan?.name ?? 'unknown' },
+    })
+  }, [loading, hasPermission, permissionType, subscription?.plan?.name, trackEvent])
 
   if (loading) {
     return (

--- a/src/components/Memberbase/GroupsBoard.tsx
+++ b/src/components/Memberbase/GroupsBoard.tsx
@@ -453,7 +453,10 @@ const GroupMembersTable = ({ groupId, group }: { groupId: string; group: Group }
                       </CheckboxRoot>
                     </Table.Cell>
                     {columns.map((column) => (
-                      <Table.Cell key={column.id}>{member[column.id]}</Table.Cell>
+                      // ph-no-capture: member data is never recorded in session replays
+                      <Table.Cell key={column.id} className='ph-no-capture'>
+                        {member[column.id]}
+                      </Table.Cell>
                     ))}
                   </Table.Row>
                 ))}

--- a/src/components/Memberbase/Members/Import.tsx
+++ b/src/components/Memberbase/Members/Import.tsx
@@ -282,7 +282,15 @@ export const ImportProgress = () => {
               </Dialog.Title>
             </Dialog.Header>
             <Dialog.Body>
-              <List.Root display='flex' flexDirection='column' gap={2} pl={4} listStyleType='disc'>
+              {/* ph-no-capture: import errors quote the offending CSV rows */}
+              <List.Root
+                display='flex'
+                flexDirection='column'
+                gap={2}
+                pl={4}
+                listStyleType='disc'
+                className='ph-no-capture'
+              >
                 {data?.errors?.map((error, i) => (
                   <List.Item key={i} whiteSpace='pre-wrap' fontSize='sm'>
                     {error}

--- a/src/components/Memberbase/Members/Import.tsx
+++ b/src/components/Memberbase/Members/Import.tsx
@@ -38,6 +38,7 @@ import { SpreadsheetManager } from '~components/Spreadsheet/SpreadsheetManager'
 import { useToast } from '~components/Toast'
 import { QueryKeys } from '~src/queries/keys'
 import { useAddMembers, useImportJobProgress } from '~src/queries/members'
+import { AnalyticsEvents, trackAnalyticsEvent } from '~utils/analytics'
 import { MemberbaseTabsContext } from '..'
 import { useTable } from '../TableProvider'
 import { MembersCsvManager } from './MembersCsvManager'
@@ -135,6 +136,22 @@ export const ImportProgress = () => {
       })
     }
   }, [queryClient, organization.address, isComplete])
+
+  // Track the async job outcome once per job
+  const trackedJobRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!jobId || trackedJobRef.current === jobId || (!isComplete && !hasFailed)) return
+    trackedJobRef.current = jobId
+    trackAnalyticsEvent({
+      name: AnalyticsEvents.MembersImportCompleted,
+      props: {
+        status: hasFailed ? 'failed' : 'completed',
+        added: data?.result?.added ?? 0,
+        total: data?.result?.total ?? 0,
+        error_count: data?.errors?.length ?? 0,
+      },
+    })
+  }, [jobId, isComplete, hasFailed, data])
 
   const closeAlert = () => setJobId(null)
 
@@ -473,6 +490,7 @@ export const ImportMembers = () => {
     const finalData = mapSpreadsheetData(parsedRows, columnMapping)
 
     try {
+      trackAnalyticsEvent({ name: AnalyticsEvents.MembersImportStarted, props: { total_rows: finalData.length } })
       const data = await addMembers.mutateAsync(finalData)
       setJobId(data?.jobId)
       setColumnMapping({})

--- a/src/components/Memberbase/Members/MemberCard.tsx
+++ b/src/components/Memberbase/Members/MemberCard.tsx
@@ -20,7 +20,9 @@ const MemberCard = ({ member, actions, selectable = true }: MemberCardProps) => 
   const alias = memberAlias(member)
 
   return (
-    <Card.Root variant='data-list-item'>
+    // ph-no-capture: the whole card is excluded from session replays — member
+    // data reaches both the body and the checkbox's aria-label.
+    <Card.Root variant='data-list-item' className='ph-no-capture'>
       <Card.Header>
         <Flex gap={3} alignItems='center' minW={0}>
           {selectable && member.id && (

--- a/src/components/Memberbase/Members/index.test.tsx
+++ b/src/components/Memberbase/Members/index.test.tsx
@@ -115,3 +115,44 @@ describe('MembersTable layout', () => {
     }
   })
 })
+
+// Session replay must never record memberbase PII: rrweb skips any subtree
+// carrying `ph-no-capture`, so every element rendering a member field has to sit
+// inside one. See docs/analytics.md.
+describe('MembersTable session replay exclusion', () => {
+  it('keeps member cards out of replays on mobile', () => {
+    renderMembers()
+
+    expect(screen.getByText('Ada Lovelace').closest('.ph-no-capture')).not.toBeNull()
+    expect(screen.getByText('ada@example.test', { exact: false }).closest('.ph-no-capture')).not.toBeNull()
+  })
+
+  it('keeps member table cells out of replays on desktop', () => {
+    const original = window.matchMedia
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+
+    try {
+      renderMembers()
+
+      for (const value of ['Ada', 'Lovelace', 'ada@example.test', 'Alan', 'Turing', 'alan@example.test']) {
+        expect(screen.getByRole('cell', { name: value }).closest('.ph-no-capture')).not.toBeNull()
+      }
+      // Column headers are field names, not member data — they stay visible.
+      expect(screen.getByRole('columnheader', { name: 'Email' }).closest('.ph-no-capture')).toBeNull()
+    } finally {
+      Object.defineProperty(window, 'matchMedia', { writable: true, value: original })
+    }
+  })
+})

--- a/src/components/Memberbase/Members/index.tsx
+++ b/src/components/Memberbase/Members/index.tsx
@@ -787,7 +787,10 @@ const MemberTableItem = ({ member, openDeleteSelected, onAddToGroup, onAddToCens
       {columns
         .filter((column) => column.visible)
         .map((column) => (
-          <Table.Cell key={column.id}>{maskIfNeeded(column.id, member[column.id])}</Table.Cell>
+          // ph-no-capture: member data is never recorded in session replays
+          <Table.Cell key={column.id} className='ph-no-capture'>
+            {maskIfNeeded(column.id, member[column.id])}
+          </Table.Cell>
         ))}
       <Table.Cell>
         <MemberActions

--- a/src/components/Organization/Create.tsx
+++ b/src/components/Organization/Create.tsx
@@ -88,6 +88,11 @@ export const OrganizationCreate = ({
       trackEvent({
         name: AnalyticsEvents.OrganizationCreated,
         props: {
+          // The group profile and `org_name` super property are only registered
+          // once the organization has been fetched, which is after this event
+          // fires — so the creation event carries the name itself.
+          org_name: values.name || 'unknown',
+          org_address: address,
           org_type: values.type || 'unknown',
           org_size: values.size || 'unknown',
           org_country: values.country || 'unknown',

--- a/src/components/Organization/Create.tsx
+++ b/src/components/Organization/Create.tsx
@@ -80,12 +80,19 @@ export const OrganizationCreate = ({
   const [isPending, setIsPending] = useState(false)
   const methods = useForm<FormData>()
   const { handleSubmit } = methods
-  const { trackPlausibleEvent } = useAnalytics()
+  const { trackEvent } = useAnalytics()
   const { bearedFetch } = useAuth()
 
   const { mutateAsync: createOrganization } = useOrganizationCreate({
-    onSuccess: async ({ address }) => {
-      trackPlausibleEvent({ name: AnalyticsEvents.OrganizationCreated })
+    onSuccess: async ({ address }, values) => {
+      trackEvent({
+        name: AnalyticsEvents.OrganizationCreated,
+        props: {
+          org_type: values.type || 'unknown',
+          org_size: values.size || 'unknown',
+          org_country: values.country || 'unknown',
+        },
+      })
       toast({
         title: t('organization.create_org_success', {
           defaultValue: 'Organization created successfully',

--- a/src/components/Organization/Form.tsx
+++ b/src/components/Organization/Form.tsx
@@ -19,6 +19,8 @@ export const PublicOrgForm = ({ minified }: { minified?: boolean }) => {
           defaultValue: "Enter your organization's email",
         })}
         required
+        // Organization name is not personal data and stays readable in session replays
+        data-ph-unmask=''
       />
       {!minified && (
         <>

--- a/src/components/Pricing/PricingModalProvider.tsx
+++ b/src/components/Pricing/PricingModalProvider.tsx
@@ -1,4 +1,6 @@
 import React, { ReactNode, useState } from 'react'
+import { useAnalytics } from '~components/AnalyticsProvider'
+import { AnalyticsEvents } from '~utils/analytics'
 import { PlanUpgradeData, PlanUpgradeModal } from './Modals'
 import { SubscriptionPaymentData } from './SubscriptionPayment'
 import { PricingModalProviderContext, PricingModalType } from './use-pricing-modal'
@@ -9,8 +11,16 @@ export const PricingModalProvider: React.FC<{ children?: ReactNode }> = ({ child
   const [isOpen, setIsOpen] = useState(false)
   const [modalType, setModalType] = useState<PricingModalType>(null)
   const [modalData, setModalData] = useState<ModalData>(null)
+  const { trackEvent } = useAnalytics()
 
   const openModal = (type: PricingModalType, data?: ModalData) => {
+    trackEvent({
+      name: AnalyticsEvents.PaywallViewed,
+      props: {
+        modal_type: type ?? 'unknown',
+        source: (data && 'context' in data && data.context) || 'unknown',
+      },
+    })
     setModalType(type)
     setModalData(data || null)
     setIsOpen(true)

--- a/src/components/Pricing/SubscriptionPayment.tsx
+++ b/src/components/Pricing/SubscriptionPayment.tsx
@@ -166,7 +166,7 @@ export const SubscriptionPayment = ({ lookupKey, billingPeriod, onClose }: Subsc
   const { subscription } = useSubscription()
   const { mutateAsync: checkSubscription } = useUpdateSubscription()
   const toast = useToast()
-  const { trackPlausibleEvent } = useAnalytics()
+  const { trackEvent } = useAnalytics()
   const { colorMode } = useColorMode()
   const stripePublicKey = useAppEnv().STRIPE_PUBLIC_KEY
 
@@ -202,6 +202,10 @@ export const SubscriptionPayment = ({ lookupKey, billingPeriod, onClose }: Subsc
         address: signerAddress,
         locale: i18n.resolvedLanguage,
       }
+      trackEvent({
+        name: AnalyticsEvents.CheckoutStarted,
+        props: { lookup_key: String(lookupKey), billing_period: String(billingPeriod) },
+      })
       // Create a Checkout Session
       return await bearedFetch<CheckoutResponse>(ApiEndpoints.SubscriptionCheckout, {
         method: 'POST',
@@ -225,7 +229,7 @@ export const SubscriptionPayment = ({ lookupKey, billingPeriod, onClose }: Subsc
         })
     }
     return await Promise.resolve('')
-  }, [currentAddress, bearedFetch, lookupKey, i18n.resolvedLanguage, toast, t, onClose])
+  }, [currentAddress, bearedFetch, lookupKey, billingPeriod, i18n.resolvedLanguage, toast, t, onClose, trackEvent])
 
   const onComplete = async () => {
     let nsub = await checkSubscription()
@@ -239,8 +243,14 @@ export const SubscriptionPayment = ({ lookupKey, billingPeriod, onClose }: Subsc
       nsub = await checkSubscription()
     }
     await queryClient.invalidateQueries({ queryKey: QueryKeys.organization.subscription() })
-    trackPlausibleEvent({
+    trackEvent({
       name: AnalyticsEvents.SubscriptionSuccessful,
+      props: {
+        lookup_key: String(lookupKey),
+        billing_period: String(billingPeriod),
+        previous_plan: subscription.plan.name,
+        new_plan: nsub.plan.name,
+      },
     })
     onClose()
   }

--- a/src/components/Process/Create/VoterAuthentication/index.test.tsx
+++ b/src/components/Process/Create/VoterAuthentication/index.test.tsx
@@ -8,11 +8,18 @@ import { VoterAuthentication } from '.'
 import { Census, defaultQuestion, Process } from '../common'
 
 const mockValidateCensus = vi.fn()
+const mockTrackAnalyticsEvent = vi.fn()
 
 // Partial mock: AllProviders (used by render) still mounts the real ApiClientProvider.
 vi.mock('~src/providers/ApiClientProvider', async (importOriginal) => ({
   ...(await importOriginal<typeof import('~src/providers/ApiClientProvider')>()),
   useApiClient: () => ({ client: { elections: { validateCensus: mockValidateCensus } } }),
+}))
+
+// Partial mock: keep the real AnalyticsEvents taxonomy, intercept only the sink.
+vi.mock('~utils/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~utils/analytics')>()),
+  trackAnalyticsEvent: (...args: unknown[]) => mockTrackAnalyticsEvent(...args),
 }))
 
 type FormWatcherProps = { name: keyof Process }
@@ -114,6 +121,51 @@ describe('VoterAuthentication', () => {
 
     // Confirm does NOT make any additional API calls
     expect(mockValidateCensus).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports census_configured once when the auth configuration changes', async () => {
+    mockValidateCensus.mockResolvedValue({ valid: true })
+
+    const user = userEvent.setup()
+    render(<TestForm initialCensus={defaultCensus} />)
+
+    await user.click(screen.getByRole('button', { name: /voter authentication/i }))
+    await user.click(await screen.findByRole('button', { name: /next/i }))
+
+    // Step 2: switching 2FA on is a real change to the stored configuration
+    await user.click(screen.getByRole('checkbox', { name: /enable two-factor authentication/i }))
+    await user.click(screen.getByRole('button', { name: /next/i }))
+    await waitFor(() => expect(mockValidateCensus).toHaveBeenCalledTimes(1))
+
+    await user.click(screen.getByRole('button', { name: /confirm/i }))
+
+    await waitFor(() => expect(mockTrackAnalyticsEvent).toHaveBeenCalledTimes(1))
+    expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith({
+      name: 'census_configured',
+      props: { auth_fields_count: 1, two_fa: true, two_fa_method: 'email' },
+    })
+  })
+
+  // The modal is also the "Edit" entry point: reopening and confirming an
+  // unchanged configuration must not count as a fresh one.
+  it('does not report census_configured when a re-confirm changes nothing', async () => {
+    mockValidateCensus.mockResolvedValue({ valid: true })
+
+    const user = userEvent.setup()
+    render(<TestForm initialCensus={defaultCensus} />)
+
+    await user.click(screen.getByRole('button', { name: /voter authentication/i }))
+    await user.click(await screen.findByRole('button', { name: /next/i }))
+    await user.click(screen.getByRole('button', { name: /next/i }))
+    await waitFor(() => expect(mockValidateCensus).toHaveBeenCalledTimes(1))
+
+    await user.click(screen.getByRole('button', { name: /confirm/i }))
+
+    await waitFor(() => {
+      const census = JSON.parse(screen.getByTestId('form-census').textContent!)
+      expect(census).toHaveProperty('credentials')
+    })
+    expect(mockTrackAnalyticsEvent).not.toHaveBeenCalled()
   })
 
   it('does not make API calls when toggling weightedVote', async () => {

--- a/src/components/Process/Create/VoterAuthentication/index.tsx
+++ b/src/components/Process/Create/VoterAuthentication/index.tsx
@@ -9,7 +9,8 @@ import { Trans, useTranslation } from 'react-i18next'
 import { getApiErrorMessage } from '~components/Auth/api'
 import { useApiClient } from '~src/providers/ApiClientProvider'
 import { useToast } from '~components/Toast'
-import { Process } from '../common'
+import { AnalyticsEvents, trackAnalyticsEvent } from '~utils/analytics'
+import { Census, Process } from '../common'
 import { CredentialsForm } from './CredentialsForm'
 import { CredentialsOverview, SummaryDisplay } from './SummaryDisplay'
 import { TwoFactorForm } from './TwoFactorForm'
@@ -41,6 +42,11 @@ const useValidateCensus = () => {
       }),
   })
 }
+
+// Order-insensitive identity of an auth configuration, used to tell an actual
+// change from a no-op re-confirm. Credentials are a set, not a sequence.
+const censusConfigSignature = (config: Census) =>
+  JSON.stringify([[...(config.credentials ?? [])].sort(), !!config.use2FA, config.use2FAMethod ?? 'none'])
 
 export const VoterAuthentication = () => {
   const { t } = useTranslation()
@@ -124,11 +130,26 @@ export const VoterAuthentication = () => {
     } else {
       // Step 3 (Confirm): save auth config to form — census is created by the backend during process publish
       const currentFormData = voterAuthForm.getValues()
-      mainForm.setValue('census', {
+      const nextCensus: Census = {
         credentials: currentFormData.credentials,
         use2FA: currentFormData.use2FA,
         use2FAMethod: currentFormData.use2FAMethod ?? 'email',
-      })
+      }
+      // The modal doubles as the "Edit" entry point, so a confirm that changes
+      // nothing must not report a fresh configuration — otherwise every reopen
+      // inflates the count.
+      const configChanged = !census || censusConfigSignature(census) !== censusConfigSignature(nextCensus)
+      mainForm.setValue('census', nextCensus)
+      if (configChanged) {
+        trackAnalyticsEvent({
+          name: AnalyticsEvents.CensusConfigured,
+          props: {
+            auth_fields_count: nextCensus.credentials?.length ?? 0,
+            two_fa: !!nextCensus.use2FA,
+            two_fa_method: nextCensus.use2FAMethod ?? 'none',
+          },
+        })
+      }
       setStepCompletion((prev) => ({ ...prev, step2Completed: true }))
       toast({
         title: t('voter_auth.configured', { defaultValue: 'Voter authentication configured' }),

--- a/src/components/Process/Create/draft-saver.test.tsx
+++ b/src/components/Process/Create/draft-saver.test.tsx
@@ -15,7 +15,7 @@ vi.mock('~components/Auth/Subscription', () => ({
 }))
 
 vi.mock('~components/AnalyticsProvider', () => ({
-  useAnalytics: () => ({ track: vi.fn(), trackPlausibleEvent: vi.fn() }),
+  useAnalytics: () => ({ track: vi.fn(), trackEvent: vi.fn(), trackPlausibleEvent: vi.fn() }),
 }))
 
 vi.mock('~components/Auth/useAuth', () => ({

--- a/src/components/Process/Create/index.test.tsx
+++ b/src/components/Process/Create/index.test.tsx
@@ -19,7 +19,7 @@ vi.mock('~utils/analytics', () => ({
 
 vi.mock('~components/AnalyticsProvider', () => ({
   useAnalytics: () => ({
-    track: vi.fn(),
+    trackEvent: vi.fn(),
   }),
 }))
 

--- a/src/components/Process/Create/index.tsx
+++ b/src/components/Process/Create/index.tsx
@@ -377,10 +377,12 @@ const TemplateButtons = () => {
   const [isTemplateModalOpen, setTemplateModalOpen] = useState(false)
   const reset = useSafeReset()
   const pendingTemplateRef = useRef<TemplateTypes | null>(null)
+  const { trackEvent } = useAnalytics()
 
   const applyTemplate = (templateId: TemplateTypes) => {
     const config = TemplateConfigs[templateId]
     const previousFormValues = methods.getValues()
+    trackEvent({ name: AnalyticsEvents.ProcessTemplateSelected, props: { template: templateId } })
     setActiveTemplate(templateId)
     reset({
       ...previousFormValues,
@@ -668,7 +670,7 @@ const ProcessCreateView = () => {
   const queryClient = useQueryClient()
   const { isSubmitting, isSubmitSuccessful, isDirty } = methods.formState
   const { setStepDoneAsync } = useOrganizationSetup()
-  const { trackPlausibleEvent } = useAnalytics()
+  const { trackEvent } = useAnalytics()
   const formToVotingProcessRequest = useFormToVotingProcessRequest()
   const effectiveDraftId = draftId ?? storedDraftId
   // Confirm navigation if form is dirty
@@ -803,7 +805,16 @@ const ProcessCreateView = () => {
         queryKey: QueryKeys.organization.elections(organization?.address),
       })
 
-      trackPlausibleEvent({ name: AnalyticsEvents.ProcessCreated })
+      trackEvent({
+        name: AnalyticsEvents.ProcessCreated,
+        props: {
+          census_type: form.censusType,
+          weighted: !!form.weightedVote,
+          question_count: form.questions?.length ?? 0,
+          template: activeTemplate || 'none',
+          from_draft: !!effectiveDraftId,
+        },
+      })
 
       toast({
         title: t('form.process_create.success_title'),
@@ -855,6 +866,14 @@ const ProcessCreateView = () => {
     ]
 
     const hasSidebarErrors = sidebarFieldKeys.some((key) => key in errors)
+
+    trackEvent({
+      name: AnalyticsEvents.ProcessCreationFailed,
+      props: {
+        failed_fields: Object.keys(errors).join(','),
+        sidebar_errors: hasSidebarErrors,
+      },
+    })
 
     if (hasSidebarErrors) {
       openSidebar()

--- a/src/components/Process/Dashboard/ProcessView.tsx
+++ b/src/components/Process/Dashboard/ProcessView.tsx
@@ -79,6 +79,7 @@ import { usePublicLanguage } from '~i18n/usePublicLanguage'
 import { useCensusSize } from '~queries/census'
 import { Routes } from '~src/router/routes'
 import { getPublicProcessPath } from '~src/ssr/public-pages'
+import { AnalyticsEvents, trackAnalyticsEvent } from '~utils/analytics'
 import { useResultTypeLabel } from '../resultTypeLabels'
 import { VotingReportPdfButton } from '../VotingReportPdf/VotingReportPdfButton'
 import { CensusSearch } from './CensusSearch'
@@ -124,7 +125,8 @@ const ProcessViewContent = () => {
   const { t } = useTranslation()
   const { format: formatDate } = useDateFns()
   const { showSidebar, toggleSidebar } = useSidebarVisibility()
-  const { election, status } = useElection()
+  const { election, results, status } = useElection()
+  const { size: censusSize } = useCensusSize()
   const id = election?.id ?? ''
   const location = useLocation()
   const navigate = useNavigate()
@@ -160,6 +162,25 @@ const ProcessViewContent = () => {
       navigate(getProcessViewPathForTab(id, 'questions'), { replace: true })
     }
   }, [tabValue, showResultsTab, navigate, id])
+
+  // Election-level participation BI, captured admin-side only (voters are never tracked)
+  const trackedResultsElectionRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (tabValue !== 'results' || !showResultsTab || trackedResultsElectionRef.current === id) return
+    if (!election?.published) return
+    trackedResultsElectionRef.current = id
+    const voteCount = processVoteCount(results)
+    trackAnalyticsEvent({
+      name: AnalyticsEvents.ProcessResultsViewed,
+      props: {
+        election_id: id,
+        status: status ?? 'unknown',
+        vote_count: voteCount,
+        census_size: censusSize,
+        turnout_pct: censusSize ? Math.round((voteCount / censusSize) * 100) : 0,
+      },
+    })
+  }, [tabValue, showResultsTab, id, election, results, status, censusSize])
 
   return (
     <Box position='relative' w='full' minH='100dvh' overflow='hidden'>

--- a/src/components/Process/View.tsx
+++ b/src/components/Process/View.tsx
@@ -248,6 +248,9 @@ export const ProcessView = () => {
                   borderColor='table.border'
                   borderRadius='md'
                   scrollMarginTop='70px'
+                  // Ballot content must never appear in analytics/session replays,
+                  // even when an org admin previews the process from the dashboard
+                  className='ph-no-capture'
                 >
                   <ElectionQuestions
                     onInvalid={(args) => {
@@ -304,7 +307,8 @@ const SuccessVoteModal = () => {
       <Portal>
         <Dialog.Backdrop />
         <Dialog.Positioner>
-          <Dialog.Content>
+          {/* Contains the vote verification link (vote id) — never capture it */}
+          <Dialog.Content className='ph-no-capture'>
             <Dialog.CloseTrigger />
             <Dialog.Header display='flex' flexDirection='column'>
               <Dialog.Title>{t('process.success_modal.title')}</Dialog.Title>

--- a/src/components/Process/VotingReportPdf/VotingReportPdfButton.tsx
+++ b/src/components/Process/VotingReportPdf/VotingReportPdfButton.tsx
@@ -9,6 +9,7 @@ import { useToast } from '~components/Toast'
 import { useAppEnv } from '~src/app-env'
 import { getVocdoniClientConfig } from '~src/providers/vocdoni-client-config'
 import { useApiClient } from '~src/providers/ApiClientProvider'
+import { AnalyticsEvents, trackAnalyticsEvent } from '~utils/analytics'
 
 import {
   buildCertificateData,
@@ -88,6 +89,7 @@ export const useVotingReportPdfDownload = (election?: ElectionLike) => {
       anchor.click()
       anchor.remove()
       window.setTimeout(() => URL.revokeObjectURL(url), 1000)
+      trackAnalyticsEvent({ name: AnalyticsEvents.PdfReportDownloaded, props: { election_id: election.id } })
     } catch {
       toast({
         title: t('process_pdf.download_error', { defaultValue: 'Could not generate the PDF report' }),

--- a/src/queries/groups.ts
+++ b/src/queries/groups.ts
@@ -5,6 +5,7 @@ import { ApiEndpoints } from '~components/Auth/api'
 import { useAuth } from '~components/Auth/useAuth'
 import { QueryKeys } from '~src/queries/keys'
 import { Member } from '~src/queries/members'
+import { AnalyticsEvents, trackAnalyticsEvent } from '~utils/analytics'
 
 export type Group = {
   id: string
@@ -77,7 +78,11 @@ export const useCreateGroup = () => {
         body,
       })
     },
-    onSuccess: () => {
+    onSuccess: (_data, body) => {
+      trackAnalyticsEvent({
+        name: AnalyticsEvents.MemberGroupCreated,
+        props: { group_size: body?.memberIDs?.length ?? 0 },
+      })
       queryClient.invalidateQueries({
         queryKey: QueryKeys.organization.groups(organization.address),
       })
@@ -100,6 +105,7 @@ export const useDeleteGroup = () => {
       )
     },
     onSuccess: () => {
+      trackAnalyticsEvent({ name: AnalyticsEvents.MemberGroupDeleted })
       queryClient.invalidateQueries({
         queryKey: QueryKeys.organization.groups(organization.address),
         exact: false,

--- a/src/queries/organization.ts
+++ b/src/queries/organization.ts
@@ -9,6 +9,7 @@ import { generatePath } from 'react-router-dom'
 import { ApiEndpoints } from '~components/Auth/api'
 import { useAuth } from '~components/Auth/useAuth'
 import { Routes } from '~routes'
+import { AnalyticsEvents, trackAnalyticsEvent } from '~utils/analytics'
 import { QueryKeys } from './keys'
 
 export enum SetupStepIds {
@@ -235,11 +236,13 @@ export const useOrganizationSetup = () => {
 
   const setStepDone = (stepId: SetupStepId) => {
     if (hasStepDone(stepId)) return
+    trackAnalyticsEvent({ name: AnalyticsEvents.OnboardingStepCompleted, props: { step: stepId } })
     updateMeta({ completedSteps: [...new Set([...completedSteps, stepId])] })
   }
 
   const setStepDoneAsync = async (stepId: SetupStepId) => {
     if (hasStepDone(stepId)) return
+    trackAnalyticsEvent({ name: AnalyticsEvents.OnboardingStepCompleted, props: { step: stepId } })
     await updateMetaAsync({ completedSteps: [...new Set([...completedSteps, stepId])] })
   }
 
@@ -344,7 +347,8 @@ export const useInviteMemberMutation = () => {
         method: 'POST',
         body,
       }),
-    onSuccess: () => {
+    onSuccess: (_data, body) => {
+      trackAnalyticsEvent({ name: AnalyticsEvents.TeamMemberInvited, props: { role: body?.role ?? 'unknown' } })
       // Invalidate queries to refresh member and pending member lists
       queryClient.invalidateQueries({ queryKey: QueryKeys.organization.users() })
     },
@@ -363,6 +367,7 @@ export const useRemoveUserMutation = () => {
         { method: 'DELETE' }
       ),
     onSuccess: () => {
+      trackAnalyticsEvent({ name: AnalyticsEvents.TeamMemberRemoved })
       // Invalidate queries to refresh member and pending member lists
       queryClient.invalidateQueries({ queryKey: QueryKeys.organization.users() })
     },

--- a/src/queries/stripe.ts
+++ b/src/queries/stripe.ts
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query'
 import { ensure0x } from '~utils/address'
 import { ApiEndpoints } from '~components/Auth/api'
 import { useAuth } from '~components/Auth/useAuth'
+import { AnalyticsEvents, trackAnalyticsEvent } from '~utils/analytics'
 
 export const usePortalSession = () => {
   const { bearedFetch, currentAddress } = useAuth()
@@ -11,5 +12,8 @@ export const usePortalSession = () => {
       bearedFetch<{ portalURL: string }>(
         ApiEndpoints.SubscriptionPortal.replace('{address}', ensure0x(currentAddress))
       ),
+    onSuccess: () => {
+      trackAnalyticsEvent({ name: AnalyticsEvents.BillingPortalOpened })
+    },
   })
 }

--- a/src/utils/analytics.test.ts
+++ b/src/utils/analytics.test.ts
@@ -368,6 +368,44 @@ describe('posthog initialization', () => {
     await vi.waitFor(() => expect(consoleSpy).toHaveBeenCalledWith('Failed to initialize PostHog:', expect.any(Error)))
     consoleSpy.mockRestore()
   })
+
+  // A failed init used to latch the "already started" guard forever, so a
+  // transient failure disabled analytics until a full page reload.
+  it('retries on a later attempt when the first init fails', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockPosthog.init.mockImplementationOnce(() => {
+      throw new Error('PostHog init failed')
+    })
+    const { initializePosthog } = await import('./analytics')
+
+    initializePosthog({ key: 'phc_test', consent: null })
+    await vi.waitFor(() => expect(consoleSpy).toHaveBeenCalledWith('Failed to initialize PostHog:', expect.any(Error)))
+
+    initializePosthog({ key: 'phc_test', consent: null })
+
+    await vi.waitFor(() => expect(mockPosthog.init).toHaveBeenCalledTimes(2))
+    consoleSpy.mockRestore()
+  })
+})
+
+describe('toPosthogConsent', () => {
+  it('keeps the two explicit choices', async () => {
+    const { toPosthogConsent } = await import('./analytics')
+
+    expect(toPosthogConsent('accepted')).toBe('accepted')
+    expect(toPosthogConsent('rejected')).toBe('rejected')
+  })
+
+  // The value comes from localStorage, so it may be absent or hand-edited.
+  it('treats anything else as no decision', async () => {
+    const { toPosthogConsent } = await import('./analytics')
+
+    expect(toPosthogConsent(null)).toBeNull()
+    expect(toPosthogConsent(undefined)).toBeNull()
+    expect(toPosthogConsent('true')).toBeNull()
+    expect(toPosthogConsent('Accepted')).toBeNull()
+    expect(toPosthogConsent('')).toBeNull()
+  })
 })
 
 describe('posthog event tracking', () => {

--- a/src/utils/analytics.test.ts
+++ b/src/utils/analytics.test.ts
@@ -25,6 +25,8 @@ const mockPosthog = {
   opt_in_capturing: vi.fn(),
   opt_out_capturing: vi.fn(),
   has_opted_out_capturing: vi.fn(() => false),
+  startSessionRecording: vi.fn(),
+  stopSessionRecording: vi.fn(),
 }
 
 vi.mock('posthog-js', () => ({
@@ -224,6 +226,22 @@ describe('posthog before_send guard', () => {
 
     expect(posthogBeforeSend(null)).toBeNull()
   })
+
+  it('redacts email addresses from exception payloads', async () => {
+    const { posthogBeforeSend } = await import('./analytics')
+
+    const event = {
+      event: '$exception',
+      properties: {
+        $current_url: 'https://app.vocdoni.io/admin',
+        $exception_message: 'Failed to invite someone@example.com to the team',
+        $exception_list: [{ value: 'someone@example.com not found' }],
+      },
+    }
+    const result = posthogBeforeSend(event as any)
+    expect(result?.properties?.$exception_message).toBe('Failed to invite [redacted-email] to the team')
+    expect(result?.properties?.$exception_list).toEqual([{ value: '[redacted-email] not found' }])
+  })
 })
 
 describe('posthog initialization', () => {
@@ -246,6 +264,8 @@ describe('posthog initialization', () => {
     expect(config.persistence).toBe('memory')
     expect(config.person_profiles).toBe('identified_only')
     expect(config.disable_session_recording).toBe(true)
+    expect(config.session_recording).toEqual({ maskAllInputs: true })
+    expect(config.capture_exceptions).toBe(true)
   })
 
   it('initializes with cookie persistence when consent was already accepted', async () => {
@@ -383,6 +403,36 @@ describe('posthog consent lifecycle', () => {
 
     await vi.waitFor(() => expect(mockPosthog.opt_out_capturing).toHaveBeenCalledTimes(1))
     expect(mockPosthog.set_config).toHaveBeenCalledWith({ persistence: 'memory' })
+    expect(mockPosthog.stopSessionRecording).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('posthog session recording', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    Object.values(mockPosthog).forEach((fn) => fn.mockClear())
+    mockPosthog.has_opted_out_capturing.mockReturnValue(false)
+    window.history.pushState({}, '', '/')
+  })
+
+  it('does nothing before initialization', async () => {
+    const { setPosthogSessionRecording } = await import('./analytics')
+
+    setPosthogSessionRecording(true)
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mockPosthog.startSessionRecording).not.toHaveBeenCalled()
+  })
+
+  it('starts and stops recording after initialization', async () => {
+    const { initializePosthog, setPosthogSessionRecording } = await import('./analytics')
+
+    initializePosthog({ key: 'phc_test', consent: 'accepted' })
+    setPosthogSessionRecording(true)
+    await vi.waitFor(() => expect(mockPosthog.startSessionRecording).toHaveBeenCalledTimes(1))
+
+    setPosthogSessionRecording(false)
+    await vi.waitFor(() => expect(mockPosthog.stopSessionRecording).toHaveBeenCalledTimes(1))
   })
 })
 

--- a/src/utils/analytics.test.ts
+++ b/src/utils/analytics.test.ts
@@ -27,6 +27,8 @@ const mockPosthog = {
   has_opted_out_capturing: vi.fn(() => false),
   startSessionRecording: vi.fn(),
   stopSessionRecording: vi.fn(),
+  onFeatureFlags: vi.fn((_cb: () => void) => () => {}),
+  isFeatureEnabled: vi.fn((_flag: string): boolean | undefined => undefined),
 }
 
 vi.mock('posthog-js', () => ({
@@ -433,6 +435,56 @@ describe('posthog session recording', () => {
 
     setPosthogSessionRecording(false)
     await vi.waitFor(() => expect(mockPosthog.stopSessionRecording).toHaveBeenCalledTimes(1))
+  })
+})
+
+describe('posthog feature flags', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    Object.values(mockPosthog).forEach((fn) => fn.mockClear())
+    mockPosthog.has_opted_out_capturing.mockReturnValue(false)
+    mockPosthog.onFeatureFlags.mockImplementation(() => () => {})
+    window.history.pushState({}, '', '/')
+  })
+
+  it('notifies listeners registered before initialization once flags load', async () => {
+    let flagsLoadedCallback: (() => void) | undefined
+    mockPosthog.onFeatureFlags.mockImplementation((cb: () => void) => {
+      flagsLoadedCallback = cb
+      return () => {}
+    })
+    mockPosthog.isFeatureEnabled.mockImplementation((flag: string) => flag === 'new-dashboard')
+
+    const { initializePosthog, onPosthogFeatureFlags } = await import('./analytics')
+
+    const seen: Array<boolean | undefined> = []
+    onPosthogFeatureFlags((isEnabled) => seen.push(isEnabled('new-dashboard')))
+
+    initializePosthog({ key: 'phc_test', consent: null })
+    await vi.waitFor(() => expect(mockPosthog.onFeatureFlags).toHaveBeenCalledTimes(1))
+
+    flagsLoadedCallback?.()
+    expect(seen).toEqual([true])
+  })
+
+  it('stops notifying after unsubscribe', async () => {
+    let flagsLoadedCallback: (() => void) | undefined
+    mockPosthog.onFeatureFlags.mockImplementation((cb: () => void) => {
+      flagsLoadedCallback = cb
+      return () => {}
+    })
+
+    const { initializePosthog, onPosthogFeatureFlags } = await import('./analytics')
+
+    const listener = vi.fn()
+    const unsubscribe = onPosthogFeatureFlags(listener)
+
+    initializePosthog({ key: 'phc_test', consent: null })
+    await vi.waitFor(() => expect(mockPosthog.onFeatureFlags).toHaveBeenCalledTimes(1))
+
+    unsubscribe()
+    flagsLoadedCallback?.()
+    expect(listener).not.toHaveBeenCalled()
   })
 })
 

--- a/src/utils/analytics.test.ts
+++ b/src/utils/analytics.test.ts
@@ -187,6 +187,46 @@ describe('posthog url sanitization', () => {
   })
 })
 
+describe('posthog session replay input masking', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    document.body.innerHTML = ''
+  })
+
+  it('masks input values by default', async () => {
+    const { posthogMaskInput } = await import('./analytics')
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+
+    expect(posthogMaskInput('ada@lovelace.org', input)).toBe('****************')
+    expect(posthogMaskInput('anything')).toBe('********')
+  })
+
+  it('keeps values readable inside a data-ph-unmask subtree', async () => {
+    const { posthogMaskInput, POSTHOG_UNMASK_ATTRIBUTE } = await import('./analytics')
+
+    const wrapper = document.createElement('div')
+    wrapper.setAttribute(POSTHOG_UNMASK_ATTRIBUTE, '')
+    const input = document.createElement('input')
+    wrapper.appendChild(input)
+    document.body.appendChild(wrapper)
+
+    expect(posthogMaskInput('Vocdoni Association', input)).toBe('Vocdoni Association')
+  })
+
+  it('never unmasks passwords, even inside a data-ph-unmask subtree', async () => {
+    const { posthogMaskInput, POSTHOG_UNMASK_ATTRIBUTE } = await import('./analytics')
+
+    const input = document.createElement('input')
+    input.type = 'password'
+    input.setAttribute(POSTHOG_UNMASK_ATTRIBUTE, '')
+    document.body.appendChild(input)
+
+    expect(posthogMaskInput('hunter2', input)).toBe('*******')
+  })
+})
+
 describe('posthog before_send guard', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -266,7 +306,7 @@ describe('posthog initialization', () => {
     expect(config.persistence).toBe('memory')
     expect(config.person_profiles).toBe('identified_only')
     expect(config.disable_session_recording).toBe(true)
-    expect(config.session_recording).toEqual({ maskAllInputs: true })
+    expect(config.session_recording).toEqual({ maskAllInputs: true, maskInputFn: expect.any(Function) })
     expect(config.capture_exceptions).toBe(true)
   })
 

--- a/src/utils/analytics.test.ts
+++ b/src/utils/analytics.test.ts
@@ -14,6 +14,23 @@ vi.mock('react-gtm-module', () => ({
   dataLayer: mockGtmDataLayer,
 }))
 
+const mockPosthog = {
+  init: vi.fn(),
+  capture: vi.fn(),
+  identify: vi.fn(),
+  reset: vi.fn(),
+  group: vi.fn(),
+  register: vi.fn(),
+  set_config: vi.fn(),
+  opt_in_capturing: vi.fn(),
+  opt_out_capturing: vi.fn(),
+  has_opted_out_capturing: vi.fn(() => false),
+}
+
+vi.mock('posthog-js', () => ({
+  default: mockPosthog,
+}))
+
 describe('analytics initialization', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -113,6 +130,292 @@ describe('analytics error handling', () => {
     trackGTMEvent({ name: 'Signup' })
 
     await vi.waitFor(() => expect(consoleSpy).toHaveBeenCalledWith('Failed to track GTM event:', expect.any(Error)))
+  })
+})
+
+describe('posthog voting-path detection', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('matches public voting routes with and without language prefixes', async () => {
+    const { isVotingPath } = await import('./analytics')
+
+    expect(isVotingPath('/processes/0x1234')).toBe(true)
+    expect(isVotingPath('/processes/0x1234/summary')).toBe(true)
+    expect(isVotingPath('/es/processes/0x1234')).toBe(true)
+    expect(isVotingPath('/pt-br/processes/0x1234/summary')).toBe(true)
+  })
+
+  it('does not match non-voting routes', async () => {
+    const { isVotingPath } = await import('./analytics')
+
+    expect(isVotingPath('/')).toBe(false)
+    expect(isVotingPath('/processes')).toBe(false)
+    expect(isVotingPath('/admin/processes/all')).toBe(false)
+    expect(isVotingPath('/admin/process/0x1234')).toBe(false)
+    expect(isVotingPath('/organization/0x1234')).toBe(false)
+    expect(isVotingPath('/es/organization/0x1234')).toBe(false)
+  })
+})
+
+describe('posthog url sanitization', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('strips sensitive query params from urls', async () => {
+    const { sanitizeAnalyticsUrl } = await import('./analytics')
+
+    expect(sanitizeAnalyticsUrl('https://app.vocdoni.io/account/verify?email=a%40b.com&code=1234&foo=bar')).toBe(
+      'https://app.vocdoni.io/account/verify?foo=bar'
+    )
+    expect(sanitizeAnalyticsUrl('https://app.vocdoni.io/account/password/reset?token=secret')).toBe(
+      'https://app.vocdoni.io/account/password/reset'
+    )
+  })
+
+  it('leaves clean or unparseable urls untouched', async () => {
+    const { sanitizeAnalyticsUrl } = await import('./analytics')
+
+    expect(sanitizeAnalyticsUrl('https://app.vocdoni.io/admin?page=2')).toBe('https://app.vocdoni.io/admin?page=2')
+    expect(sanitizeAnalyticsUrl('not a url')).toBe('not a url')
+  })
+})
+
+describe('posthog before_send guard', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    window.history.pushState({}, '', '/')
+  })
+
+  it('drops any event captured on a voting route', async () => {
+    const { posthogBeforeSend } = await import('./analytics')
+
+    const event = { event: '$pageview', properties: { $current_url: 'https://app.vocdoni.io/es/processes/0x1234' } }
+    expect(posthogBeforeSend(event as any)).toBeNull()
+  })
+
+  it('drops events without a url when the window is on a voting route', async () => {
+    const { posthogBeforeSend } = await import('./analytics')
+
+    window.history.pushState({}, '', '/processes/0x1234')
+    const event = { event: '$snapshot', properties: {} }
+    expect(posthogBeforeSend(event as any)).toBeNull()
+  })
+
+  it('sanitizes urls on allowed events', async () => {
+    const { posthogBeforeSend } = await import('./analytics')
+
+    const event = {
+      event: '$pageview',
+      properties: {
+        $current_url: 'https://app.vocdoni.io/account/verify?email=a%40b.com',
+        $referrer: 'https://app.vocdoni.io/account/signup?email=a%40b.com',
+      },
+    }
+    const result = posthogBeforeSend(event as any)
+    expect(result?.properties?.$current_url).toBe('https://app.vocdoni.io/account/verify')
+    expect(result?.properties?.$referrer).toBe('https://app.vocdoni.io/account/signup')
+  })
+
+  it('returns null for null events', async () => {
+    const { posthogBeforeSend } = await import('./analytics')
+
+    expect(posthogBeforeSend(null)).toBeNull()
+  })
+})
+
+describe('posthog initialization', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    Object.values(mockPosthog).forEach((fn) => fn.mockClear())
+    mockPosthog.has_opted_out_capturing.mockReturnValue(false)
+    window.history.pushState({}, '', '/')
+  })
+
+  it('initializes cookieless (memory persistence) before consent', async () => {
+    const { initializePosthog } = await import('./analytics')
+
+    initializePosthog({ key: 'phc_test', consent: null })
+    await vi.waitFor(() => expect(mockPosthog.init).toHaveBeenCalledTimes(1))
+
+    const [key, config] = mockPosthog.init.mock.calls[0]
+    expect(key).toBe('phc_test')
+    expect(config.api_host).toBe('https://eu.i.posthog.com')
+    expect(config.persistence).toBe('memory')
+    expect(config.person_profiles).toBe('identified_only')
+    expect(config.disable_session_recording).toBe(true)
+  })
+
+  it('initializes with cookie persistence when consent was already accepted', async () => {
+    const { initializePosthog } = await import('./analytics')
+
+    initializePosthog({ key: 'phc_test', host: 'https://relay.vocdoni.io', consent: 'accepted' })
+    await vi.waitFor(() => expect(mockPosthog.init).toHaveBeenCalledTimes(1))
+
+    const [, config] = mockPosthog.init.mock.calls[0]
+    expect(config.api_host).toBe('https://relay.vocdoni.io')
+    expect(config.persistence).toBe('localStorage+cookie')
+  })
+
+  it('registers the analytics client id as a super property', async () => {
+    const { initializePosthog } = await import('./analytics')
+
+    initializePosthog({ key: 'phc_test', analyticsClientId: 'client-1', consent: null })
+    await vi.waitFor(() => expect(mockPosthog.register).toHaveBeenCalledWith({ client: 'client-1' }))
+  })
+
+  it('does not initialize without a key or when consent was rejected', async () => {
+    const { initializePosthog } = await import('./analytics')
+
+    initializePosthog({ key: '', consent: null })
+    initializePosthog({ key: 'phc_test', consent: 'rejected' })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mockPosthog.init).not.toHaveBeenCalled()
+  })
+
+  it('never initializes on a public voting route', async () => {
+    const { initializePosthog } = await import('./analytics')
+
+    window.history.pushState({}, '', '/ca/processes/0x1234')
+    initializePosthog({ key: 'phc_test', consent: 'accepted' })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mockPosthog.init).not.toHaveBeenCalled()
+  })
+
+  it('only initializes once', async () => {
+    const { initializePosthog } = await import('./analytics')
+
+    initializePosthog({ key: 'phc_test', consent: null })
+    initializePosthog({ key: 'phc_test', consent: null })
+    await vi.waitFor(() => expect(mockPosthog.init).toHaveBeenCalledTimes(1))
+  })
+
+  it('catches and logs an error when init throws', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockPosthog.init.mockImplementationOnce(() => {
+      throw new Error('PostHog init failed')
+    })
+    const { initializePosthog } = await import('./analytics')
+
+    initializePosthog({ key: 'phc_test', consent: null })
+
+    await vi.waitFor(() => expect(consoleSpy).toHaveBeenCalledWith('Failed to initialize PostHog:', expect.any(Error)))
+    consoleSpy.mockRestore()
+  })
+})
+
+describe('posthog event tracking', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    Object.values(mockPosthog).forEach((fn) => fn.mockClear())
+    mockPosthog.has_opted_out_capturing.mockReturnValue(false)
+    window.history.pushState({}, '', '/')
+  })
+
+  it('does nothing before initialization', async () => {
+    const { trackPosthogEvent } = await import('./analytics')
+
+    trackPosthogEvent({ name: 'Signup' })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mockPosthog.capture).not.toHaveBeenCalled()
+  })
+
+  it('maps legacy event names to the snake_case taxonomy', async () => {
+    const { initializePosthog, trackPosthogEvent } = await import('./analytics')
+
+    initializePosthog({ key: 'phc_test', consent: null })
+    trackPosthogEvent({ name: 'Signup' })
+    trackPosthogEvent({ name: 'ProcessCreated', props: { census_type: 'csp' } })
+
+    await vi.waitFor(() => expect(mockPosthog.capture).toHaveBeenCalledTimes(2))
+    expect(mockPosthog.capture).toHaveBeenNthCalledWith(1, 'account_signed_up', undefined)
+    expect(mockPosthog.capture).toHaveBeenNthCalledWith(2, 'process_created', { census_type: 'csp' })
+  })
+})
+
+describe('posthog consent lifecycle', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    Object.values(mockPosthog).forEach((fn) => fn.mockClear())
+    mockPosthog.has_opted_out_capturing.mockReturnValue(false)
+    window.history.pushState({}, '', '/')
+  })
+
+  it('does nothing before initialization', async () => {
+    const { applyPosthogConsent } = await import('./analytics')
+
+    applyPosthogConsent('accepted')
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mockPosthog.set_config).not.toHaveBeenCalled()
+  })
+
+  it('upgrades to cookie persistence when consent is accepted', async () => {
+    const { applyPosthogConsent, initializePosthog } = await import('./analytics')
+
+    initializePosthog({ key: 'phc_test', consent: null })
+    applyPosthogConsent('accepted')
+
+    await vi.waitFor(() => expect(mockPosthog.set_config).toHaveBeenCalledWith({ persistence: 'localStorage+cookie' }))
+    expect(mockPosthog.opt_in_capturing).not.toHaveBeenCalled()
+  })
+
+  it('re-opts in a previously opted-out user on acceptance', async () => {
+    mockPosthog.has_opted_out_capturing.mockReturnValue(true)
+    const { applyPosthogConsent, initializePosthog } = await import('./analytics')
+
+    initializePosthog({ key: 'phc_test', consent: null })
+    applyPosthogConsent('accepted')
+
+    await vi.waitFor(() => expect(mockPosthog.opt_in_capturing).toHaveBeenCalledTimes(1))
+  })
+
+  it('opts out and drops persisted state when consent is rejected', async () => {
+    const { applyPosthogConsent, initializePosthog } = await import('./analytics')
+
+    initializePosthog({ key: 'phc_test', consent: null })
+    applyPosthogConsent('rejected')
+
+    await vi.waitFor(() => expect(mockPosthog.opt_out_capturing).toHaveBeenCalledTimes(1))
+    expect(mockPosthog.set_config).toHaveBeenCalledWith({ persistence: 'memory' })
+  })
+})
+
+describe('posthog identity helpers', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    Object.values(mockPosthog).forEach((fn) => fn.mockClear())
+    mockPosthog.has_opted_out_capturing.mockReturnValue(false)
+    window.history.pushState({}, '', '/')
+  })
+
+  it('identifies, groups and resets only after initialization', async () => {
+    const analytics = await import('./analytics')
+
+    analytics.identifyPosthogUser('user-1')
+    analytics.setPosthogOrganization('0xabc')
+    analytics.resetPosthogUser()
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mockPosthog.identify).not.toHaveBeenCalled()
+    expect(mockPosthog.group).not.toHaveBeenCalled()
+    expect(mockPosthog.reset).not.toHaveBeenCalled()
+
+    analytics.initializePosthog({ key: 'phc_test', consent: 'accepted' })
+    analytics.identifyPosthogUser('user-1', { email: 'a@b.com' })
+    analytics.setPosthogOrganization('0xabc', { plan_name: 'Free' })
+    analytics.registerPosthogSuperProperties({ locale: 'ca' })
+    analytics.resetPosthogUser()
+
+    await vi.waitFor(() => expect(mockPosthog.reset).toHaveBeenCalledTimes(1))
+    expect(mockPosthog.identify).toHaveBeenCalledWith('user-1', { email: 'a@b.com' })
+    expect(mockPosthog.group).toHaveBeenCalledWith('organization', '0xabc', { plan_name: 'Free' })
+    expect(mockPosthog.register).toHaveBeenCalledWith({ locale: 'ca' })
   })
 })
 

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -201,6 +201,8 @@ export const sanitizeAnalyticsUrl = (url: string): string => {
   }
 }
 
+const EMAIL_REGEX = /[\w.+-]+@[\w-]+\.[\w.-]+/g
+
 export const posthogBeforeSend = (event: CaptureResult | null): CaptureResult | null => {
   if (!event) return null
 
@@ -220,6 +222,22 @@ export const posthogBeforeSend = (event: CaptureResult | null): CaptureResult | 
   }
   if (typeof event.properties?.$referrer === 'string') {
     event.properties.$referrer = sanitizeAnalyticsUrl(event.properties.$referrer)
+  }
+
+  // Error tracking: strip email addresses from exception payloads
+  if (event.event === '$exception') {
+    for (const key of ['$exception_message', '$exception_list'] as const) {
+      const value = event.properties?.[key]
+      if (typeof value === 'string') {
+        event.properties[key] = value.replace(EMAIL_REGEX, '[redacted-email]')
+      } else if (value !== undefined) {
+        try {
+          event.properties[key] = JSON.parse(JSON.stringify(value).replace(EMAIL_REGEX, '[redacted-email]'))
+        } catch {
+          // leave the payload untouched if it cannot be serialized
+        }
+      }
+    }
   }
 
   return event
@@ -252,7 +270,12 @@ export const initializePosthog = ({ key, host, analyticsClientId, consent }: Pos
         person_profiles: 'identified_only',
         // Cookieless until the user accepts the cookie banner
         persistence: consent === 'accepted' ? 'localStorage+cookie' : 'memory',
+        // Recording is started explicitly, only for consented dashboard users
         disable_session_recording: true,
+        session_recording: {
+          maskAllInputs: true,
+        },
+        capture_exceptions: true,
         before_send: posthogBeforeSend,
       })
       if (analyticsClientId) {
@@ -300,6 +323,7 @@ export const applyPosthogConsent = (consent: PosthogConsent): void => {
           posthog.opt_in_capturing()
         }
       } else if (consent === 'rejected') {
+        posthog.stopSessionRecording()
         posthog.opt_out_capturing()
         posthog.set_config({ persistence: 'memory' })
       }
@@ -345,6 +369,26 @@ export const setPosthogOrganization = (address: string, props?: Record<string, u
     })
     .catch((error) => {
       console.error('Failed to set PostHog organization group:', error)
+    })
+}
+
+// Session replay is opt-in twice over: it only ever runs for authenticated
+// dashboard users who accepted the cookie banner, and voting routes are
+// excluded at the before_send layer regardless.
+export const setPosthogSessionRecording = (enabled: boolean): void => {
+  if (!posthogInitStarted) return
+  if (!canUseBrowserAnalytics()) return
+
+  void loadPosthogModule()
+    .then(({ default: posthog }) => {
+      if (enabled) {
+        posthog.startSessionRecording()
+      } else {
+        posthog.stopSessionRecording()
+      }
+    })
+    .catch((error) => {
+      console.error('Failed to toggle PostHog session recording:', error)
     })
 }
 

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -167,6 +167,12 @@ export const trackAnalyticsEvent = (event: AnalyticsEvent): void => {
 
 export type PosthogConsent = 'accepted' | 'rejected' | null
 
+// The consent choice lives in localStorage, so it is user-editable and may hold
+// anything. Anything that is not an explicit choice is treated as "no decision
+// yet" (cookieless, anonymous) rather than being trusted as one.
+export const toPosthogConsent = (value: string | null | undefined): PosthogConsent =>
+  value === 'accepted' || value === 'rejected' ? value : null
+
 type PosthogInitConfig = {
   key: string
   host?: string
@@ -263,7 +269,13 @@ let posthogInitialized = false
 let posthogModulePromise: Promise<typeof import('posthog-js')> | null = null
 
 const loadPosthogModule = () => {
-  posthogModulePromise ??= import('posthog-js')
+  // A rejected promise must not stay cached: a transient chunk-load failure
+  // would otherwise keep PostHog dead for the rest of the session, since every
+  // later caller would await the same rejection.
+  posthogModulePromise ??= import('posthog-js').catch((error) => {
+    posthogModulePromise = null
+    throw error
+  })
   return posthogModulePromise
 }
 
@@ -299,6 +311,9 @@ export const initializePosthog = ({ key, host, analyticsClientId, consent }: Pos
       posthogInitialized = true
     })
     .catch((error) => {
+      // Release the guard so a later attempt (consent change, remount) can
+      // retry instead of leaving analytics permanently disabled.
+      posthogInitStarted = false
       console.error('Failed to initialize PostHog:', error)
     })
 }

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -281,6 +281,7 @@ export const initializePosthog = ({ key, host, analyticsClientId, consent }: Pos
       if (analyticsClientId) {
         posthog.register({ client: analyticsClientId })
       }
+      attachPosthogFlagBridge(posthog)
       posthogInitialized = true
     })
     .catch((error) => {
@@ -370,6 +371,48 @@ export const setPosthogOrganization = (address: string, props?: Record<string, u
     .catch((error) => {
       console.error('Failed to set PostHog organization group:', error)
     })
+}
+
+// --- Feature flags ---
+// Listeners may register before PostHog has initialized (children effects run
+// before the provider effect); they are held here and bridged once the SDK is
+// ready, so `useFeatureFlag` works regardless of mount order.
+
+type FlagListener = (isEnabled: (flag: string) => boolean | undefined) => void
+
+const posthogFlagListeners = new Set<FlagListener>()
+let posthogFlagBridgeAttached = false
+
+const attachPosthogFlagBridge = (posthog: (typeof import('posthog-js'))['default']): void => {
+  if (posthogFlagBridgeAttached) return
+  posthogFlagBridgeAttached = true
+
+  posthog.onFeatureFlags(() => {
+    for (const listener of posthogFlagListeners) {
+      listener((flag) => posthog.isFeatureEnabled(flag))
+    }
+  })
+}
+
+export const onPosthogFeatureFlags = (listener: FlagListener): (() => void) => {
+  posthogFlagListeners.add(listener)
+
+  // Late subscribers get the current values right away
+  if (posthogInitialized && canUseBrowserAnalytics()) {
+    void loadPosthogModule()
+      .then(({ default: posthog }) => {
+        if (posthogFlagListeners.has(listener)) {
+          listener((flag) => posthog.isFeatureEnabled(flag))
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to read PostHog feature flags:', error)
+      })
+  }
+
+  return () => {
+    posthogFlagListeners.delete(listener)
+  }
 }
 
 // Session replay is opt-in twice over: it only ever runs for authenticated

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -185,6 +185,19 @@ export const isVotingPath = (pathname: string): boolean => VOTING_PATH_REGEX.tes
 // password-reset links carry tokens) and must never reach analytics.
 const SENSITIVE_QUERY_PARAMS = ['email', 'token', 'code']
 
+// Session replay masks every input value (`maskAllInputs`), which would also
+// hide fields we do want to read back — the organization name in settings being
+// the one case. Opt a field back in by adding `data-ph-unmask` to it (or to any
+// ancestor). Passwords are never unmasked, whatever the markup says.
+export const POSTHOG_UNMASK_ATTRIBUTE = 'data-ph-unmask'
+
+export const posthogMaskInput = (text: string, element?: HTMLElement): string => {
+  const masked = '*'.repeat(text.length)
+  if (!element) return masked
+  if (element instanceof HTMLInputElement && element.type === 'password') return masked
+  return element.closest(`[${POSTHOG_UNMASK_ATTRIBUTE}]`) ? text : masked
+}
+
 export const sanitizeAnalyticsUrl = (url: string): string => {
   try {
     const parsed = new URL(url)
@@ -274,6 +287,7 @@ export const initializePosthog = ({ key, host, analyticsClientId, consent }: Pos
         disable_session_recording: true,
         session_recording: {
           maskAllInputs: true,
+          maskInputFn: posthogMaskInput,
         },
         capture_exceptions: true,
         before_send: posthogBeforeSend,

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -10,16 +10,36 @@ type TagManagerArgs = {
 }
 
 export const AnalyticsEvents = {
+  // Legacy events keep their original names so Plausible/GTM history stays
+  // continuous; PostHog receives them renamed via posthogEventNames below.
   AccountSignup: 'Signup',
   OrganizationCreated: 'OrganizationCreated',
   UserLoggedIn: 'LoggedIn',
   ProcessCreated: 'ProcessCreated',
   SubscriptionSuccessful: 'SubscriptionSuccessful',
+  // Newer events use snake_case in every sink
+  CheckoutStarted: 'checkout_started',
+  BillingPortalOpened: 'billing_portal_opened',
+  PaywallViewed: 'paywall_viewed',
+  FeatureBlocked: 'feature_blocked',
+  ProcessCreationFailed: 'process_creation_failed',
+  ProcessTemplateSelected: 'process_template_selected',
+  ProcessAction: 'process_action',
+  ProcessResultsViewed: 'process_results_viewed',
+  MembersImportStarted: 'members_import_started',
+  MembersImportCompleted: 'members_import_completed',
+  MemberGroupCreated: 'member_group_created',
+  MemberGroupDeleted: 'member_group_deleted',
+  CensusConfigured: 'census_configured',
+  OnboardingStepCompleted: 'onboarding_step_completed',
+  TeamMemberInvited: 'team_member_invited',
+  TeamMemberRemoved: 'team_member_removed',
+  PdfReportDownloaded: 'pdf_report_downloaded',
 } as const
 
 export interface AnalyticsEvent {
   name: (typeof AnalyticsEvents)[keyof typeof AnalyticsEvents]
-  props?: Record<string, string>
+  props?: Record<string, string | number | boolean>
 }
 
 let plausibleInitialized = false
@@ -106,7 +126,10 @@ export const trackPlausibleEvent = (event: AnalyticsEvent): void => {
 
   void loadPlausibleModule()
     .then(({ track }) => {
-      track(event.name, { props: event.props })
+      // Plausible only accepts string custom property values
+      const props =
+        event.props && Object.fromEntries(Object.entries(event.props).map(([key, value]) => [key, String(value)]))
+      track(event.name, { props })
     })
     .catch((error) => {
       console.error('Failed to track Plausible event:', error)
@@ -129,6 +152,15 @@ export const trackGTMEvent = (event: AnalyticsEvent): void => {
     .catch((error) => {
       console.error('Failed to track GTM event:', error)
     })
+}
+
+// Fans an event out to every configured sink. Safe to call from hooks or query
+// files without the AnalyticsProvider context: every sink silently no-ops until
+// it has been initialized.
+export const trackAnalyticsEvent = (event: AnalyticsEvent): void => {
+  trackPlausibleEvent(event)
+  trackGTMEvent(event)
+  trackPosthogEvent(event)
 }
 
 // --- PostHog ---

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,3 +1,5 @@
+import type { CaptureResult } from 'posthog-js'
+
 type PlausibleConfig = {
   domain: string
   customProperties?: Record<string, string> | ((eventName: string) => Record<string, string>)
@@ -126,5 +128,203 @@ export const trackGTMEvent = (event: AnalyticsEvent): void => {
     })
     .catch((error) => {
       console.error('Failed to track GTM event:', error)
+    })
+}
+
+// --- PostHog ---
+
+export type PosthogConsent = 'accepted' | 'rejected' | null
+
+type PosthogInitConfig = {
+  key: string
+  host?: string
+  analyticsClientId?: string
+  consent: PosthogConsent
+}
+
+// Voters must never be tracked: matches public voting routes (`/processes/:id`
+// and `/processes/:id/summary`, with or without a `/:lang` prefix) where PostHog
+// is neither loaded nor allowed to emit a single event.
+const VOTING_PATH_REGEX = /^\/([a-z]{2}(-[a-z]{2})?\/)?processes\/[^/]+/
+
+export const isVotingPath = (pathname: string): boolean => VOTING_PATH_REGEX.test(pathname)
+
+// Query params that may carry PII (signup redirects carry `?email=`,
+// password-reset links carry tokens) and must never reach analytics.
+const SENSITIVE_QUERY_PARAMS = ['email', 'token', 'code']
+
+export const sanitizeAnalyticsUrl = (url: string): string => {
+  try {
+    const parsed = new URL(url)
+    let changed = false
+    for (const param of SENSITIVE_QUERY_PARAMS) {
+      if (parsed.searchParams.has(param)) {
+        parsed.searchParams.delete(param)
+        changed = true
+      }
+    }
+    return changed ? parsed.toString() : url
+  } catch {
+    return url
+  }
+}
+
+export const posthogBeforeSend = (event: CaptureResult | null): CaptureResult | null => {
+  if (!event) return null
+
+  const currentUrl = event.properties?.$current_url
+  let pathname = canUseBrowserAnalytics() ? window.location.pathname : ''
+  if (typeof currentUrl === 'string') {
+    try {
+      pathname = new URL(currentUrl).pathname
+    } catch {
+      // keep the window pathname fallback
+    }
+  }
+  if (isVotingPath(pathname)) return null
+
+  if (typeof currentUrl === 'string') {
+    event.properties.$current_url = sanitizeAnalyticsUrl(currentUrl)
+  }
+  if (typeof event.properties?.$referrer === 'string') {
+    event.properties.$referrer = sanitizeAnalyticsUrl(event.properties.$referrer)
+  }
+
+  return event
+}
+
+// Set synchronously when an init is accepted so concurrent callers (init,
+// consent changes, identify) can rely on the shared module promise ordering.
+let posthogInitStarted = false
+let posthogInitialized = false
+let posthogModulePromise: Promise<typeof import('posthog-js')> | null = null
+
+const loadPosthogModule = () => {
+  posthogModulePromise ??= import('posthog-js')
+  return posthogModulePromise
+}
+
+export const initializePosthog = ({ key, host, analyticsClientId, consent }: PosthogInitConfig): void => {
+  if (posthogInitStarted) return
+  if (!canUseBrowserAnalytics()) return
+  if (!key || consent === 'rejected') return
+  if (isVotingPath(window.location.pathname)) return
+
+  posthogInitStarted = true
+
+  void loadPosthogModule()
+    .then(({ default: posthog }) => {
+      posthog.init(key, {
+        api_host: host || 'https://eu.i.posthog.com',
+        defaults: '2026-06-25',
+        person_profiles: 'identified_only',
+        // Cookieless until the user accepts the cookie banner
+        persistence: consent === 'accepted' ? 'localStorage+cookie' : 'memory',
+        disable_session_recording: true,
+        before_send: posthogBeforeSend,
+      })
+      if (analyticsClientId) {
+        posthog.register({ client: analyticsClientId })
+      }
+      posthogInitialized = true
+    })
+    .catch((error) => {
+      console.error('Failed to initialize PostHog:', error)
+    })
+}
+
+// Maps legacy event names (kept as-is for Plausible/GTM continuity) to the
+// snake_case taxonomy used in PostHog. Unmapped names pass through unchanged.
+const posthogEventNames: Record<string, string> = {
+  Signup: 'account_signed_up',
+  LoggedIn: 'user_logged_in',
+  OrganizationCreated: 'organization_created',
+  ProcessCreated: 'process_created',
+  SubscriptionSuccessful: 'subscription_completed',
+}
+
+export const trackPosthogEvent = (event: AnalyticsEvent): void => {
+  if (!posthogInitStarted) return
+  if (!canUseBrowserAnalytics()) return
+
+  void loadPosthogModule()
+    .then(({ default: posthog }) => {
+      posthog.capture(posthogEventNames[event.name] ?? event.name, event.props)
+    })
+    .catch((error) => {
+      console.error('Failed to track PostHog event:', error)
+    })
+}
+
+export const applyPosthogConsent = (consent: PosthogConsent): void => {
+  if (!posthogInitStarted) return
+  if (!canUseBrowserAnalytics()) return
+
+  void loadPosthogModule()
+    .then(({ default: posthog }) => {
+      if (consent === 'accepted') {
+        posthog.set_config({ persistence: 'localStorage+cookie' })
+        if (posthog.has_opted_out_capturing()) {
+          posthog.opt_in_capturing()
+        }
+      } else if (consent === 'rejected') {
+        posthog.opt_out_capturing()
+        posthog.set_config({ persistence: 'memory' })
+      }
+    })
+    .catch((error) => {
+      console.error('Failed to apply PostHog consent:', error)
+    })
+}
+
+export const identifyPosthogUser = (id: string, props?: Record<string, unknown>): void => {
+  if (!posthogInitStarted) return
+  if (!canUseBrowserAnalytics()) return
+
+  void loadPosthogModule()
+    .then(({ default: posthog }) => {
+      posthog.identify(id, props)
+    })
+    .catch((error) => {
+      console.error('Failed to identify PostHog user:', error)
+    })
+}
+
+export const resetPosthogUser = (): void => {
+  if (!posthogInitStarted) return
+  if (!canUseBrowserAnalytics()) return
+
+  void loadPosthogModule()
+    .then(({ default: posthog }) => {
+      posthog.reset()
+    })
+    .catch((error) => {
+      console.error('Failed to reset PostHog user:', error)
+    })
+}
+
+export const setPosthogOrganization = (address: string, props?: Record<string, unknown>): void => {
+  if (!posthogInitStarted) return
+  if (!canUseBrowserAnalytics()) return
+
+  void loadPosthogModule()
+    .then(({ default: posthog }) => {
+      posthog.group('organization', address, props)
+    })
+    .catch((error) => {
+      console.error('Failed to set PostHog organization group:', error)
+    })
+}
+
+export const registerPosthogSuperProperties = (props: Record<string, unknown>): void => {
+  if (!posthogInitStarted) return
+  if (!canUseBrowserAnalytics()) return
+
+  void loadPosthogModule()
+    .then(({ default: posthog }) => {
+      posthog.register(props)
+    })
+    .catch((error) => {
+      console.error('Failed to register PostHog super properties:', error)
     })
 }

--- a/src/utils/use-feature-flag.ts
+++ b/src/utils/use-feature-flag.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+import { onPosthogFeatureFlags } from '~utils/analytics'
+
+/**
+ * Reads a PostHog feature flag. Returns `undefined` until flags have loaded
+ * (render your default state), then the flag value. When PostHog is disabled
+ * (no POSTHOG_KEY, rejected consent, voting routes) it stays `undefined`
+ * forever, so defaults must always be safe.
+ *
+ * Flags are never bootstrapped server-side: SSR HTML is cached across users,
+ * so per-user payloads must not be injected there.
+ */
+export const useFeatureFlag = (flag: string): boolean | undefined => {
+  const [enabled, setEnabled] = useState<boolean | undefined>(undefined)
+
+  useEffect(() => onPosthogFeatureFlags((isEnabled) => setEnabled(isEnabled(flag))), [flag])
+
+  return enabled
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
     },
     server: {
       deps: {
-        inline: ['@plausible-analytics/tracker', 'react-gtm-module'],
+        inline: ['@plausible-analytics/tracker', 'react-gtm-module', 'posthog-js'],
       },
     },
   },
@@ -38,6 +38,7 @@ export default defineConfig({
       // Mock problematic packages for testing
       '@plausible-analytics/tracker': path.resolve(__dirname, './src/__mocks__/@plausible-analytics/tracker.ts'),
       'react-gtm-module': path.resolve(__dirname, './src/__mocks__/react-gtm-module.ts'),
+      'posthog-js': path.resolve(__dirname, './src/__mocks__/posthog-js.ts'),
     },
   },
 })


### PR DESCRIPTION
closes #1733 

## What

Adds PostHog (EU Cloud) as the app's product-analytics and BI tool, alongside the existing Plausible and
GTM sinks, and provisions the dashboards that read the resulting data.

The whole integration is gated on a runtime `POSTHOG_KEY`. **Unset means PostHog is never loaded**, so
merging this changes nothing anywhere until the key is deployed.

## Why

We had no way to answer basic product questions — how many organizations activate, where the election
wizard loses people, which paywall actually converts. Plausible gives page-level traffic and GTM gives
marketing tags; neither can express a funnel or an organization-level cohort.

## Voters are never tracked

This was the hard constraint, and it is enforced in two independent layers rather than one:

1. `initializePosthog` refuses to load the SDK at all when the path matches a voting route
   (`/processes/:id`, `/processes/:id/summary`, with or without a language prefix). Voters never
   download posthog-js.
2. `posthogBeforeSend` returns `null` for **any** event — pageview, autocapture, replay snapshot,
   exception — whose URL is a voting route. This covers an admin SPA-navigating into a process view,
   where the SDK is already loaded.

Consequently there are no voter-side events in the taxonomy at all. Election participation BI comes from
admin-side events (`process_results_viewed` carries `turnout_pct`) and, later, the backend.

## Privacy model

- **Cookieless until consent.** Before the banner is accepted PostHog runs with `persistence: 'memory'`
  and `person_profiles: 'identified_only'` — no cookies, no localStorage, anonymous events only. On
  accept, persistence upgrades and dashboard users are identified. On reject, `opt_out_capturing()`.
- **URL scrubbing.** `email`, `token` and `code` query params are stripped from `$current_url` and
  `$referrer`; email addresses are redacted from exception payloads.
- **Session replay** is limited to authenticated users who accepted consent, with `maskAllInputs`.
- **Memberbase PII is never recorded.** Every surface rendering a member record carries `.ph-no-capture`,
  so rrweb skips the subtree entirely — text *and* attributes. That distinction matters: `MemberCard`'s
  checkbox `aria-label` embeds the member's name, which text-only masking would have leaked. Covered:
  member table cells, member cards, group member tables, and the CSV import error list (which quotes
  offending rows). Surrounding chrome — tabs, headings, counts, column headers, group names — stays
  visible so replays remain useful.
- **Opting a field back in.** `posthogMaskInput` (wired as `maskInputFn`) restores input values inside a
  `data-ph-unmask` subtree; passwords are never restored regardless of markup. The only current use is
  the organization name in Settings → Organization details.

## What is tracked

Six pre-existing events keep their historical strings for Plausible/GTM and are renamed to snake_case for
PostHog; new events are snake_case everywhere. Full taxonomy in `docs/analytics.md`.

Organization-level BI: every session registers `org_address` / `org_name` / `org_plan` super properties,
and the `organization` group profile carries name, plan, type, country, size, usage counters and renewal
date. The name is sent three ways on purpose — as the group's `name` (what PostHog uses as a group's
display label, without which every org renders as a bare `0x…` address), as a super property (group
properties are only queryable with the group analytics add-on, super properties land on every event), and
on `organization_created` itself, which fires before the group profile has been registered.

## Dashboards and funnels

`scripts/posthog-insights.mjs` (`pnpm posthog:insights`) creates three dashboards and 14 insights through
the PostHog API, so they live in git and are reproducible rather than hand-clicked. Objects are matched
by name, so re-running updates in place instead of duplicating.

| Dashboard | Insights |
| --- | --- |
| **Activation** | signup → org → first election (steps, time-to-convert, weekly trend); memberbase import funnel; onboarding steps completed; organizations created by name |
| **Monetization** | paywall → checkout → subscription (by `source`); blocked feature → upgrade (by `feature`); paywall exposure per plan |
| **Elections & engagement** | wizard funnel `process_template_selected` → `census_published` → `process_created` → `process_results_viewed`; created vs failed; weekly active organizations; most active organizations by name; elections by census type |

Two things these do that the PostHog UI defaults do not:

- **Organization-level aggregation.** Every funnel starting after an org exists sets
  `aggregation_group_type_index` to the `organization` group, so conversion counts organizations rather
  than seats — several colleagues sharing one journey no longer inflate the numerator. The index is
  resolved at runtime from the API; if the group type does not exist yet the script warns and falls back
  to person aggregation.
- **Conversion windows matched to each flow** — 7 days for checkout, 30 for activation, 1 hour for wizard
  failures. An unbounded window flatters every funnel.

Requires a personal API key with `project:read`, `insight:write`, `dashboard:write`; `--dry-run` works
fully offline so the generated query JSON can be reviewed in a diff.

## Feature flags

```tsx
const enabled = useFeatureFlag('new-dashboard') // undefined until flags load
```

`undefined` means "not loaded / PostHog disabled", so defaults must always be safe. Flags must never gate
voter-facing functionality — the SDK does not exist on voting routes. No SSR bootstrapping, since SSR
HTML is LRU-cached across users.

## Configuration

| Variable | Meaning |
| --- | --- |
| `POSTHOG_KEY` | Project API key. Unset = PostHog fully disabled. |
| `POSTHOG_HOST` | Defaults to `https://eu.i.posthog.com` (EU residency). Can be pointed at a reverse proxy later without code changes. |

Env is runtime-injected via `app-env-build.ts` and Vike's global context, so one Docker image works
across environments.

## How this was verified

- `pnpm lint` clean; 613 tests pass, including new coverage for URL sanitization, the voting-route
  guards, consent transitions, replay input masking, memberbase `.ph-no-capture` coverage, and the
  organization name reaching both the group profile and super properties.
- The masking tests assert both directions — member values have a `.ph-no-capture` ancestor *and* column
  headers do not — so they discriminate rather than matching everything.
- Every generated insight query was validated field-by-field and enum-by-enum against PostHog's published
  query schema before being sent.
- Manually verified in a browser: no requests to posthog.com on a public process page; no `ph_*` storage
  before consent; identity and `$groups.organization` attached after login; network silence after reject.

One caveat worth knowing for anyone testing this: posthog-js silently drops every event when its internal
bot check trips, which includes Playwright and Puppeteer even with a spoofed user agent. The SDK still
initializes and still calls `/flags/`, so it looks alive while nothing is ever sent. Automated end-to-end
checks need a headed browser. Also, `window.posthog` is always `undefined` here — the SDK is an ES module
import, not the script snippet — so it cannot be used to tell whether PostHog loaded. Use the network
tab. Both gotchas are documented in `docs/analytics.md`.

## Rollout

1. Merge — no behaviour change while `POSTHOG_KEY` is unset.
2. Set `POSTHOG_KEY` in the stage container's runtime env; confirm events arrive and voting pages stay
   silent.
3. Publish the updated privacy policy and complete the DPA/subprocessor paperwork **before** enabling the
   key in production.
4. Then set it in production.

## Follow-ups (not in this PR)

- Server-side events from `saas-backend` with `posthog-node`, keyed to the same `organization` group:
  renewals, churn, payment failures, final turnout, and a periodic usage-counter sync. The frontend
  cannot see any of these.
- Decide whether `identify` should keep sending email and first/last name, or key on user id alone.
- PostHog workspace config: replay sampling, per-product billing limits, surveys targeted to `/admin/*`
  only.
