### PR TITLE
fix(auth): restore the organization creation step in the signup flow

### DIFF
--- a/src/components/Account/use-account-health-tools.test.tsx
+++ b/src/components/Account/use-account-health-tools.test.tsx
@@ -1,0 +1,54 @@
+import { VocdoniApiError } from '@vocdoni/api-client'
+import { renderHook } from '@testing-library/react'
+import { useAuth } from '~components/Auth/useAuth'
+import { useAccountHealthTools } from './use-account-health-tools'
+
+vi.mock('~components/Auth/useAuth', () => ({
+  useAuth: vi.fn(),
+}))
+
+const mockAuth = (overrides = {}) => vi.mocked(useAuth).mockReturnValue({ addressesError: null, ...overrides } as never)
+
+// The SaaS answers a brand new account with 404 {"error":"user has no organizations","code":40012}.
+const noOrganizationsError = () =>
+  new VocdoniApiError(404, { error: 'user has no organizations', code: 40012 }, 'user has no organizations', 40012)
+
+describe('useAccountHealthTools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('treats the "user has no organizations" 404 as a definitive answer, not a failed lookup', () => {
+    mockAuth({ currentAddress: undefined, addressesError: noOrganizationsError() })
+
+    const { result } = renderHook(() => useAccountHealthTools())
+
+    expect(result.current.exists).toBe(false)
+    expect(result.current.isUnknown).toBe(false)
+  })
+
+  it('reports a server-side failure as unknown so an org owner never sees onboarding', () => {
+    mockAuth({ currentAddress: undefined, addressesError: new VocdoniApiError(502, undefined, 'Bad Gateway') })
+
+    const { result } = renderHook(() => useAccountHealthTools())
+
+    expect(result.current.isUnknown).toBe(true)
+  })
+
+  it('reports a network failure as unknown', () => {
+    mockAuth({ currentAddress: undefined, addressesError: new Error('Failed to fetch') })
+
+    const { result } = renderHook(() => useAccountHealthTools())
+
+    expect(result.current.isUnknown).toBe(true)
+  })
+
+  it('reports an organization once an address is resolved', () => {
+    mockAuth({ currentAddress: '0x123', addressesError: null })
+
+    const { result } = renderHook(() => useAccountHealthTools())
+
+    expect(result.current.exists).toBe(true)
+    expect(result.current.isUnknown).toBe(false)
+  })
+})

--- a/src/components/Account/use-account-health-tools.tsx
+++ b/src/components/Account/use-account-health-tools.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from '~components/Auth/useAuth'
+import { isClientError } from '~components/Auth/useAuthProvider'
 
 /**
  * Whether the session has a usable organization: an org exists when the session
@@ -7,12 +8,17 @@ import { useAuth } from '~components/Auth/useAuth'
  * `exists: false` is only meaningful when `isUnknown` is false — a failed address
  * lookup also leaves the address unset, and treating that as "no organizations"
  * shows onboarding to a user who has one.
+ *
+ * "This account owns no organizations" is itself an error response: the SaaS
+ * answers `/auth/addresses` with 404 `user has no organizations` (code 40012).
+ * That is a definitive answer, so only errors that aren't a 4xx — a 5xx, a
+ * dropped connection — leave the account state genuinely unknown.
  */
 export const useAccountHealthTools = () => {
   const { currentAddress, addressesError } = useAuth()
 
   return {
     exists: !!currentAddress,
-    isUnknown: !currentAddress && !!addressesError,
+    isUnknown: !currentAddress && !!addressesError && !isClientError(addressesError),
   }
 }

--- a/src/components/Auth/useAuthProvider.ts
+++ b/src/components/Auth/useAuthProvider.ts
@@ -20,7 +20,8 @@ export enum LocalStorageKeys {
  * Whether the API answered with a 4xx, i.e. a definitive "no" rather than a
  * failure to reach it. Retrying those only delays the answer.
  */
-const isClientError = (error: unknown) => error instanceof VocdoniApiError && error.status >= 400 && error.status < 500
+export const isClientError = (error: unknown) =>
+  error instanceof VocdoniApiError && error.status >= 400 && error.status < 500
 
 const getStorageItem = (key: string) => (typeof localStorage === 'undefined' ? null : localStorage.getItem(key))
 const setStorageItem = (key: string, value: string) => {

--- a/src/components/Organization/Dashboard/index.test.tsx
+++ b/src/components/Organization/Dashboard/index.test.tsx
@@ -9,11 +9,13 @@ vi.mock('~components/Auth/useAuth', () => ({
 
 const useOrganizationSetupMock = vi.fn()
 
+let electionsQueryState: any = { data: null, isLoading: false, isError: false, error: null }
+
 vi.mock('@tanstack/react-query', async () => {
   const actual = await vi.importActual<any>('@tanstack/react-query')
   return {
     ...actual,
-    useQuery: () => ({ data: null, isLoading: false, isError: false, error: null }),
+    useQuery: () => electionsQueryState,
   }
 })
 
@@ -65,11 +67,35 @@ vi.mock('./UsageLimits', () => ({
 
 describe('OrganizationDashboard', () => {
   beforeEach(() => {
+    electionsQueryState = { data: null, isLoading: false, isError: false, error: null }
     setAuthMock({ currentAddress: '0xabc' })
     setReactProvidersMock({
       ElectionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
       useOrganization: () => mockUseOrganization({ organization: null }),
     })
+  })
+
+  it('offers to create an organization even when the shared elections cache holds an error', () => {
+    // The elections cache entry is keyed per organization, but the /admin/processes loaders can
+    // leave it in an error state for an account that has no organization at all. A disabled
+    // useQuery still reports that cached error, and showing it here hides the only way forward.
+    useOrganizationSetupMock.mockReturnValue({ checklist: [], progress: 0, isStepsAccordionOpen: false })
+    setAuthMock({ currentAddress: undefined })
+    electionsQueryState = {
+      data: null,
+      isLoading: false,
+      isError: true,
+      error: new Error('invalid URL parameter: missing orgAddress'),
+    }
+
+    render(
+      <TestMemoryRouter>
+        <OrganizationDashboard />
+      </TestMemoryRouter>
+    )
+
+    expect(screen.getByText('Create your first organization')).toBeInTheDocument()
+    expect(screen.queryByText('Error loading voting processes')).not.toBeInTheDocument()
   })
 
   it('renders dashboard header', () => {

--- a/src/components/Organization/Dashboard/index.tsx
+++ b/src/components/Organization/Dashboard/index.tsx
@@ -314,21 +314,9 @@ const Processes = () => {
     )
   }
 
-  if (isError) {
-    return (
-      <Flex flexGrow={1} flexDir='column' justify='center' align='center' gap={4}>
-        <ListStateAlert
-          show
-          status='error'
-          title={t('dashboard.welcome.error_loading_processes', {
-            defaultValue: 'Error loading voting processes',
-          })}
-          description={error instanceof Error ? error.message : undefined}
-        />
-      </Flex>
-    )
-  }
-
+  // Checked before the error state on purpose: with no organization this query never ran, and
+  // any error on its cache entry belongs to something else. Reporting it would replace the only
+  // way forward — the button that creates the missing organization.
   if (!organization) {
     return (
       <Flex flexGrow={1} flexDir='column' justify='center' align='center' gap={4}>
@@ -342,6 +330,21 @@ const Processes = () => {
             })}
           </ReactRouterLink>
         </Button>
+      </Flex>
+    )
+  }
+
+  if (isError) {
+    return (
+      <Flex flexGrow={1} flexDir='column' justify='center' align='center' gap={4}>
+        <ListStateAlert
+          show
+          status='error'
+          title={t('dashboard.welcome.error_loading_processes', {
+            defaultValue: 'Error loading voting processes',
+          })}
+          description={error instanceof Error ? error.message : undefined}
+        />
       </Flex>
     )
   }

--- a/src/queries/keys.ts
+++ b/src/queries/keys.ts
@@ -10,8 +10,15 @@ export const QueryKeys = {
     results: electionQueryKeys.results,
   },
   organization: {
-    elections: (address?: string, params?: { page?: number; status?: string }) =>
-      ['organizations', 'elections', address, params].filter(Boolean),
+    // The address stays in the key even when it is undefined: dropping it collapses an
+    // addressless read onto a shorter key that another call shape can also produce, so an
+    // addressless failure would surface in a query that never asked for it.
+    elections: (address?: string, params?: { page?: number; status?: string }) => [
+      'organizations',
+      'elections',
+      address ?? null,
+      params ?? null,
+    ],
     info: (address?: string) => ['organizations', 'info', address].filter(Boolean),
     users: (address?: string) => ['organizations', 'users', address].filter(Boolean),
     names: ['organizations', 'names'],

--- a/src/queries/organization.test.ts
+++ b/src/queries/organization.test.ts
@@ -1,4 +1,6 @@
 import type { VocdoniApiClient } from '@vocdoni/api-client'
+import { hashKey } from '@tanstack/react-query'
+import { QueryKeys } from '~src/queries/keys'
 import { paginatedElectionsQuery } from './organization'
 
 const list = vi.fn()
@@ -26,5 +28,23 @@ describe('paginatedElectionsQuery', () => {
 
   it('is disabled without an organization address', () => {
     expect(paginatedElectionsQuery(undefined, client, {}).enabled).toBe(false)
+  })
+
+  it('refuses to list without an organization address instead of asking the API for every process', async () => {
+    // `enabled` only guards useQuery; ensureQueryData (the /admin/processes loaders) ignores it
+    // and would otherwise send GET /processes with no orgAddress, which the SaaS rejects with
+    // 400 "invalid URL parameter: missing orgAddress".
+    await expect(paginatedElectionsQuery(undefined, client, {}).queryFn()).rejects.toThrow(/no organization address/i)
+    expect(list).not.toHaveBeenCalled()
+  })
+
+  it('keeps the organization address in the cache key so addressless reads cannot share an entry', () => {
+    // `.filter(Boolean)` used to drop an undefined address, collapsing this key onto a
+    // different organization's — and onto the dashboard's own elections query.
+    const withoutAddress = QueryKeys.organization.elections(undefined, {})
+    const withAddress = QueryKeys.organization.elections('0xorg', {})
+
+    expect(hashKey(withoutAddress)).not.toBe(hashKey(withAddress))
+    expect(withoutAddress).toHaveLength(withAddress.length)
   })
 })

--- a/src/queries/organization.ts
+++ b/src/queries/organization.ts
@@ -98,6 +98,13 @@ export const paginatedElectionsQuery = (
   enabled: !!address,
   queryKey: QueryKeys.organization.elections(address, params),
   queryFn: async () => {
+    // `enabled` above only guards useQuery. The /admin/processes loaders read this through
+    // ensureQueryData, which ignores it, so keep the guard here too: without an address the
+    // SaaS rejects the call with 400 "invalid URL parameter: missing orgAddress" and the
+    // failure would be cached against a key no organization owns.
+    if (!address) {
+      throw new Error('Cannot list elections with no organization address selected')
+    }
     const result = await client.elections.list({
       orgAddress: address,
       page: params.page ? Number(params.page) : 1,

--- a/src/router/NonLoggedRoute.test.tsx
+++ b/src/router/NonLoggedRoute.test.tsx
@@ -1,0 +1,93 @@
+import { VocdoniApiError } from '@vocdoni/api-client'
+import { screen } from '@testing-library/react'
+import { Route, Routes as RouterRoutes } from 'react-router-dom'
+import { useAuth } from '~components/Auth/useAuth'
+import { renderWithProviders, TestMemoryRouter } from '~src/test-utils'
+import NonLoggedRoute from './NonLoggedRoute'
+import { Routes } from './routes'
+
+vi.mock('~components/Auth/useAuth', () => ({
+  useAuth: vi.fn(),
+}))
+
+const mockAuth = (overrides = {}) =>
+  vi.mocked(useAuth).mockReturnValue({
+    isAuthenticated: true,
+    isAuthLoading: false,
+    currentAddress: undefined,
+    addressesError: null,
+    ...overrides,
+  } as never)
+
+// The SaaS answers /auth/addresses with 404 "user has no organizations" (code 40012)
+// for an account that has just verified its email.
+const noOrganizationsError = () => new VocdoniApiError(404, { code: 40012 }, 'user has no organizations', 40012)
+
+const renderAt = (initialEntry: string, element = <NonLoggedRoute />) =>
+  renderWithProviders(
+    <TestMemoryRouter initialEntries={[initialEntry]}>
+      <RouterRoutes>
+        <Route element={element}>
+          <Route path={Routes.auth.verify} element={<div>Verify</div>} />
+          <Route path={Routes.auth.signIn} element={<div>Sign in</div>} />
+        </Route>
+        <Route path={Routes.auth.organizationCreate} element={<div>Create organization</div>} />
+        <Route path={Routes.dashboard.base} element={<div>Dashboard</div>} />
+        <Route path={Routes.integrators.base} element={<div>Integrators</div>} />
+      </RouterRoutes>
+    </TestMemoryRouter>
+  )
+
+describe('NonLoggedRoute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('sends a just-verified account with no organization to the organization creation step', () => {
+    // Verifying the email logs the account in while it is still on /account/verify, so this
+    // guard runs before Verify's own navigation settles. Sending it to the dashboard here
+    // replaces the org creation step the account was on its way to.
+    mockAuth({ addressesError: noOrganizationsError() })
+
+    renderAt(Routes.auth.verify)
+
+    expect(screen.getByText('Create organization')).toBeInTheDocument()
+    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument()
+  })
+
+  it('sends an account that owns an organization to the dashboard', () => {
+    mockAuth({ currentAddress: '0x123' })
+
+    renderAt(Routes.auth.signIn)
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+  })
+
+  it('sends an account to the dashboard when the address lookup failed, rather than to onboarding', () => {
+    // A 502 leaves the address unset just like "no organizations" does; an owner must not be
+    // pushed into creating a second organization because a request failed.
+    mockAuth({ addressesError: new VocdoniApiError(502, undefined, 'Bad Gateway') })
+
+    renderAt(Routes.auth.signIn)
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+  })
+
+  it('keeps the integrators group on its own root when it has no organization yet', () => {
+    // Integrator organizations are provisioned inside the integrators app, not through
+    // the /account organization creation step.
+    mockAuth({ addressesError: noOrganizationsError() })
+
+    renderAt(Routes.auth.signIn, <NonLoggedRoute redirectTo={Routes.integrators.base} />)
+
+    expect(screen.getByText('Integrators')).toBeInTheDocument()
+  })
+
+  it('renders the auth screen for an account that is not logged in', () => {
+    mockAuth({ isAuthenticated: false })
+
+    renderAt(Routes.auth.signIn)
+
+    expect(screen.getByText('Sign in')).toBeInTheDocument()
+  })
+})

--- a/src/router/NonLoggedRoute.tsx
+++ b/src/router/NonLoggedRoute.tsx
@@ -1,13 +1,16 @@
 import { Navigate, Outlet, useLocation, useOutletContext } from 'react-router-dom'
+import { useAccountHealthTools } from '~components/Account/use-account-health-tools'
 import { useAuth } from '~components/Auth/useAuth'
 import { Loading } from '~src/router/SuspenseLoader'
 import { Routes } from './routes'
 
 // redirectTo lets reusable auth groups (e.g. the integrators app) send already-authenticated
-// users to their own root instead of the default dashboard.
-const NonLoggedRoute = ({ redirectTo = Routes.dashboard.base }: { redirectTo?: string }) => {
+// users to their own root instead of the default dashboard. A group that sets it owns its
+// destination; the default /account group derives one from the account's organization state.
+const NonLoggedRoute = ({ redirectTo }: { redirectTo?: string }) => {
   const { pathname } = useLocation()
   const { isAuthenticated, isAuthLoading } = useAuth()
+  const { exists, isUnknown } = useAccountHealthTools()
   const context = useOutletContext()
 
   if (isAuthLoading) {
@@ -15,7 +18,14 @@ const NonLoggedRoute = ({ redirectTo = Routes.dashboard.base }: { redirectTo?: s
   }
 
   if (isAuthenticated && pathname !== Routes.auth.passwordReset) {
-    return <Navigate to={redirectTo} replace />
+    // Verifying an email logs the account in while it is still on /account/verify, so this
+    // guard runs before Verify's own navigation has settled and its <Navigate> lands last.
+    // Sending a freshly verified account to the dashboard therefore *replaces* the
+    // organization creation step it was on its way to. It has nothing to do on the dashboard
+    // anyway, so point it at the same step. `isUnknown` keeps an owner whose address lookup
+    // merely failed from being pushed into creating a second organization.
+    const target = redirectTo ?? (exists || isUnknown ? Routes.dashboard.base : Routes.auth.organizationCreate)
+    return <Navigate to={target} replace />
   }
 
   return <Outlet context={context} />

--- a/src/router/OrganizationProtectedRoute.test.tsx
+++ b/src/router/OrganizationProtectedRoute.test.tsx
@@ -1,3 +1,4 @@
+import { VocdoniApiError } from '@vocdoni/api-client'
 import { screen } from '@testing-library/react'
 import { Route, Routes } from 'react-router-dom'
 import { useAuth } from '~components/Auth/useAuth'
@@ -41,6 +42,21 @@ describe('OrganizationProtectedRoute', () => {
     renderGuard()
 
     expect(screen.getByText("You don't belong to any organization yet!")).toBeInTheDocument()
+  })
+
+  it('onboards a freshly verified account, whose address lookup 404s with "user has no organizations"', () => {
+    // /auth/addresses answers 404 {"error":"user has no organizations","code":40012} for a brand
+    // new account, so "no organizations" arrives as an error and must not read as a failed lookup.
+    vi.mocked(useAuth).mockReturnValue(
+      mockAuth({
+        addressesError: new VocdoniApiError(404, { code: 40012 }, 'user has no organizations', 40012),
+      })
+    )
+
+    renderGuard()
+
+    expect(screen.getByText("You don't belong to any organization yet!")).toBeInTheDocument()
+    expect(screen.queryByText("We couldn't load your organizations")).not.toBeInTheDocument()
   })
 
   it('reports a failed address lookup instead of claiming there are no organizations', () => {


### PR DESCRIPTION
This is Opus 5 speaking on behalf of elboletaire.

Signing up has been broken since #1712 removed the VocdoniSDK: the organization creation step is skipped, and a brand new account then lands on a dashboard that tells it something went wrong instead of offering to create the missing organization. Three separate regressions, each reproduced against `saas-api-dev` before and after the fix.

## 1. The organization creation step is reached, then overwritten

Verifying an email calls `setSession`, which flips `isAuthenticated` and re-renders `NonLoggedRoute` **while the router is still at `/account/verify`**. The guard returns `<Navigate to="/admin" replace />`, and its effect runs *after* `Verify`'s own push, replacing it. Captured live:

```
[TRACE] verify: navigating to /account/create-organization from /en/account/verify
[TRACE] verify: navigate() returned, location is /en/account/create-organization
[TRACE] NonLoggedRoute: redirecting to /admin from /account/verify   <- still the old pathname
[TRACE] NonLoggedRoute: redirecting to /admin from /account/verify

history: [["push","/en/account/create-organization"], ["replace","/en/admin"], ["replace","/en/admin"]]
```

This could not happen before the refactor: `isAuthLoading` was `(isAuthenticated && signerIdle) || (isAuthenticated && !signerIdle && signerPending)`, true the instant `storeLogin` scheduled `updateSigner`, so the guard rendered `<Loading/>` for the whole window. The replacement, `isAuthenticated && addressesLoading`, settles as soon as `/auth/addresses` does — for an account with no organization, an immediate 4xx.

Rather than special-casing `/account/verify`, an authenticated account that *provably* owns no organization is now sent to the organization creation step, so both parties agree on the destination and the ordering stops mattering. Auth groups that pass `redirectTo` (integrators, which provision organizations themselves) keep theirs.

## 2. `NoOrganizations` was unreachable

`/auth/addresses` answers a brand new account with:

```
HTTP 404  {"error":"user has no organizations","code":40012}
```

`useAccountHealthTools` mapped **any** `addressesError` onto `isUnknown`, so every org-guarded route showed *"We couldn't load your organizations / Try again"* to accounts that simply had none — and `exists: false && !isUnknown` was unreachable, making the whole onboarding screen dead code. Note `useAuthProvider` already treats this 4xx as a definitive answer (`isClientError` skips retries for exactly this reason); the two disagreed. Only non-4xx errors now mean "unknown".

## 3. `invalid URL parameter: missing orgAddress` in "Recent voting processes"

Three things combined, each verified independently:

- `QueryKeys.organization.elections` dropped an `undefined` address via `.filter(Boolean)`, collapsing an addressless read onto `['organizations','elections',{}]` — the same key the dashboard box produces (`{page: undefined, status: undefined}` hashes identically to `{}`).
- The `/admin/processes/*` loaders read the query through `ensureQueryData`, which **ignores** the `enabled: !!address` guard, and loaders run before `OrganizationProtectedRoute` can block them. So they sent `GET /processes` with no `orgAddress` → HTTP 400, cached against that shared key.
- A disabled `useQuery` still reports a cached error, and `Processes` checked `isError` before `!organization` — so the error replaced the onboarding button.

The address now stays in the key, `queryFn` refuses to run without one, and the missing-organization branch is checked first.

## How this was verified

Every fix was written test-first, with each test watched failing for the right reason before any production code changed (fix 2's guard test was verified red by temporarily reverting the one-line change).

`pnpm test` → **629 passed, 1 skipped**. `pnpm lint` → clean.

End-to-end against `saas-api-dev` with throwaway accounts, before and after:

| Scenario | Before | After |
|---|---|---|
| signup → verify | `/en/admin`, no org step | `/en/account/create-organization`, org created, dashboard OK |
| no-org account signs in | `/en/admin` | `/en/account/create-organization` |
| no-org account on `/admin/processes/all` | "We couldn't load your organizations" | "You don't belong to any organization yet! / Create your organization" |
| ...then back to the dashboard | "Error loading voting processes / invalid URL parameter: missing orgAddress" | "Create your first organization" |
| account **owning** an org, hard-load `/admin/processes/all` | works | works (regression check on the new `queryFn` guard) |

## Worth a look during review

- **Scope call made deliberately:** fix 1 keys off "provably owns no organization", so a no-org account is sent to organization creation from *any* auth screen, sign-in included — not only after verification. `isUnknown` guards it, so an owner whose lookup merely 5xx'd still gets the dashboard instead of being pushed into creating a second organization. Happy to narrow it to `/account/verify` if you'd rather.
- **Separate pre-existing bug, not touched here:** after `OrganizationCreate` succeeds, `navigate('/admin')` updates the URL but the creation form stays on screen until a reload. Observed on `develop` before any of these changes, so it is not a regression from this PR. It looks like the `createBrowserRouter`-per-render pattern in `Providers.tsx` (`RouterProvider` keeping the first router while history moves on) — the same thing that file's comment is wrestling with. Deserves its own issue.
