### PR TITLE
fix(archive): render public archive pages without an OrganizationProvider

### DIFF
--- a/src/components/Layout/LegalNotice.test.tsx
+++ b/src/components/Layout/LegalNotice.test.tsx
@@ -1,4 +1,4 @@
-import LegalNotice from './LegalNotice'
+import LegalNotice, { StaticLegalNotice } from './LegalNotice'
 import { render, screen } from '~src/test-utils'
 import { resetReactProvidersMock, setReactProvidersMock } from '~src/test-utils-react-providers-mock'
 
@@ -46,27 +46,32 @@ describe('LegalNotice', () => {
     expect(screen.getByText('0xabc')).toBeInTheDocument()
   })
 
-  it('renders from the orgName prop without reading the organization context', () => {
-    setReactProvidersMock({
-      useOrganization: () => {
-        throw new Error('useOrganization() must be used inside <OrganizationProvider>')
-      },
+  describe('StaticLegalNotice', () => {
+    beforeEach(() => {
+      // The real hook throws outside its provider: the static variant must never reach it.
+      setReactProvidersMock({
+        useOrganization: () => {
+          throw new Error('useOrganization() must be used inside <OrganizationProvider>')
+        },
+      })
     })
 
-    render(<LegalNotice orgName='Legacy org' />)
+    it('renders from the orgName prop without reading the organization context', () => {
+      render(<StaticLegalNotice orgName='Legacy org' />)
 
-    expect(screen.getByText('Legacy org')).toBeInTheDocument()
-  })
-
-  it('renders nothing when the orgName prop is empty', () => {
-    setReactProvidersMock({
-      useOrganization: () => {
-        throw new Error('useOrganization() must be used inside <OrganizationProvider>')
-      },
+      expect(screen.getByText('Legacy org')).toBeInTheDocument()
     })
 
-    render(<LegalNotice orgName='' />)
+    it('renders nothing when orgName is empty', () => {
+      render(<StaticLegalNotice orgName='' />)
 
-    expect(screen.queryByTestId('layout-legal-notice')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('layout-legal-notice')).not.toBeInTheDocument()
+    })
+
+    it('renders nothing when orgName is undefined', () => {
+      render(<StaticLegalNotice orgName={undefined} />)
+
+      expect(screen.queryByTestId('layout-legal-notice')).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/components/Layout/LegalNotice.test.tsx
+++ b/src/components/Layout/LegalNotice.test.tsx
@@ -45,4 +45,28 @@ describe('LegalNotice', () => {
 
     expect(screen.getByText('0xabc')).toBeInTheDocument()
   })
+
+  it('renders from the orgName prop without reading the organization context', () => {
+    setReactProvidersMock({
+      useOrganization: () => {
+        throw new Error('useOrganization() must be used inside <OrganizationProvider>')
+      },
+    })
+
+    render(<LegalNotice orgName='Legacy org' />)
+
+    expect(screen.getByText('Legacy org')).toBeInTheDocument()
+  })
+
+  it('renders nothing when the orgName prop is empty', () => {
+    setReactProvidersMock({
+      useOrganization: () => {
+        throw new Error('useOrganization() must be used inside <OrganizationProvider>')
+      },
+    })
+
+    render(<LegalNotice orgName='' />)
+
+    expect(screen.queryByTestId('layout-legal-notice')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/Layout/LegalNotice.tsx
+++ b/src/components/Layout/LegalNotice.tsx
@@ -2,10 +2,7 @@ import { Box, Link, Text } from '@chakra-ui/react'
 import { useOrganization } from '@vocdoni/react-components'
 import { Trans } from 'react-i18next'
 
-const LegalNoticeContent = () => {
-  const { organization } = useOrganization()
-  const orgName = organization?.name?.default || organization?.address
-
+const LegalNoticeContent = ({ orgName }: { orgName?: string }) => {
   if (!orgName) return null
 
   return (
@@ -37,8 +34,21 @@ const LegalNoticeContent = () => {
   )
 }
 
-const LegalNotice = () => {
-  return <LegalNoticeContent />
+const ProviderLegalNotice = () => {
+  const { organization } = useOrganization()
+
+  return <LegalNoticeContent orgName={organization?.name?.default || organization?.address} />
+}
+
+type LegalNoticeProps = {
+  /** Renders without an OrganizationProvider (archive-era pages); falsy values render nothing. */
+  orgName?: string
+}
+
+const LegalNotice = ({ orgName }: LegalNoticeProps) => {
+  if (orgName !== undefined) return <LegalNoticeContent orgName={orgName} />
+
+  return <ProviderLegalNotice />
 }
 
 export default LegalNotice

--- a/src/components/Layout/LegalNotice.tsx
+++ b/src/components/Layout/LegalNotice.tsx
@@ -2,7 +2,11 @@ import { Box, Link, Text } from '@chakra-ui/react'
 import { useOrganization } from '@vocdoni/react-components'
 import { Trans } from 'react-i18next'
 
-const LegalNoticeContent = ({ orgName }: { orgName?: string }) => {
+/**
+ * Legal notice that never reads the organization context — for pages rendered without an
+ * `OrganizationProvider` (archive-era). Renders nothing when `orgName` is empty.
+ */
+export const StaticLegalNotice = ({ orgName }: { orgName?: string }) => {
   if (!orgName) return null
 
   return (
@@ -34,21 +38,14 @@ const LegalNoticeContent = ({ orgName }: { orgName?: string }) => {
   )
 }
 
-const ProviderLegalNotice = () => {
+/**
+ * Reads the organization from its provider. Must be rendered inside an `OrganizationProvider`
+ * — `useOrganization()` throws otherwise. Pages without one use {@link StaticLegalNotice}.
+ */
+const LegalNotice = () => {
   const { organization } = useOrganization()
 
-  return <LegalNoticeContent orgName={organization?.name?.default || organization?.address} />
-}
-
-type LegalNoticeProps = {
-  /** Renders without an OrganizationProvider (archive-era pages); falsy values render nothing. */
-  orgName?: string
-}
-
-const LegalNotice = ({ orgName }: LegalNoticeProps) => {
-  if (orgName !== undefined) return <LegalNoticeContent orgName={orgName} />
-
-  return <ProviderLegalNotice />
+  return <StaticLegalNotice orgName={organization?.name?.default || organization?.address} />
 }
 
 export default LegalNotice

--- a/src/elements/processes/PublicPage.tsx
+++ b/src/elements/processes/PublicPage.tsx
@@ -1,6 +1,6 @@
 import type { VotingProcessResponse } from '@vocdoni/api-types'
 import { ElectionProvider, OrganizationProvider } from '@vocdoni/react-components'
-import LegalNotice from '~components/Layout/LegalNotice'
+import LegalNotice, { StaticLegalNotice } from '~components/Layout/LegalNotice'
 import ArchiveProcessView from '~components/Process/Archive/View'
 import { ProcessView as ProcessViewComponent } from '~components/Process/View'
 import { useLocalizedText } from '~src/legacy/use-localized-text'
@@ -33,7 +33,7 @@ const PublicProcessPage = ({
     return (
       <>
         <ArchiveProcessView election={legacyElection} />
-        <LegalNotice orgName={orgName} />
+        <StaticLegalNotice orgName={orgName} />
       </>
     )
   }

--- a/src/elements/processes/PublicPage.tsx
+++ b/src/elements/processes/PublicPage.tsx
@@ -3,7 +3,8 @@ import { ElectionProvider, OrganizationProvider } from '@vocdoni/react-component
 import LegalNotice from '~components/Layout/LegalNotice'
 import ArchiveProcessView from '~components/Process/Archive/View'
 import { ProcessView as ProcessViewComponent } from '~components/Process/View'
-import type { LegacyElection } from '~src/legacy/vochain-archive'
+import { useLocalizedText } from '~src/legacy/use-localized-text'
+import type { LegacyElection, LegacyOrganization } from '~src/legacy/vochain-archive'
 
 type PublicProcessPageProps = {
   id: string
@@ -12,14 +13,27 @@ type PublicProcessPageProps = {
   organizationAddress?: string
   /** Archive-era (64-hex vochain id) election: rendered read-only, no providers needed. */
   legacyElection?: LegacyElection
+  legacyOrganization?: LegacyOrganization
 }
 
-const PublicProcessPage = ({ id, election, organizationAddress, legacyElection }: PublicProcessPageProps) => {
+const PublicProcessPage = ({
+  id,
+  election,
+  organizationAddress,
+  legacyElection,
+  legacyOrganization,
+}: PublicProcessPageProps) => {
+  const localize = useLocalizedText()
+
   if (legacyElection) {
+    // No OrganizationProvider in the archive era: feed the legal notice directly.
+    const orgName =
+      localize(legacyOrganization?.account?.name) || legacyOrganization?.address || legacyElection.organizationId
+
     return (
       <>
         <ArchiveProcessView election={legacyElection} />
-        <LegalNotice />
+        <LegalNotice orgName={orgName} />
       </>
     )
   }

--- a/src/elements/processes/PublicSummary.tsx
+++ b/src/elements/processes/PublicSummary.tsx
@@ -3,7 +3,8 @@ import { ElectionProvider, OrganizationProvider } from '@vocdoni/react-component
 import LegalNotice from '~components/Layout/LegalNotice'
 import ArchiveProcessView from '~components/Process/Archive/View'
 import { ProcessSummary as ProcessSummaryComponent } from '~components/Process/Summary'
-import type { LegacyElection } from '~src/legacy/vochain-archive'
+import { useLocalizedText } from '~src/legacy/use-localized-text'
+import type { LegacyElection, LegacyOrganization } from '~src/legacy/vochain-archive'
 
 type PublicProcessSummaryViewProps = {
   id: string
@@ -12,6 +13,7 @@ type PublicProcessSummaryViewProps = {
   organizationAddress?: string
   /** Archive-era (64-hex vochain id) election: rendered read-only, no providers needed. */
   legacyElection?: LegacyElection
+  legacyOrganization?: LegacyOrganization
 }
 
 const PublicProcessSummaryView = ({
@@ -19,12 +21,19 @@ const PublicProcessSummaryView = ({
   election,
   organizationAddress,
   legacyElection,
+  legacyOrganization,
 }: PublicProcessSummaryViewProps) => {
+  const localize = useLocalizedText()
+
   if (legacyElection) {
+    // No OrganizationProvider in the archive era: feed the legal notice directly.
+    const orgName =
+      localize(legacyOrganization?.account?.name) || legacyOrganization?.address || legacyElection.organizationId
+
     return (
       <>
         <ArchiveProcessView election={legacyElection} />
-        <LegalNotice />
+        <LegalNotice orgName={orgName} />
       </>
     )
   }

--- a/src/elements/processes/PublicSummary.tsx
+++ b/src/elements/processes/PublicSummary.tsx
@@ -1,6 +1,6 @@
 import type { VotingProcessResponse } from '@vocdoni/api-types'
 import { ElectionProvider, OrganizationProvider } from '@vocdoni/react-components'
-import LegalNotice from '~components/Layout/LegalNotice'
+import LegalNotice, { StaticLegalNotice } from '~components/Layout/LegalNotice'
 import ArchiveProcessView from '~components/Process/Archive/View'
 import { ProcessSummary as ProcessSummaryComponent } from '~components/Process/Summary'
 import { useLocalizedText } from '~src/legacy/use-localized-text'
@@ -33,7 +33,7 @@ const PublicProcessSummaryView = ({
     return (
       <>
         <ArchiveProcessView election={legacyElection} />
-        <LegalNotice orgName={orgName} />
+        <StaticLegalNotice orgName={orgName} />
       </>
     )
   }

--- a/src/elements/processes/view.test.tsx
+++ b/src/elements/processes/view.test.tsx
@@ -17,6 +17,11 @@ vi.mock('~components/Process/View', () => ({
   ProcessView: () => <div>Process view content</div>,
 }))
 
+vi.mock('~components/Process/Archive/View', () => ({
+  __esModule: true,
+  default: () => <div>Archive view content</div>,
+}))
+
 const routerFutureFlags = {
   v7_startTransition: true,
   v7_relativeSplatPath: true,
@@ -60,6 +65,44 @@ describe('Process view', () => {
       'To ensure a secure, verifiable and transparent vote, Esquerra republicana uses the Vocdoni platform'
     )
     expect(screen.getByRole('link', { name: 'vocdoni.io' })).toHaveAttribute('href', 'https://vocdoni.io/')
+  })
+
+  it('renders the archive-era legal notice without an OrganizationProvider', async () => {
+    // The real hook throws outside its provider; the archive path must never reach it.
+    setReactProvidersMock({
+      useOrganization: () => {
+        throw new Error('useOrganization() must be used inside <OrganizationProvider>')
+      },
+    })
+
+    const legacyId = '6be21a5a9dc0df48fb84a39242adec0f72812132d5ec0886c454020000000000'
+    const router = createTestMemoryRouter(
+      [
+        {
+          path: '/processes/:id',
+          id: 'process-view',
+          loader: async () => ({
+            era: 'archive',
+            legacyElection: { id: legacyId, organizationId: 'df48fb84a39242adec0f72812132d5ec0886c454' },
+            legacyOrganization: {
+              address: 'df48fb84a39242adec0f72812132d5ec0886c454',
+              account: { name: { default: 'Legacy org' } },
+            },
+          }),
+          element: <Process />,
+        },
+      ],
+      {
+        initialEntries: [`/processes/${legacyId}`],
+        future: routerFutureFlags,
+      }
+    )
+
+    render(<TestRouterProvider router={router} />)
+
+    expect(await screen.findByTestId('layout-legal-notice')).toHaveTextContent(
+      'To ensure a secure, verifiable and transparent vote, Legacy org uses the Vocdoni platform'
+    )
   })
 
   it('does not render the legal notice on another route', async () => {

--- a/src/elements/processes/view.tsx
+++ b/src/elements/processes/view.tsx
@@ -1,18 +1,24 @@
 import type { VotingProcessResponse } from '@vocdoni/api-types'
 import { useLoaderData } from 'react-router-dom'
-import type { LegacyElection } from '~src/legacy/vochain-archive'
+import type { LegacyElection, LegacyOrganization } from '~src/legacy/vochain-archive'
 import { ensureAddressPrefix } from '~utils/address'
 import PublicProcessPage from './PublicPage'
 
 type ProcessRouteData =
   | { era: 'saas'; election: VotingProcessResponse }
-  | { era: 'archive'; legacyElection: LegacyElection }
+  | { era: 'archive'; legacyElection: LegacyElection; legacyOrganization?: LegacyOrganization }
 
 const Process = () => {
   const data = useLoaderData() as ProcessRouteData
 
   if (data.era === 'archive') {
-    return <PublicProcessPage id={data.legacyElection.id} legacyElection={data.legacyElection} />
+    return (
+      <PublicProcessPage
+        id={data.legacyElection.id}
+        legacyElection={data.legacyElection}
+        legacyOrganization={data.legacyOrganization}
+      />
+    )
   }
 
   const { election } = data

--- a/src/pages/shared/PublicProcessPage.tsx
+++ b/src/pages/shared/PublicProcessPage.tsx
@@ -25,7 +25,11 @@ export default function PublicProcessPage() {
         showDashboardButton={false}
       >
         {data.era === 'archive' ? (
-          <PublicProcessView id={data.id} legacyElection={data.legacyElection} />
+          <PublicProcessView
+            id={data.id}
+            legacyElection={data.legacyElection}
+            legacyOrganization={data.legacyOrganization}
+          />
         ) : (
           <PublicProcessView id={data.id} election={data.election} organizationAddress={data.organization?.address} />
         )}

--- a/src/pages/shared/PublicProcessSummaryPage.tsx
+++ b/src/pages/shared/PublicProcessSummaryPage.tsx
@@ -25,7 +25,11 @@ export default function PublicProcessSummaryPage() {
         showDashboardButton={false}
       >
         {data.era === 'archive' ? (
-          <PublicProcessSummaryView id={data.id} legacyElection={data.legacyElection} />
+          <PublicProcessSummaryView
+            id={data.id}
+            legacyElection={data.legacyElection}
+            legacyOrganization={data.legacyOrganization}
+          />
         ) : (
           <PublicProcessSummaryView
             id={data.id}

--- a/src/router/routes/root.tsx
+++ b/src/router/routes/root.tsx
@@ -40,7 +40,12 @@ const RootElements = (client: VocdoniApiClient, vochainGateway: string) => [
       const id = params.id!
 
       if (isLegacyProcessId(id)) {
-        return { era: 'archive', legacyElection: await fetchLegacyElection(vochainGateway, id) } as const
+        const legacyElection = await fetchLegacyElection(vochainGateway, id)
+        const legacyOrganization = await fetchLegacyOrganization(vochainGateway, legacyElection.organizationId).catch(
+          () => undefined
+        )
+
+        return { era: 'archive', legacyElection, legacyOrganization } as const
       }
 
       return { era: 'saas', election: await client.elections.get(id) } as const


### PR DESCRIPTION
Fable 5 here, controlled by elboletaire.

## What

Public process pages for legacy (64-hex vochain) ids were returning HTTP 500 — e.g. `/ca/processes/6be21a5a…000000` on app-dev. The archive data layer from #1712 works fine; the crash was at render time: the archive-era branch of `PublicProcessPage`/`PublicProcessSummaryView` rendered `<LegalNotice />` outside any `<OrganizationProvider>`, and `useOrganization()` in `@vocdoni/react-providers` v2 throws in that case, killing the whole SSR render.

## How

- `LegalNotice` accepts an optional `orgName` prop that renders without touching the organization context (SaaS-era provider path unchanged).
- Archive-era process elements resolve the name from the legacy organization (localized name → address → `organizationId`) and pass it down.
- The Vike pages now thread `legacyOrganization` (the SSR loader already fetched it, it was just dropped), and the SPA route loader fetches it best-effort to match.

Side benefit: the legal notice actually shows up on archive pages now — before, even without the crash, it had no provider to read from.

## Verification

- Reproduced the 500 locally on develop, then verified `/ca/processes/6be21a…` and its `/summary` both return 200 over SSR with the notice rendering the legacy org name, localized.
- Regression tests: archive route renders with `useOrganization` mocked to throw; `LegalNotice` with `orgName` never calls the hook.
- `pnpm lint` and `pnpm test` (618 passed) clean. No i18n key changes.

## Follow-up

The bespoke read-only archive view will be replaced by mapping legacy data onto the shared process view components (tracked in #1742) — this PR only fixes the rendering crash.
