### PR TITLE
fix(process): scope stored draft ids per organization

### DIFF
--- a/src/components/Process/Create/draft-saver.test.tsx
+++ b/src/components/Process/Create/draft-saver.test.tsx
@@ -4,6 +4,7 @@ import { createTestQueryClient } from '~src/test-utils'
 import { setReactProvidersMock } from '~src/test-utils-react-providers-mock'
 import { CensusTypes } from '../Census/CensusType'
 import { defaultProcessValues, Process } from './common'
+import { getStoredDraftId, storeDraftId as persistDraftId } from './draft-storage'
 import { useFormDraftSaver } from './index'
 
 const create = vi.fn()
@@ -55,8 +56,17 @@ const form: Process = {
   censusType: CensusTypes.CSP,
 }
 
-const renderSaver = (draftId: string | null = null) => {
-  const storeDraftId = vi.fn()
+const orgAddress = '0xorgaddr'
+
+/**
+ * `persist` mirrors what the real `useStoredDraftId` setter does — writing
+ * through to localStorage — so tests can exercise the storage-backed paths
+ * instead of only asserting on the spy.
+ */
+const renderSaver = (draftId: string | null = null, { persist = false }: { persist?: boolean } = {}) => {
+  const storeDraftId = vi.fn((id: string | null) => {
+    if (persist) persistDraftId(orgAddress, id)
+  })
   const queryClient = createTestQueryClient()
   const { result } = renderHook(() => useFormDraftSaver(true, () => form, draftId, storeDraftId), {
     wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
@@ -68,8 +78,9 @@ const renderSaver = (draftId: string | null = null) => {
 describe('useFormDraftSaver', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.clear()
     setReactProvidersMock({
-      useOrganization: vi.fn().mockReturnValue({ organization: { address: '0xorgaddr' } }),
+      useOrganization: vi.fn().mockReturnValue({ organization: { address: orgAddress } }),
     })
     create.mockResolvedValue('draft-1')
     update.mockResolvedValue(undefined)
@@ -151,5 +162,58 @@ describe('useFormDraftSaver', () => {
     expect(storeDraftId).toHaveBeenCalledWith('draft-1')
     expect(publishedId).toBe('draft-1')
     expect(update).toHaveBeenCalledWith('draft-1', { published: true })
+  })
+
+  describe('clearPublishedDraftId', () => {
+    it('drops the stored id when it points at the published draft', () => {
+      persistDraftId(orgAddress, 'draft-1')
+      const { result, storeDraftId } = renderSaver('draft-1', { persist: true })
+
+      result.current.clearPublishedDraftId('draft-1')
+
+      expect(storeDraftId).toHaveBeenCalledWith(null)
+      expect(getStoredDraftId(orgAddress)).toBeNull()
+    })
+
+    it('keeps a stored id pointing at a different draft', () => {
+      // Opening a draft from the drafts list (`?draftId=`) publishes it without
+      // ever repointing storage, so publishing must not forget the draft the
+      // create form would otherwise resume.
+      persistDraftId(orgAddress, 'draft-other')
+      const { result, storeDraftId } = renderSaver('draft-1', { persist: true })
+
+      result.current.clearPublishedDraftId('draft-1')
+
+      expect(storeDraftId).not.toHaveBeenCalled()
+      expect(getStoredDraftId(orgAddress)).toBe('draft-other')
+    })
+
+    it('drops the id the write queue stored during this same publish', async () => {
+      // The create path stores the new id inside the queued write, after the
+      // caller's render closure was captured — so the `draftId` prop is still
+      // null here. Deciding against it instead of storage would leave the
+      // pointer aimed at a published process, which a later draft delete would
+      // then delete.
+      const { result, storeDraftId } = renderSaver(null, { persist: true })
+
+      const publishedId = await result.current.writeDraft(() => ({ published: true }) as never)
+      expect(getStoredDraftId(orgAddress)).toBe('draft-1')
+
+      result.current.clearPublishedDraftId(publishedId)
+
+      expect(storeDraftId).toHaveBeenLastCalledWith(null)
+      expect(getStoredDraftId(orgAddress)).toBeNull()
+    })
+
+    it('leaves other organizations untouched', () => {
+      persistDraftId('0xotherorg', 'draft-1')
+      persistDraftId(orgAddress, 'draft-1')
+      const { result } = renderSaver('draft-1', { persist: true })
+
+      result.current.clearPublishedDraftId('draft-1')
+
+      expect(getStoredDraftId(orgAddress)).toBeNull()
+      expect(getStoredDraftId('0xotherorg')).toBe('draft-1')
+    })
   })
 })

--- a/src/components/Process/Create/draft-storage.test.ts
+++ b/src/components/Process/Create/draft-storage.test.ts
@@ -1,0 +1,135 @@
+import { act, renderHook } from '@testing-library/react'
+import {
+  clearStoredDraftId,
+  DraftIdsStorageKey,
+  getStoredDraftId,
+  LegacyDraftIdStorageKey,
+  storeDraftId,
+  useStoredDraftId,
+} from './draft-storage'
+
+const OrgA = '0xaaa0000000000000000000000000000000000001'
+const OrgB = '0xbbb0000000000000000000000000000000000002'
+
+describe('draft-storage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('getStoredDraftId / storeDraftId', () => {
+    it('returns null when nothing is stored', () => {
+      expect(getStoredDraftId(OrgA)).toBeNull()
+    })
+
+    it('round-trips a draft id for an organization', () => {
+      storeDraftId(OrgA, 'draft-1')
+      expect(getStoredDraftId(OrgA)).toBe('draft-1')
+    })
+
+    it('does not return a draft id stored for a different organization', () => {
+      // Regression: a draft saved while acting as org A must never leak into org B,
+      // where updating it fails with permission errors
+      storeDraftId(OrgA, 'draft-1')
+      expect(getStoredDraftId(OrgB)).toBeNull()
+    })
+
+    it('keeps a draft id per organization', () => {
+      storeDraftId(OrgA, 'draft-1')
+      storeDraftId(OrgB, 'draft-2')
+      expect(getStoredDraftId(OrgA)).toBe('draft-1')
+      expect(getStoredDraftId(OrgB)).toBe('draft-2')
+    })
+
+    it('normalizes addresses (case and 0x prefix)', () => {
+      storeDraftId('AAA0000000000000000000000000000000000001', 'draft-1')
+      expect(getStoredDraftId('0xAaA0000000000000000000000000000000000001')).toBe('draft-1')
+    })
+
+    it('clears only the given organization entry when storing null', () => {
+      storeDraftId(OrgA, 'draft-1')
+      storeDraftId(OrgB, 'draft-2')
+      storeDraftId(OrgA, null)
+      expect(getStoredDraftId(OrgA)).toBeNull()
+      expect(getStoredDraftId(OrgB)).toBe('draft-2')
+    })
+
+    it('returns null for a missing address', () => {
+      storeDraftId(OrgA, 'draft-1')
+      expect(getStoredDraftId(null)).toBeNull()
+      expect(getStoredDraftId(undefined)).toBeNull()
+    })
+
+    it('ignores writes without an address', () => {
+      storeDraftId(null, 'draft-1')
+      expect(localStorage.getItem(DraftIdsStorageKey)).toBeNull()
+    })
+
+    it('survives corrupted storage contents', () => {
+      localStorage.setItem(DraftIdsStorageKey, 'not-json')
+      expect(getStoredDraftId(OrgA)).toBeNull()
+      storeDraftId(OrgA, 'draft-1')
+      expect(getStoredDraftId(OrgA)).toBe('draft-1')
+    })
+  })
+
+  describe('clearStoredDraftId', () => {
+    it('clears the entry when it points to the given draft', () => {
+      storeDraftId(OrgA, 'draft-1')
+      clearStoredDraftId(OrgA, 'draft-1')
+      expect(getStoredDraftId(OrgA)).toBeNull()
+    })
+
+    it('keeps the entry when it points to a different draft', () => {
+      storeDraftId(OrgA, 'draft-1')
+      clearStoredDraftId(OrgA, 'draft-2')
+      expect(getStoredDraftId(OrgA)).toBe('draft-1')
+    })
+  })
+
+  describe('useStoredDraftId', () => {
+    it('returns the stored draft id for the given organization', () => {
+      storeDraftId(OrgA, 'draft-1')
+      const { result } = renderHook(() => useStoredDraftId(OrgA))
+      expect(result.current[0]).toBe('draft-1')
+    })
+
+    it('persists ids through its setter', () => {
+      const { result } = renderHook(() => useStoredDraftId(OrgA))
+      act(() => result.current[1]('draft-1'))
+      expect(result.current[0]).toBe('draft-1')
+      expect(getStoredDraftId(OrgA)).toBe('draft-1')
+    })
+
+    it('forgets the previous organization draft when the address changes', () => {
+      // Regression: switching organization must not keep exposing the old org's draft id
+      storeDraftId(OrgA, 'draft-1')
+      const { result, rerender } = renderHook(({ address }) => useStoredDraftId(address), {
+        initialProps: { address: OrgA },
+      })
+      expect(result.current[0]).toBe('draft-1')
+
+      rerender({ address: OrgB })
+      expect(result.current[0]).toBeNull()
+    })
+
+    it('picks up the stored draft id once the address becomes available', () => {
+      storeDraftId(OrgA, 'draft-1')
+      const { result, rerender } = renderHook(({ address }) => useStoredDraftId(address), {
+        initialProps: { address: undefined as string | undefined },
+      })
+      expect(result.current[0]).toBeNull()
+
+      rerender({ address: OrgA })
+      expect(result.current[0]).toBe('draft-1')
+    })
+
+    it('drops the legacy un-scoped draft-id key and never exposes it', () => {
+      // Pre-scoping clients stored a bare draft id with no owner info; it cannot be
+      // trusted against the current org, so it must be discarded
+      localStorage.setItem(LegacyDraftIdStorageKey, JSON.stringify('draft-legacy'))
+      const { result } = renderHook(() => useStoredDraftId(OrgA))
+      expect(result.current[0]).toBeNull()
+      expect(localStorage.getItem(LegacyDraftIdStorageKey)).toBeNull()
+    })
+  })
+})

--- a/src/components/Process/Create/draft-storage.test.ts
+++ b/src/components/Process/Create/draft-storage.test.ts
@@ -70,6 +70,11 @@ describe('draft-storage', () => {
       storeDraftId(OrgA, 'draft-1')
       expect(getStoredDraftId(OrgA)).toBe('draft-1')
     })
+
+    it('ignores non-string values in stored contents', () => {
+      localStorage.setItem(DraftIdsStorageKey, JSON.stringify({ [OrgA]: 0 }))
+      expect(getStoredDraftId(OrgA)).toBeNull()
+    })
   })
 
   describe('clearStoredDraftId', () => {

--- a/src/components/Process/Create/draft-storage.ts
+++ b/src/components/Process/Create/draft-storage.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useState } from 'react'
+import { ensure0x } from '~utils/address'
+
+/**
+ * Draft ids are scoped per organization address: a draft created while acting as one org
+ * cannot be updated from another (the API rejects it with a permission error), so a single
+ * un-scoped id would leak between orgs when the user switches organization or account.
+ * Stored shape: { [lowercased 0x address]: draftId }
+ */
+export const DraftIdsStorageKey = 'draft-ids'
+/** Pre-scoping key holding a bare draft id with no owner info; discarded on sight */
+export const LegacyDraftIdStorageKey = 'draft-id'
+
+const normalizeAddress = (address?: string | null): string | null => (address ? ensure0x(address).toLowerCase() : null)
+
+const readDraftIds = (): Record<string, string> => {
+  if (typeof localStorage === 'undefined') return {}
+  try {
+    const parsed = JSON.parse(localStorage.getItem(DraftIdsStorageKey) ?? '{}')
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {}
+  } catch (e) {
+    return {}
+  }
+}
+
+export const getStoredDraftId = (address?: string | null): string | null => {
+  const key = normalizeAddress(address)
+  return key ? (readDraftIds()[key] ?? null) : null
+}
+
+export const storeDraftId = (address: string | null | undefined, draftId: string | null): void => {
+  const key = normalizeAddress(address)
+  if (!key || typeof localStorage === 'undefined') return
+  const ids = readDraftIds()
+  if (draftId) {
+    ids[key] = draftId
+  } else {
+    delete ids[key]
+  }
+  localStorage.setItem(DraftIdsStorageKey, JSON.stringify(ids))
+}
+
+/** Clears the stored draft id for an org, but only when it currently points to the given draft */
+export const clearStoredDraftId = (address: string | null | undefined, draftId: string): void => {
+  if (getStoredDraftId(address) === draftId) {
+    storeDraftId(address, null)
+  }
+}
+
+export const useStoredDraftId = (address?: string | null): [string | null, (draftId: string | null) => void] => {
+  const key = normalizeAddress(address)
+  const [storedDraftId, setStoredDraftId] = useState<string | null>(() => getStoredDraftId(key))
+
+  useEffect(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem(LegacyDraftIdStorageKey)
+    }
+  }, [])
+
+  // Re-read when the org address changes (async account load or org switch)
+  useEffect(() => {
+    setStoredDraftId(getStoredDraftId(key))
+  }, [key])
+
+  const store = useCallback(
+    (draftId: string | null) => {
+      storeDraftId(key, draftId)
+      setStoredDraftId(key ? draftId : null)
+    },
+    [key]
+  )
+
+  return [storedDraftId, store]
+}

--- a/src/components/Process/Create/draft-storage.ts
+++ b/src/components/Process/Create/draft-storage.ts
@@ -25,7 +25,9 @@ const readDraftIds = (): Record<string, string> => {
 
 export const getStoredDraftId = (address?: string | null): string | null => {
   const key = normalizeAddress(address)
-  return key ? (readDraftIds()[key] ?? null) : null
+  const draftId = key ? readDraftIds()[key] : null
+  // Guard against hand-edited/corrupted entries holding non-string values
+  return typeof draftId === 'string' ? draftId : null
 }
 
 export const storeDraftId = (address: string | null | undefined, draftId: string | null): void => {

--- a/src/components/Process/Create/index.tsx
+++ b/src/components/Process/Create/index.tsx
@@ -351,7 +351,23 @@ export const useFormDraftSaver = (
     return () => clearInterval(id)
   }, [saveDraft])
 
-  return { saveDraft, isSaving, skipSave, draftLimitReached, writeDraft }
+  // Publishing turns the draft into a process, so the stored pointer must be
+  // dropped: a later "delete draft" following it would delete the vote we just
+  // published. Only when it actually points at *this* draft though — publishing
+  // one opened straight from the drafts list (`?draftId=`) must not forget an
+  // unrelated resumable draft. Reads storage rather than the `draftId` prop:
+  // on the create path the id is stored inside the write queue, after the
+  // caller's render closure was captured, so the prop is stale (null) here.
+  const clearPublishedDraftId = useCallback(
+    (processId: string) => {
+      if (getStoredDraftId(organization?.address) === processId) {
+        storeDraftId(null)
+      }
+    },
+    [organization?.address, storeDraftId]
+  )
+
+  return { saveDraft, isSaving, skipSave, draftLimitReached, writeDraft, clearPublishedDraftId }
 }
 
 const TemplateButtons = () => {
@@ -663,7 +679,7 @@ const ProcessCreateView = () => {
     onOpen: openConfirmationModal,
     onClose: () => setLeaveConfirmationOpen(false),
   })
-  const { saveDraft, isSaving, skipSave, writeDraft } = useFormDraftSaver(
+  const { saveDraft, isSaving, skipSave, writeDraft, clearPublishedDraftId } = useFormDraftSaver(
     isDirty,
     methods.getValues,
     effectiveDraftId,
@@ -798,15 +814,7 @@ const ProcessCreateView = () => {
 
       methods.reset(defaultProcessValues)
 
-      // The stored draft id now points at a published process, so drop it —
-      // deleting it would delete the vote we just published. Only when it
-      // actually points at *this* draft though: publishing a draft opened
-      // straight from the drafts list (`?draftId=`) must not forget an
-      // unrelated resumable draft. Read from storage rather than the hook
-      // state, which is stale here when `writeDraft` just created the draft.
-      if (getStoredDraftId(organization?.address) === processId) {
-        storeDraftId(null)
-      }
+      clearPublishedDraftId(processId)
 
       navigate(generatePath(Routes.dashboard.process, { id: processId }))
     } catch (error) {

--- a/src/components/Process/Create/index.tsx
+++ b/src/components/Process/Create/index.tsx
@@ -15,7 +15,6 @@ import {
   VStack,
 } from '@chakra-ui/react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useLocalStorage } from '@uidotdev/usehooks'
 import { useOrganization } from '@vocdoni/react-components'
 import { VocdoniApiError } from '@vocdoni/api-client'
 import type {
@@ -55,6 +54,7 @@ import { Routes } from '~routes'
 import { SetupStepIds, useOrganizationSetup } from '~src/queries/organization'
 import { AnalyticsEvents } from '~utils/analytics'
 import { LiveStreamingInput } from './LiveStreamingInput'
+import { useStoredDraftId } from './draft-storage'
 import { Questions } from './MainContent'
 import { CreateSidebar } from './Sidebar'
 import { useProcessTemplates } from './TemplateProvider'
@@ -631,7 +631,6 @@ const ProcessCreateView = () => {
   const { groupId } = useParams()
   const [searchParams] = useSearchParams()
   const draftId = searchParams.get('draftId')
-  const [storedDraftId, storeDraftId] = useLocalStorage('draft-id', null)
   const navigate = useNavigate()
   const location = useLocation()
   const { showSidebar, toggleSidebar, openSidebar } = useSidebarVisibility()
@@ -647,6 +646,9 @@ const ProcessCreateView = () => {
   const openConfirmationModal = () => setLeaveConfirmationOpen(true)
   const { organization } = useOrganization()
   const { client: apiClient } = useApiClient()
+  // Draft ids are stored scoped to the acting organization so switching orgs never
+  // resumes (and tries to update) a draft owned by a different org
+  const [storedDraftId, storeDraftId] = useStoredDraftId(organization?.address)
   const queryClient = useQueryClient()
   const { isSubmitting, isSubmitSuccessful, isDirty } = methods.formState
   const { setStepDoneAsync } = useOrganizationSetup()

--- a/src/components/Process/Create/index.tsx
+++ b/src/components/Process/Create/index.tsx
@@ -54,7 +54,7 @@ import { Routes } from '~routes'
 import { SetupStepIds, useOrganizationSetup } from '~src/queries/organization'
 import { AnalyticsEvents } from '~utils/analytics'
 import { LiveStreamingInput } from './LiveStreamingInput'
-import { useStoredDraftId } from './draft-storage'
+import { getStoredDraftId, useStoredDraftId } from './draft-storage'
 import { Questions } from './MainContent'
 import { CreateSidebar } from './Sidebar'
 import { useProcessTemplates } from './TemplateProvider'
@@ -799,8 +799,14 @@ const ProcessCreateView = () => {
       methods.reset(defaultProcessValues)
 
       // The stored draft id now points at a published process, so drop it —
-      // deleting it would delete the vote we just published.
-      storeDraftId(null)
+      // deleting it would delete the vote we just published. Only when it
+      // actually points at *this* draft though: publishing a draft opened
+      // straight from the drafts list (`?draftId=`) must not forget an
+      // unrelated resumable draft. Read from storage rather than the hook
+      // state, which is stale here when `writeDraft` just created the draft.
+      if (getStoredDraftId(organization?.address) === processId) {
+        storeDraftId(null)
+      }
 
       navigate(generatePath(Routes.dashboard.process, { id: processId }))
     } catch (error) {

--- a/src/elements/dashboard/processes/drafts.test.tsx
+++ b/src/elements/dashboard/processes/drafts.test.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, renderHook } from '@testing-library/react'
 import React from 'react'
+import { getStoredDraftId, storeDraftId } from '~components/Process/Create/draft-storage'
 import { mockUseOrganization, render, screen, TestMemoryRouter } from '~src/test-utils'
 import { resetReactProvidersMock, setReactProvidersMock } from '~src/test-utils-react-providers-mock'
 import { DraftsTable, useDeleteDraft } from './drafts'
@@ -45,6 +46,7 @@ describe('useDeleteDraft', () => {
   beforeEach(() => {
     deleteElectionMock.mockClear()
     toastSpy.mockClear()
+    localStorage.clear()
     setReactProvidersMock({
       useOrganization: () => mockUseOrganization({ organization: { address: '0xorg' } }),
     })
@@ -85,6 +87,40 @@ describe('useDeleteDraft', () => {
 
     await expect(result.current.mutateAsync({ draftId: 'draft-3' })).rejects.toThrow(error)
     expect(toastSpy).not.toHaveBeenCalled()
+  })
+
+  it('clears the stored draft id after a successful delete', async () => {
+    storeDraftId('0xorg', 'draft-1')
+    const queryClient = new QueryClient()
+    const { result } = renderHook(() => useDeleteDraft(), { wrapper: createWrapper(queryClient) })
+
+    await act(async () => {
+      await result.current.mutateAsync({ draftId: 'draft-1' })
+    })
+
+    expect(getStoredDraftId('0xorg')).toBeNull()
+  })
+
+  it('keeps the stored draft id when the delete fails', async () => {
+    storeDraftId('0xorg', 'draft-1')
+    deleteElectionMock.mockRejectedValueOnce(new Error('boom'))
+    const queryClient = new QueryClient()
+    const { result } = renderHook(() => useDeleteDraft(), { wrapper: createWrapper(queryClient) })
+
+    await expect(result.current.mutateAsync({ draftId: 'draft-1' })).rejects.toThrow()
+    expect(getStoredDraftId('0xorg')).toBe('draft-1')
+  })
+
+  it('keeps the stored draft id when deleting a different draft', async () => {
+    storeDraftId('0xorg', 'draft-1')
+    const queryClient = new QueryClient()
+    const { result } = renderHook(() => useDeleteDraft(), { wrapper: createWrapper(queryClient) })
+
+    await act(async () => {
+      await result.current.mutateAsync({ draftId: 'draft-2' })
+    })
+
+    expect(getStoredDraftId('0xorg')).toBe('draft-1')
   })
 })
 

--- a/src/elements/dashboard/processes/drafts.tsx
+++ b/src/elements/dashboard/processes/drafts.tsx
@@ -71,6 +71,9 @@ export const useDeleteDraft = () => {
     mutationKey: QueryKeys.organization.drafts(organization?.address),
     mutationFn: ({ draftId }: { draftId: string; silent?: boolean }) => client.elections.delete(draftId),
     onSuccess: (_data, variables) => {
+      // Only forget the resumable draft pointer once the server actually deleted
+      // it, and only when it points at this draft
+      clearStoredDraftId(organization?.address, variables.draftId)
       if (!variables?.silent) {
         toast({
           title: t('drafts.deleted_draft', {
@@ -253,7 +256,6 @@ export const DraftsContextMenu = ({ draft }: { draft: Draft }) => {
 
   const deleteDraft = () => {
     deleteDraftMutation.mutate({ draftId: draft.id })
-    clearStoredDraftId(currentAddress, draft.id)
   }
 
   return (

--- a/src/elements/dashboard/processes/drafts.tsx
+++ b/src/elements/dashboard/processes/drafts.tsx
@@ -30,6 +30,7 @@ import RoutedPaginatedTableFooter from '~components/Pagination/PaginatedTableFoo
 import { useCreateProcess } from '~components/Process/Create'
 import { Process, SelectorTypes } from '~components/Process/Create/common'
 import { votingProcessToCreateRequest, votingProcessToForm } from '~components/Process/Create/draft-mapping'
+import { clearStoredDraftId } from '~components/Process/Create/draft-storage'
 import { useApiClient } from '~src/providers/ApiClientProvider'
 import { useToast } from '~components/Toast'
 import { QueryKeys } from '~queries/keys'
@@ -252,7 +253,7 @@ export const DraftsContextMenu = ({ draft }: { draft: Draft }) => {
 
   const deleteDraft = () => {
     deleteDraftMutation.mutate({ draftId: draft.id })
-    localStorage.removeItem('draft-id')
+    clearStoredDraftId(currentAddress, draft.id)
   }
 
   return (


### PR DESCRIPTION
Fable 5 here, controlled by elboletaire.

## What

Draft ids are now stored in localStorage scoped per acting organization address (`draft-ids` key holding `{ [org address]: draftId }`), replacing the single global `draft-id` key.

## Why

The old key carried no information about which organization owns the draft. After switching organizations (or logging into a different account), the process creation form kept resuming the previous org's draft via `effectiveDraftId`, and every autosave tried to `PUT` that draft with the new org's credentials — failing repeatedly with permission errors.

Scoping the stored id by the same address autosave sends as `orgAddress` fixes both the org-switch and the logout/re-login cases at the root, without adding draft-clearing side effects to auth code — and, unlike simply clearing on switch, it lets each org resume its own draft when you switch back.

Details:

- New `src/components/Process/Create/draft-storage.ts` with `useStoredDraftId(address)` plus non-hook helpers (`getStoredDraftId` / `storeDraftId` / `clearStoredDraftId`). The create view scopes by `organization?.address` — the exact value autosave sends as `orgAddress`, which is what the API authorizes against.
- The legacy un-scoped `draft-id` key is dropped on sight: it can't be attributed to any org, so it can't be trusted. Users currently stuck with a stale id get unstuck on their next visit to the create form.
- Post-publish cleanup and the drafts list "Delete Draft" action now only clear the stored id when it actually points at the affected draft (previously the key was wiped unconditionally, even when publishing or deleting an unrelated draft). The publish-side guard lives in `useFormDraftSaver` as `clearPublishedDraftId`, and reads storage rather than the `draftId` prop — on the create path the id is stored inside the write queue, after the caller's render closure was captured, so the prop is still `null` at that point.
- The drafts list clears the stored id from the delete mutation's `onSuccess`, so a failed delete no longer loses the ability to resume a draft that still exists server-side.

## How it was verified

TDD: the regression cases were written first against a null stub and watched fail (draft stored for org A must not be returned for org B; the hook must forget the previous org's draft when the address changes; the legacy key must be discarded), then the implementation turned them green.

- 17 tests in `draft-storage.test.ts`.
- 8 in `drafts.test.tsx`, covering clear-on-success, keep-on-failure, and keep-when-deleting-a-different-draft.
- 4 in `draft-saver.test.tsx` for the publish-time cleanup. Checked these are real regression tests, not just green: reverting the guard to the unconditional clear makes *keeps a stored id pointing at a different draft* fail, and the other three are characterisation.

Full `pnpm lint` and `pnpm test` pass (140 files / 639 tests, 1 skipped).

Not verified end-to-end against the API: every scenario is covered at the hook level rather than by driving the create view's UI.
